### PR TITLE
Simplify initial setup state handling

### DIFF
--- a/AGENTS/FIRST_STARTUP_EXPERIENCE_PLAN.md
+++ b/AGENTS/FIRST_STARTUP_EXPERIENCE_PLAN.md
@@ -1,0 +1,60 @@
+# First Startup Experience Plan
+
+This document describes the simplest, most standard way to let the first operator create an admin account through the UI while keeping the codebase easy to reason about. The flow mirrors what many SaaS products do: a public status check, a one-time initial setup path that reuses our existing user creation service, and the regular login screen once an admin exists.
+
+## Objectives
+- Detect whether the database has an administrator account.
+- Prompt unauthenticated visitors to create that first admin through the web UI only while none exist.
+- Hand control back to the normal sign-in form immediately after initial setup succeeds.
+
+## Data we need
+- **`system_settings` table**: a single-row key/value table that already fits most FastAPI projects (`key` TEXT primary key, `value` JSONB/TEXT, `created_at`, `updated_at`).
+- Store an `initial_setup.completed_at` timestamp (null until the initial admin is created). Keeping this flag alongside other system-wide settings means we do not introduce bespoke columns on the `users` table and lets us gate the initial setup route even if someone later deletes all admins.
+
+## Backend plan
+1. **Status endpoint**
+   - Add `GET /auth/initial-setup` under the existing auth router (GET reads status, POST below performs setup).
+   - Response shape: `{ "initialSetupRequired": boolean }`.
+   - Implementation: open a transaction, lock the `initial_setup.completed_at` row (`SELECT ... FOR UPDATE`), and compute `initialSetupRequired` as `initial_setup.completed_at IS NULL AND admin_count == 0`.
+   - Keep the handler unauthenticated; it only reveals whether the instance has ever been set up.
+
+2. **Initial setup submission**
+   - Reuse the existing `POST /users` route and schema instead of inventing a bespoke payload. The handler already validates email, password strength, and role assignment through `UsersService`.
+   - Introduce a light-weight dependency (e.g. `InitialSetupWindow`) that:
+     1. Opens a transaction.
+     2. Locks the `initial_setup.completed_at` row.
+     3. Counts current admins.
+     4. Raises `HTTP 409` when an admin exists or the completion flag is set.
+   - Allow the route to execute without authentication only while the dependency confirms the setup window is open. Otherwise, fall back to the existing behaviour that requires an authenticated admin.
+   - After creating the admin, call the shared session-issuance helper so the response mirrors the normal login flow (session cookie + user payload) and set `initial_setup.completed_at = utcnow()` before committing.
+   - If the guard fails (an admin already exists or another request won the race), return HTTP 409 with a friendly error payload.
+
+3. **Fallback CLI flow**
+   - Keep the existing CLI command for environments that prefer scripted provisioning; it can also reset `initial_setup.completed_at` to `NULL` if operators intentionally need to reopen the window. When the reset happens, the guard dependency automatically allows anonymous use of `POST /users` again.
+
+## Frontend plan
+1. **Status check**
+   - The auth layout (same place we choose between login and forgot-password forms) calls `GET /auth/initial-setup` as soon as it mounts.
+   - Cache the response for the session. If the POST request later returns 409, immediately invalidate the cache and render the login screen instead.
+
+2. **Initial setup form**
+   - Render an `InitialAdminSetup` component when `initialSetupRequired` is true.
+   - Fields: email, password + confirmation, optional display name. Use the same validation helpers as the signup/invite forms for consistency.
+   - Submit to `POST /users`. On success, route to the dashboard with the returned session info. On error, show the validation feedback inline and, for a 409, swap back to the login form.
+
+3. **Standard login otherwise**
+   - When `initialSetupRequired` is false, render the existing login form unchanged. No further logic is needed.
+
+## Security checklist
+- **Atomic guard**: lock the settings row and count admins inside the same transaction so two anonymous requests cannot both create admins. The same guard dependency also prevents bypassing the normal admin-only `POST /users` semantics once the instance is configured.
+- **Input validation**: reuse established schemas for email and password strength, force the role to `ADMIN`, and rely on centralised password hashing.
+- **Rate limiting**: apply the standard unauthenticated rate limiter/middleware used on other auth routes.
+- **Session handling**: issue the same secure, HTTPOnly session cookie and ensure CSRF protections stay in place because the initial setup endpoint lives in the auth module.
+- **Audit log**: emit an audit event noting who created the initial admin and when.
+
+## Operational notes
+- Add backend tests for the status endpoint, the successful initial setup, and the "already configured" guard.
+- Add a frontend test that mocks the status API to cover both the setup form and the fallback login screen.
+- Document in the deployment guide that the app now self-prompts for the first admin while the CLI command remains available for scripted installs.
+
+This keeps the initial setup experience tiny, familiar to most developers, and aligned with how common FastAPI apps manage first-user setup.

--- a/backend/api/migrations/versions/0006_system_settings.py
+++ b/backend/api/migrations/versions/0006_system_settings.py
@@ -1,0 +1,30 @@
+"""Create system_settings table."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0006_system_settings"
+down_revision = "0005_workspace_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "system_settings",
+        sa.Column("key", sa.String(length=100), nullable=False),
+        sa.Column("value", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("created_at", sa.String(length=32), nullable=False),
+        sa.Column("updated_at", sa.String(length=32), nullable=False),
+        sa.PrimaryKeyConstraint("key"),
+    )
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(sa.text("ALTER TABLE system_settings ALTER COLUMN value DROP DEFAULT"))
+
+
+def downgrade() -> None:
+    op.drop_table("system_settings")

--- a/backend/api/modules/system/models.py
+++ b/backend/api/modules/system/models.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Persistence models for system-wide settings."""
+
+from typing import Any
+
+from sqlalchemy import JSON, String
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ...db import Base
+from ...db.mixins import TimestampMixin
+
+
+class SystemSetting(TimestampMixin, Base):
+    """Key/value storage for instance-wide configuration flags."""
+
+    __tablename__ = "system_settings"
+
+    key: Mapped[str] = mapped_column(String(100), primary_key=True)
+    value: Mapped[dict[str, Any]] = mapped_column(
+        MutableDict.as_mutable(JSON), default=dict, nullable=False
+    )
+
+
+__all__ = ["SystemSetting"]

--- a/backend/api/modules/system/repository.py
+++ b/backend/api/modules/system/repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Helpers for reading and mutating system settings."""
+
+from collections.abc import Mapping
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import SystemSetting
+
+
+class SystemSettingsRepository:
+    """Simple persistence helpers for ``SystemSetting`` records."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get(self, key: str) -> SystemSetting | None:
+        stmt = select(SystemSetting).where(SystemSetting.key == key)
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_for_update(self, key: str) -> SystemSetting | None:
+        stmt = (
+            select(SystemSetting)
+            .where(SystemSetting.key == key)
+            .with_for_update(nowait=False)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create(
+        self, *, key: str, value: Mapping[str, object] | None = None
+    ) -> SystemSetting:
+        setting = SystemSetting(key=key, value=dict(value or {}))
+        self._session.add(setting)
+        await self._session.flush()
+        await self._session.refresh(setting)
+        return setting
+
+__all__ = ["SystemSettingsRepository"]

--- a/backend/api/modules/users/repository.py
+++ b/backend/api/modules/users/repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import User, UserRole
@@ -52,6 +52,12 @@ class UsersRepository:
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
+
+    async def count_admins(self) -> int:
+        stmt = select(func.count()).where(User.role == UserRole.ADMIN)
+        result = await self._session.execute(stmt)
+        count = result.scalar_one()
+        return int(count or 0)
 
     async def create(
         self,

--- a/backend/tests/modules/auth/test_initial_setup.py
+++ b/backend/tests/modules/auth/test_initial_setup.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from sqlalchemy import text
+
+from backend.api.db.session import get_sessionmaker
+from backend.api.modules.auth.security import hash_password
+from backend.api.modules.users.models import UserRole
+from backend.api.modules.users.repository import UsersRepository
+
+
+@pytest.mark.asyncio()
+async def test_initial_setup_creates_admin_and_sets_session(
+    async_client: AsyncClient,
+) -> None:
+    session_factory = get_sessionmaker()
+    async with session_factory() as session:
+        await session.execute(text("DELETE FROM api_keys"))
+        await session.execute(text("DELETE FROM system_settings"))
+        await session.execute(text("DELETE FROM users"))
+        await session.commit()
+
+    status_response = await async_client.get("/auth/initial-setup")
+    assert status_response.status_code == 200
+    assert status_response.json() == {"initialSetupRequired": True}
+
+    payload = {
+        "email": "owner@example.com",
+        "password": "ChangeMe123!",
+        "displayName": "Owner",
+    }
+
+    response = await async_client.post("/auth/initial-setup", json=payload)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["user"]["email"] == "owner@example.com"
+    assert data["user"]["role"] == "admin"
+    assert data["expires_at"]
+    assert data["refresh_expires_at"]
+
+    session_cookie = async_client.cookies.get("ade_session")
+    refresh_cookie = async_client.cookies.get("ade_refresh")
+    csrf_cookie = async_client.cookies.get("ade_csrf")
+    assert session_cookie
+    assert refresh_cookie
+    assert csrf_cookie
+
+    repeat = await async_client.post("/auth/initial-setup", json=payload)
+    assert repeat.status_code == 409
+
+    status_after = await async_client.get("/auth/initial-setup")
+    assert status_after.status_code == 200
+    assert status_after.json() == {"initialSetupRequired": False}
+
+
+@pytest.mark.asyncio()
+async def test_initial_setup_rejected_when_admin_exists(
+    async_client: AsyncClient,
+) -> None:
+    session_factory = get_sessionmaker()
+    async with session_factory() as session:
+        repo = UsersRepository(session)
+        await repo.create(
+            email="existing@example.com",
+            password_hash=hash_password("Password123!"),
+            role=UserRole.ADMIN,
+            is_active=True,
+        )
+        await session.commit()
+
+    status_response = await async_client.get("/auth/initial-setup")
+    assert status_response.status_code == 200
+    assert status_response.json() == {"initialSetupRequired": False}
+
+    response = await async_client.post(
+        "/auth/initial-setup",
+        json={"email": "new@example.com", "password": "NewPassword123!"},
+    )
+    assert response.status_code == 409

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -15,3 +15,13 @@ export interface LoginPayload {
   email: string
   password: string
 }
+
+export interface InitialSetupStatus {
+  initialSetupRequired: boolean
+}
+
+export interface InitialSetupPayload {
+  email: string
+  password: string
+  displayName?: string | null
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,13 +1,22 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { FormEvent, ReactElement } from 'react'
 
+import type { InitialSetupPayload } from '../api/types'
 import { useAuth } from '../context/AuthContext'
 
-interface FieldErrors {
+type AuthView = 'loading' | 'setup' | 'login'
+
+type LoginFieldErrors = {
   email?: string
   password?: string
 }
+
+type SetupFieldErrors = LoginFieldErrors & {
+  confirmPassword?: string
+}
+
+type ApiError = Error & { status?: number }
 
 function validateEmail(value: string): string | undefined {
   const trimmed = value.trim()
@@ -28,42 +37,247 @@ function validatePassword(value: string): string | undefined {
   return undefined
 }
 
-export default function LoginPage(): ReactElement {
-  const navigate = useNavigate()
-  const { login } = useAuth()
+function validatePasswordConfirmation(password: string, confirmation: string): string | undefined {
+  if (!confirmation.trim()) {
+    return 'Confirm the password to continue.'
+  }
+  if (password !== confirmation) {
+    return 'Passwords must match.'
+  }
+  return undefined
+}
+
+interface InitialSetupFormProps {
+  onSubmit: (payload: InitialSetupPayload) => Promise<void>
+  onAlreadyConfigured: () => void
+}
+
+function InitialSetupForm({ onSubmit, onAlreadyConfigured }: InitialSetupFormProps): ReactElement {
   const [email, setEmail] = useState('')
+  const [displayName, setDisplayName] = useState('')
   const [password, setPassword] = useState('')
-  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [fieldErrors, setFieldErrors] = useState<SetupFieldErrors>({})
   const [formError, setFormError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const errors: FieldErrors = {
+
+    const errors: SetupFieldErrors = {
       email: validateEmail(email),
       password: validatePassword(password),
+      confirmPassword: validatePasswordConfirmation(password, confirmPassword),
     }
 
     setFieldErrors(errors)
-    if (errors.email || errors.password) {
+    if (errors.email || errors.password || errors.confirmPassword) {
       return
     }
 
     setIsSubmitting(true)
     setFormError(null)
+    const payload: InitialSetupPayload = {
+      email: email.trim(),
+      password,
+    }
+    const cleanedDisplayName = displayName.trim()
+    if (cleanedDisplayName) {
+      payload.displayName = cleanedDisplayName
+    }
+
     try {
-      await login(email.trim(), password)
-      navigate('/', { replace: true })
+      await onSubmit(payload)
     } catch (error) {
-      if (error instanceof Error) {
-        setFormError(error.message)
-      } else {
-        setFormError('Unexpected error while signing in.')
+      const problem = error as ApiError
+      if (problem.status === 409) {
+        onAlreadyConfigured()
+        return
       }
+      const message = problem.message?.trim() || 'Unable to create the administrator account.'
+      setFormError(message)
     } finally {
       setIsSubmitting(false)
     }
   }
+
+  return (
+    <form className="auth-form" onSubmit={handleSubmit} noValidate>
+      <div className="form-field">
+        <label htmlFor="setup-email">Email</label>
+        <input
+          id="setup-email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          aria-invalid={Boolean(fieldErrors.email)}
+          aria-describedby={fieldErrors.email ? 'setup-email-error' : undefined}
+          required
+        />
+        {fieldErrors.email ? (
+          <p className="field-error" id="setup-email-error" role="alert">
+            {fieldErrors.email}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="form-field">
+        <label htmlFor="display-name">Display name (optional)</label>
+        <input
+          id="display-name"
+          name="displayName"
+          type="text"
+          autoComplete="name"
+          value={displayName}
+          onChange={(event) => setDisplayName(event.target.value)}
+        />
+      </div>
+
+      <div className="form-field">
+        <label htmlFor="setup-password">Password</label>
+        <input
+          id="setup-password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          aria-invalid={Boolean(fieldErrors.password)}
+          aria-describedby={fieldErrors.password ? 'setup-password-error' : undefined}
+          required
+        />
+        {fieldErrors.password ? (
+          <p className="field-error" id="setup-password-error" role="alert">
+            {fieldErrors.password}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="form-field">
+        <label htmlFor="setup-password-confirm">Confirm password</label>
+        <input
+          id="setup-password-confirm"
+          name="confirmPassword"
+          type="password"
+          autoComplete="new-password"
+          value={confirmPassword}
+          onChange={(event) => setConfirmPassword(event.target.value)}
+          aria-invalid={Boolean(fieldErrors.confirmPassword)}
+          aria-describedby={fieldErrors.confirmPassword ? 'setup-confirm-error' : undefined}
+          required
+        />
+        {fieldErrors.confirmPassword ? (
+          <p className="field-error" id="setup-confirm-error" role="alert">
+            {fieldErrors.confirmPassword}
+          </p>
+        ) : null}
+      </div>
+
+      {formError ? (
+        <div className="form-error" role="alert" aria-live="assertive">
+          {formError}
+        </div>
+      ) : null}
+
+      <button className="auth-submit" type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Creating account...' : 'Create administrator'}
+      </button>
+    </form>
+  )
+}
+
+export default function LoginPage(): ReactElement {
+  const navigate = useNavigate()
+  const {
+    login,
+    completeInitialSetup,
+    checkInitialSetupStatus,
+  } = useAuth()
+
+  const [view, setView] = useState<AuthView>('loading')
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+
+  const [loginEmail, setLoginEmail] = useState('')
+  const [loginPassword, setLoginPassword] = useState('')
+  const [loginFieldErrors, setLoginFieldErrors] = useState<LoginFieldErrors>({})
+  const [loginFormError, setLoginFormError] = useState<string | null>(null)
+  const [loginSubmitting, setLoginSubmitting] = useState(false)
+
+  const isMountedRef = useRef(true)
+  useEffect(() => () => {
+    isMountedRef.current = false
+  }, [])
+
+  const refreshSetupStatus = useCallback(
+    async (options?: { preserveMessage?: boolean }) => {
+      try {
+        const required = await checkInitialSetupStatus()
+        if (!isMountedRef.current) {
+          return required
+        }
+        setView(required ? 'setup' : 'login')
+        if (!options?.preserveMessage) {
+          setStatusMessage(null)
+        }
+        return required
+      } catch (error) {
+        if (!isMountedRef.current) {
+          throw error
+        }
+        if (!options?.preserveMessage) {
+          setStatusMessage('Unable to determine setup status. Please try signing in.')
+        }
+        setView('login')
+        throw error
+      }
+    },
+    [checkInitialSetupStatus],
+  )
+
+  useEffect(() => {
+    void refreshSetupStatus().catch(() => undefined)
+  }, [refreshSetupStatus])
+
+  const handleLoginSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const errors: LoginFieldErrors = {
+      email: validateEmail(loginEmail),
+      password: validatePassword(loginPassword),
+    }
+    setLoginFieldErrors(errors)
+    if (errors.email || errors.password) {
+      return
+    }
+
+    setLoginSubmitting(true)
+    setLoginFormError(null)
+    try {
+      await login(loginEmail.trim(), loginPassword)
+      navigate('/', { replace: true })
+    } catch (error) {
+      const problem = error as ApiError
+      setLoginFormError(problem.message || 'Unexpected error while signing in.')
+    } finally {
+      setLoginSubmitting(false)
+    }
+  }
+
+  const handleInitialSetupSubmit = useCallback(
+    async (payload: InitialSetupPayload) => {
+      await completeInitialSetup(payload)
+      navigate('/', { replace: true })
+    },
+    [completeInitialSetup, navigate],
+  )
+
+  const handleInitialSetupAlreadyConfigured = useCallback(() => {
+    void refreshSetupStatus({ preserveMessage: true }).catch(() => undefined)
+    if (isMountedRef.current) {
+      setStatusMessage('Initial setup is already complete. Please sign in.')
+    }
+  }, [refreshSetupStatus])
 
   return (
     <main className="auth-screen">
@@ -72,57 +286,79 @@ export default function LoginPage(): ReactElement {
           <h1>Automatic Data Extractor</h1>
           <p className="auth-subtitle">Sign in to manage your document pipeline.</p>
         </header>
-        <form className="auth-form" onSubmit={handleSubmit} noValidate>
-          <div className="form-field">
-            <label htmlFor="email">Email</label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              aria-invalid={Boolean(fieldErrors.email)}
-              aria-describedby={fieldErrors.email ? 'email-error' : undefined}
-              required
-            />
-            {fieldErrors.email ? (
-              <p className="field-error" id="email-error" role="alert">
-                {fieldErrors.email}
-              </p>
-            ) : null}
+
+        {view === 'loading' ? (
+          <div className="auth-loading" role="status" aria-live="polite">
+            Checking system status...
           </div>
-
-          <div className="form-field">
-            <label htmlFor="password">Password</label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              aria-invalid={Boolean(fieldErrors.password)}
-              aria-describedby={fieldErrors.password ? 'password-error' : undefined}
-              required
-            />
-            {fieldErrors.password ? (
-              <p className="field-error" id="password-error" role="alert">
-                {fieldErrors.password}
-              </p>
+        ) : (
+          <>
+            {statusMessage ? (
+              <div className="form-error" role="alert" aria-live="assertive">
+                {statusMessage}
+              </div>
             ) : null}
-          </div>
 
-          {formError ? (
-            <div className="form-error" role="alert" aria-live="assertive">
-              {formError}
-            </div>
-          ) : null}
+            {view === 'setup' ? (
+              <InitialSetupForm
+                onSubmit={handleInitialSetupSubmit}
+                onAlreadyConfigured={handleInitialSetupAlreadyConfigured}
+              />
+            ) : (
+              <form className="auth-form" onSubmit={handleLoginSubmit} noValidate>
+                <div className="form-field">
+                  <label htmlFor="email">Email</label>
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    value={loginEmail}
+                    onChange={(event) => setLoginEmail(event.target.value)}
+                    aria-invalid={Boolean(loginFieldErrors.email)}
+                    aria-describedby={loginFieldErrors.email ? 'email-error' : undefined}
+                    required
+                  />
+                  {loginFieldErrors.email ? (
+                    <p className="field-error" id="email-error" role="alert">
+                      {loginFieldErrors.email}
+                    </p>
+                  ) : null}
+                </div>
 
-          <button className="auth-submit" type="submit" disabled={isSubmitting}>
-            {isSubmitting ? 'Signing in...' : 'Sign in'}
-          </button>
-        </form>
+                <div className="form-field">
+                  <label htmlFor="password">Password</label>
+                  <input
+                    id="password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    value={loginPassword}
+                    onChange={(event) => setLoginPassword(event.target.value)}
+                    aria-invalid={Boolean(loginFieldErrors.password)}
+                    aria-describedby={loginFieldErrors.password ? 'password-error' : undefined}
+                    required
+                  />
+                  {loginFieldErrors.password ? (
+                    <p className="field-error" id="password-error" role="alert">
+                      {loginFieldErrors.password}
+                    </p>
+                  ) : null}
+                </div>
+
+                {loginFormError ? (
+                  <div className="form-error" role="alert" aria-live="assertive">
+                    {loginFormError}
+                  </div>
+                ) : null}
+
+                <button className="auth-submit" type="submit" disabled={loginSubmitting}>
+                  {loginSubmitting ? 'Signing in...' : 'Sign in'}
+                </button>
+              </form>
+            )}
+          </>
+        )}
       </section>
     </main>
   )

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -2,13 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import type { UserProfile } from '../../api/types'
+import type { InitialSetupPayload, UserProfile } from '../../api/types'
 import LoginPage from '../LoginPage'
 
 const mockLogin = vi.fn<Promise<UserProfile>, [string, string]>()
+const mockCompleteInitialSetup = vi.fn<Promise<UserProfile>, [InitialSetupPayload]>()
 const mockNavigate = vi.fn()
 const mockLogout = vi.fn<Promise<void>, []>()
 const mockRefresh = vi.fn<Promise<void>, []>()
+const mockCheckInitialSetupStatus = vi.fn<Promise<boolean>, []>()
 
 vi.mock('../../context/AuthContext', () => ({
   useAuth: () => ({
@@ -18,6 +20,8 @@ vi.mock('../../context/AuthContext', () => ({
     login: mockLogin,
     logout: mockLogout,
     refreshSession: mockRefresh,
+    completeInitialSetup: mockCompleteInitialSetup,
+    checkInitialSetupStatus: mockCheckInitialSetupStatus,
   }),
 }))
 
@@ -32,12 +36,17 @@ vi.mock('react-router-dom', async () => {
 describe('LoginPage', () => {
   beforeEach(() => {
     mockLogin.mockReset()
+    mockCompleteInitialSetup.mockReset()
     mockNavigate.mockReset()
+    mockCheckInitialSetupStatus.mockReset()
+    mockCheckInitialSetupStatus.mockResolvedValue(false)
   })
 
   it('validates required form fields before attempting login', async () => {
     const user = userEvent.setup()
     render(<LoginPage />)
+
+    await screen.findByRole('button', { name: /sign in/i })
 
     const submitButton = screen.getByRole('button', { name: /sign in/i })
     await user.click(submitButton)
@@ -52,6 +61,8 @@ describe('LoginPage', () => {
     mockLogin.mockRejectedValueOnce(new Error('Invalid credentials'))
 
     render(<LoginPage />)
+
+    await screen.findByRole('button', { name: /sign in/i })
 
     await user.type(screen.getByLabelText('Email'), 'user@example.com')
     await user.type(screen.getByLabelText('Password'), 'Password123!')
@@ -72,11 +83,71 @@ describe('LoginPage', () => {
 
     render(<LoginPage />)
 
+    await screen.findByRole('button', { name: /sign in/i })
+
     await user.type(screen.getByLabelText('Email'), '  user@example.com  ')
     await user.type(screen.getByLabelText('Password'), 'Password123!')
     await user.click(screen.getByRole('button', { name: /sign in/i }))
 
     expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'Password123!')
     expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+  })
+
+  it('renders the initial setup form when setup is required and submits values', async () => {
+    const user = userEvent.setup()
+    mockCheckInitialSetupStatus.mockResolvedValueOnce(true)
+    mockCompleteInitialSetup.mockResolvedValueOnce({
+      user_id: 'abc',
+      email: 'owner@example.com',
+      role: 'admin',
+      is_active: true,
+    })
+
+    render(<LoginPage />)
+
+    await screen.findByRole('button', { name: /create administrator/i })
+
+    await user.type(screen.getByLabelText('Email'), 'owner@example.com')
+    await user.type(screen.getByLabelText('Display name (optional)'), 'Owner  ')
+    await user.type(screen.getByLabelText('Password'), 'Password123!')
+    await user.type(screen.getByLabelText('Confirm password'), 'Password123!')
+    await user.click(screen.getByRole('button', { name: /create administrator/i }))
+
+    expect(mockCompleteInitialSetup).toHaveBeenCalledWith({
+      email: 'owner@example.com',
+      password: 'Password123!',
+      displayName: 'Owner',
+    })
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+  })
+
+  it('falls back to the login form when setup completion returns a conflict', async () => {
+    const user = userEvent.setup()
+    mockCheckInitialSetupStatus.mockResolvedValueOnce(true)
+    const conflictError = Object.assign(new Error('Already configured'), { status: 409 })
+    mockCompleteInitialSetup.mockRejectedValueOnce(conflictError)
+
+    render(<LoginPage />)
+
+    await screen.findByRole('button', { name: /create administrator/i })
+
+    await user.type(screen.getByLabelText('Email'), 'owner@example.com')
+    await user.type(screen.getByLabelText('Password'), 'Password123!')
+    await user.type(screen.getByLabelText('Confirm password'), 'Password123!')
+    await user.click(screen.getByRole('button', { name: /create administrator/i }))
+
+    expect(await screen.findByText('Initial setup is already complete. Please sign in.')).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /sign in/i })).toBeInTheDocument()
+  })
+
+  it('shows a status message when setup status cannot be loaded', async () => {
+    mockCheckInitialSetupStatus.mockRejectedValueOnce(new Error('status failed'))
+
+    render(<LoginPage />)
+
+    expect(
+      await screen.findByText('Unable to determine setup status. Please try signing in.'),
+    ).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /sign in/i })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- update the initial setup transaction to set the locked system setting value directly and drop the unused repository upsert helper
- consolidate the frontend auth session POST handling behind a shared helper that validates the response shape before applying cookies
- reuse a shared session application helper in the auth context so login and first-admin setup both clear errors and update state consistently

## Testing
- pytest
- npm test -- --run *(fails: local vitest binary unavailable in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b5474624832eb4f6e7b87c9c66ef