### PR TITLE
Refine ADE reset command

### DIFF
--- a/backend/tests/cli/test_app.py
+++ b/backend/tests/cli/test_app.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from cli.app import build_cli_app
-from cli.commands import api_keys, settings as settings_command, users
+from cli.commands import api_keys, reset as reset_command, settings as settings_command, users
 
 
 def test_users_create_handler_resolution() -> None:
@@ -69,3 +69,11 @@ def test_settings_command_handler_resolution() -> None:
     args = parser.parse_args(["settings"])
 
     assert args.handler is settings_command.dump
+
+
+def test_reset_command_handler_resolution() -> None:
+    parser = build_cli_app()
+    args = parser.parse_args(["reset", "--yes"])
+
+    assert args.handler is reset_command.reset
+    assert args.yes is True

--- a/backend/tests/cli/test_reset.py
+++ b/backend/tests/cli/test_reset.py
@@ -1,0 +1,106 @@
+import argparse
+from pathlib import Path
+
+from cli.commands import reset as reset_command
+
+
+def _configure_environment(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    data_dir = tmp_path / "data"
+    database_path = data_dir / "db" / "ade.sqlite"
+    documents_dir = data_dir / "documents"
+
+    monkeypatch.setenv("ADE_DATABASE_DSN", f"sqlite+aiosqlite:///{database_path}")
+    monkeypatch.setenv("ADE_STORAGE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("ADE_STORAGE_DOCUMENTS_DIR", str(documents_dir))
+
+    return database_path, documents_dir
+
+
+def test_reset_command_removes_sqlite_and_documents(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    database_path, documents_dir = _configure_environment(monkeypatch, tmp_path)
+
+    database_path.parent.mkdir(parents=True)
+    database_path.write_text("placeholder", encoding="utf-8")
+    (database_path.parent / "ade.sqlite-wal").write_text("", encoding="utf-8")
+    (database_path.parent / "ade.sqlite-shm").write_text("", encoding="utf-8")
+
+    documents_dir.mkdir(parents=True)
+    (documents_dir / "cached.txt").write_text("cached", encoding="utf-8")
+    nested = documents_dir / "nested"
+    nested.mkdir()
+    (nested / "entry.txt").write_text("nested", encoding="utf-8")
+
+    reset_command.reset(argparse.Namespace(yes=True))
+
+    captured = capsys.readouterr()
+    assert "ADE data reset complete." in captured.out
+
+    assert not database_path.exists()
+    assert not (database_path.parent / "ade.sqlite-wal").exists()
+    assert not (database_path.parent / "ade.sqlite-shm").exists()
+
+    assert documents_dir.exists()
+    assert list(documents_dir.iterdir()) == []
+
+
+def test_reset_command_prompts_and_aborts(tmp_path: Path, monkeypatch, capsys) -> None:
+    database_path, documents_dir = _configure_environment(monkeypatch, tmp_path)
+
+    database_path.parent.mkdir(parents=True)
+    database_path.write_text("placeholder", encoding="utf-8")
+    documents_dir.mkdir(parents=True)
+    (documents_dir / "cached.txt").write_text("cached", encoding="utf-8")
+
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+
+    reset_command.reset(argparse.Namespace(yes=False))
+
+    captured = capsys.readouterr()
+    assert "Reset aborted." in captured.out
+
+    assert database_path.exists()
+    assert documents_dir.exists()
+    assert any(documents_dir.iterdir())
+
+
+def test_reset_command_skips_non_sqlite_database(tmp_path: Path, monkeypatch, capsys) -> None:
+    data_dir = tmp_path / "data"
+    documents_dir = data_dir / "documents"
+
+    monkeypatch.setenv(
+        "ADE_DATABASE_DSN",
+        "postgresql+asyncpg://example:secret@example.com:5432/ade",
+    )
+    monkeypatch.setenv("ADE_STORAGE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("ADE_STORAGE_DOCUMENTS_DIR", str(documents_dir))
+
+    documents_dir.mkdir(parents=True)
+    (documents_dir / "cached.txt").write_text("cached", encoding="utf-8")
+
+    reset_calls: list[str] = []
+
+    def fake_reset_database_state() -> None:
+        reset_calls.append("called")
+
+    monkeypatch.setattr(
+        reset_command,
+        "reset_database_state",
+        fake_reset_database_state,
+    )
+
+    def fail_remove(_: Path) -> None:
+        raise AssertionError("non-SQLite database should be skipped")
+
+    monkeypatch.setattr(reset_command, "_remove_sqlite_database", fail_remove)
+
+    reset_command.reset(argparse.Namespace(yes=True))
+
+    captured = capsys.readouterr()
+    assert "Configured backend 'postgresql' is not SQLite" in captured.out
+    assert "ADE data reset complete." in captured.out
+
+    assert reset_calls == ["called"]
+    assert documents_dir.exists()
+    assert list(documents_dir.iterdir()) == []

--- a/cli/app.py
+++ b/cli/app.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from backend.api.modules.users.models import UserRole
 
 from cli.commands import api_keys as api_keys_commands
+from cli.commands import reset as reset_command
 from cli.commands import settings as settings_command
 from cli.commands import start as start_command
 from cli.commands import users as user_commands
@@ -50,6 +51,13 @@ def build_cli_app() -> argparse.ArgumentParser:
         help="Inspect ADE configuration.",
     )
     settings_parser.set_defaults(handler=settings_command.dump)
+
+    reset_parser = subparsers.add_parser(
+        "reset",
+        help="Delete the ADE database and cached documents.",
+    )
+    reset_command.register_arguments(reset_parser)
+    reset_parser.set_defaults(handler=reset_command.reset)
 
     # User management -----------------------------------------------------
     users_parser = subparsers.add_parser("users", help="Manage ADE user accounts.")

--- a/cli/commands/__init__.py
+++ b/cli/commands/__init__.py
@@ -1,3 +1,3 @@
 """Command registry for ADE CLI submodules."""
 
-__all__ = ["api_keys", "users", "start", "settings"]
+__all__ = ["api_keys", "users", "start", "settings", "reset"]

--- a/cli/commands/reset.py
+++ b/cli/commands/reset.py
@@ -1,0 +1,138 @@
+"""Reset command for ADE CLI."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+from sqlalchemy.engine import URL, make_url
+
+from backend.api.db.engine import is_sqlite_memory_url, reset_database_state
+from cli.core.runtime import load_settings
+
+__all__ = ["register_arguments", "reset"]
+
+
+def register_arguments(parser: argparse.ArgumentParser) -> None:
+    """Attach options for the ``ade reset`` command."""
+
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Reset without prompting for confirmation.",
+    )
+
+
+def reset(args: argparse.Namespace) -> None:
+    """Erase the SQLite database and cached documents."""
+
+    settings = load_settings()
+    database_path, database_warning = _resolve_database_path(settings.database_dsn)
+    documents_path = _absolute_path(settings.storage_documents_dir)
+
+    _print_reset_plan(database_path, database_warning, documents_path)
+
+    if not getattr(args, "yes", False) and not _confirm_reset():
+        print("Reset aborted.")
+        return
+
+    reset_database_state()
+
+    if database_path is not None:
+        _remove_sqlite_database(database_path)
+
+    _reset_directory(documents_path)
+
+    print("ADE data reset complete.")
+
+
+def _resolve_database_path(database_dsn: str) -> tuple[Path | None, str | None]:
+    """Return the filesystem path for a SQLite database if applicable."""
+
+    url = make_url(database_dsn)
+    if url.get_backend_name() != "sqlite":
+        return None, f"Configured backend '{url.get_backend_name()}' is not SQLite."
+
+    if _is_memory_sqlite(url):
+        return None, "SQLite database is in-memory; nothing to delete."
+
+    database = (url.database or "").strip()
+    if not database:
+        return None, "SQLite database path is empty; nothing to delete."
+
+    return _absolute_path(database), None
+
+
+def _is_memory_sqlite(url: URL) -> bool:
+    """Return ``True`` if ``url`` points at an in-memory SQLite database."""
+
+    return is_sqlite_memory_url(url)
+
+
+def _remove_sqlite_database(path: Path) -> None:
+    """Delete a SQLite database and associated sidecar files."""
+
+    for candidate in _sqlite_sidecar_paths(path):
+        _remove_path(candidate)
+
+
+def _reset_directory(path: Path) -> None:
+    """Remove ``path`` and recreate an empty directory."""
+
+    if path.exists():
+        _remove_path(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _print_reset_plan(
+    database_path: Path | None, database_warning: str | None, documents_path: Path
+) -> None:
+    """Describe the artefacts that will be removed."""
+
+    print("This will delete ADE runtime state for the active environment:")
+    if database_path is not None:
+        print(f"  - SQLite database: {database_path}")
+    else:
+        reason = database_warning or "No file-based database configured."
+        print(f"  - SQLite database: skipped ({reason})")
+    print(f"  - cached documents directory: {documents_path}")
+    print("This action cannot be undone.")
+
+
+def _confirm_reset() -> bool:
+    """Prompt the operator for confirmation."""
+
+    response = input("Proceed with deletion? [y/N]: ").strip().lower()
+    return response in {"y", "yes"}
+
+
+def _absolute_path(path: Path | str) -> Path:
+    """Return an absolute version of ``path`` relative to the working directory."""
+
+    candidate = Path(path)
+    return candidate if candidate.is_absolute() else Path.cwd() / candidate
+
+
+def _sqlite_sidecar_paths(path: Path) -> list[Path]:
+    """Return sidecar artefacts produced by SQLite journaling modes."""
+
+    return [
+        path,
+        path.with_name(path.name + "-wal"),
+        path.with_name(path.name + "-shm"),
+        path.with_name(path.name + "-journal"),
+    ]
+
+
+def _remove_path(path: Path) -> None:
+    """Best-effort removal for a file or directory."""
+
+    try:
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+    except FileNotFoundError:
+        return


### PR DESCRIPTION
## Summary
- simplify the `ade reset` command flow with clearer messaging, confirmation handling, and path utilities
- normalize file and directory cleanup helpers to share removal logic across SQLite artefacts and cached documents
- extend CLI reset tests to cover non-SQLite configurations alongside confirmation and cleanup scenarios

## Testing
- pytest backend/tests/cli/test_reset.py
- pytest backend/tests/cli/test_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d9d6eb1894832ead95ee6d6d695775