### PR TITLE
Refactor settings to standard FastAPI conventions

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,21 @@
+# ADE runtime defaults for local development
+ADE_DEBUG=false
+ADE_DEV_MODE=false
+ADE_API_DOCS_ENABLED=false
+ADE_LOGGING_LEVEL=INFO
+
+ADE_SERVER_HOST=localhost
+ADE_SERVER_PORT=8000
+ADE_SERVER_PUBLIC_URL=http://localhost:8000
+ADE_SERVER_CORS_ORIGINS=["http://localhost:5173"]
+
+ADE_JWT_SECRET=development-secret
+ADE_JWT_ACCESS_TTL=60m
+ADE_JWT_REFRESH_TTL=14d
+
+ADE_STORAGE_DATA_DIR=var
+# Leave ADE_STORAGE_DOCUMENTS_DIR unset to store uploads under <storage_data_dir>/documents
+ADE_STORAGE_UPLOAD_MAX_BYTES=26214400
+ADE_STORAGE_DOCUMENT_RETENTION_PERIOD=30d
+
+#ADE_DATABASE_DSN=sqlite+aiosqlite:///./var/db/ade.sqlite

--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,10 @@ ADE_SERVER_PORT=8000
 # `ADE_SERVER_PUBLIC_URL=https://ade.example.com`
 ADE_SERVER_PUBLIC_URL=http://localhost:8000
 
-# Additional origins for CORS (comma, space, or JSON array). Include the frontend
-# dev server for local work. In production add any hosted domains, such as
-# `https://ade.example.com` for the shipped UI.
-ADE_SERVER_CORS_ORIGINS=http://localhost:5173
+# Additional origins for CORS. Provide a JSON array (e.g. ["http://localhost:5173"]).
+# Include the frontend dev server for local work. In production add hosted domains,
+# such as `https://ade.example.com` for the shipped UI.
+ADE_SERVER_CORS_ORIGINS=["http://localhost:5173"]
 
 # JWT settings for session cookies. Defaults match the development profile.
 ADE_JWT_SECRET=development-secret
@@ -34,9 +34,9 @@ ADE_JWT_ACCESS_TTL=60m
 ADE_JWT_REFRESH_TTL=14d
 
 # Runtime storage paths (created automatically if they do not exist).
-ADE_STORAGE_DATA_DIR=backend/data
+ADE_STORAGE_DATA_DIR=var
 # Optional override for the documents directory (defaults to <data>/documents).
-# ADE_STORAGE_DOCUMENTS_DIR=backend/data/documents
+# ADE_STORAGE_DOCUMENTS_DIR=var/documents
 # Maximum upload size (bytes); defaults to 25 MiB.
 ADE_STORAGE_UPLOAD_MAX_BYTES=26214400
 # Document retention window (accepts seconds or suffixed strings like 30d).
@@ -59,4 +59,4 @@ ADE_STORAGE_DOCUMENT_RETENTION_PERIOD=30d
 # ADE_OIDC_CLIENT_SECRET=change-me
 # ADE_OIDC_ISSUER=https://identity.example.com
 # ADE_OIDC_REDIRECT_URL=https://app.example.com/auth/callback
-# ADE_OIDC_SCOPES=openid email profile
+# ADE_OIDC_SCOPES=["openid","email","profile"]

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __pycache__/
 *.py[cod]
 *.pyo
 *.so
-.env
 .venv/
 .eggs/
 *.egg-info/

--- a/agents/CURRENT_TASK.md
+++ b/agents/CURRENT_TASK.md
@@ -1,0 +1,37 @@
+## Context
+Settings now expose consistent names and types, but the configuration surface
+still lives in a single `Settings` object. `agents/BEST_PRACTICE_VIOLATIONS.md`
+calls out this monolith as a FastAPI anti-pattern: services import the entire
+settings payload even when they only need a narrow slice, making tests and
+future overrides harder to reason about.
+
+## Goals
+- Introduce focused config models (for example `ServerSettings`,
+  `DatabaseSettings`, `JwtSettings`, `StorageSettings`) and compose them within a
+  slim orchestration object.
+- Update dependencies, services, and routers to consume the scoped configs they
+  need rather than the top-level `Settings` bag of values.
+- Preserve the existing `ADE_` environment variables and documentation so the
+  frontend team and operators continue to see a predictable configuration API.
+
+## Non-goals
+- Changing default values or environment names for existing settings.
+- Reworking CLI surfaces beyond swapping their imports to the new config
+  structure.
+- Introducing dynamic loading or plugin systems; this task is purely structural.
+
+## Tasks
+1. Extract domain-specific settings models, wiring them into a root `Settings`
+   container that mirrors today’s environment handling.
+2. Update modules to depend on the appropriate slice (e.g. request middleware
+   uses `ServerSettings`, repositories use `DatabaseSettings`).
+3. Adjust tests and fixtures to access the new config structure and extend docs
+   with a short note about the nested layout.
+4. Run `mypy app` and `pytest` to prove the refactor holds.
+
+## Acceptance criteria
+- Settings consumers import the scoped config objects they need rather than the
+  monolithic class.
+- Environment variables and defaults remain unchanged for operators.
+- Documentation and regression tests reflect the new structure without loss of
+  coverage.

--- a/agents/PREVIOUS_TASK.md
+++ b/agents/PREVIOUS_TASK.md
@@ -1,20 +1,23 @@
+# Align settings with standard FastAPI conventions
+
 ## Context
-`CURRENT_TASK.md` asked us to ensure both the FastAPI app and CLI bootstrap the
-SQLite database before serving traffic, fixing the missing `users` table error
-encountered by `ade users create`.
+`CURRENT_TASK.md` called for renaming and retyping configuration so the backend
+exposes predictable, standard FastAPI/Pydantic settings ahead of frontend work.
+The previous module mixed prefixes, optional strings, and bespoke helpers that
+obscured defaults and required call sites to reach for custom properties.
 
 ## Outcome
-- Added a reusable `bootstrap_database` helper that guarantees the SQLite
-  directory exists and runs `alembic upgrade head` exactly once per settings
-  configuration.
-- Integrated the helper into the FastAPI lifespan and CLI session manager so
-  web requests and CLI commands both migrate the schema before opening a
-  session.
-- Introduced regression tests that prove API startup and CLI session helpers
-  materialise the `users` table automatically.
+- Rewrote `Settings` with grouped field names, first-class Pydantic types, and
+  defaults that create runtime directories automatically while keeping access to
+  the unwrapped JWT secret for token signing.【F:app/settings.py†L28-L460】
+- Updated services and CLI helpers to consume `storage_documents_dir`
+  directly, reflecting the concrete directory returned by the new settings
+  contract.【F:app/documents/service.py†L1-L83】【F:app/jobs/service.py†L1-L118】【F:app/cli/commands/reset.py†L1-L87】
+- Refreshed environment templates, docs, and regression tests to match the
+  renamed fields, JSON-based list inputs, and developer defaults so operators
+  have a single, standard configuration story.【F:.env†L1-L18】【F:.env.example†L1-L45】【F:README.md†L137-L162】【F:docs/admin-guide/README.md†L12-L19】【F:tests/core/test_settings.py†L1-L234】
 
 ## Next steps
-- Update the developer documentation to describe the new automatic bootstrap
-  behaviour and clarify how to run migrations manually when needed.
-- Consider establishing a clean `mypy` baseline so future backend changes can
-  rely on type-checking without surfacing dozens of legacy errors.
+- Break the monolithic `Settings` class into domain-specific configs per
+  `agents/BEST_PRACTICE_VIOLATIONS.md` item #4 so modules depend only on the
+  configuration they need.

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -1,12 +1,14 @@
 """Routes for authentication flows."""
 
+from __future__ import annotations
+
+from typing import Annotated
+
 import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
-from fastapi_utils.cbv import cbv
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db.session import get_session
+from app.core.schema import ErrorMessage
 from ..users.dependencies import get_users_service
 from ..users.models import User
 from ..users.schemas import UserProfile
@@ -22,307 +24,433 @@ from .schemas import (
     SessionEnvelope,
 )
 from .security import access_control
-from .service import SSO_STATE_COOKIE, AuthService
+from .service import AuthService, SSO_STATE_COOKIE
 
 router = APIRouter(prefix="/auth", tags=["auth"])
-@cbv(router)
-class AuthRoutes:
-    session: AsyncSession = Depends(get_session)  # noqa: B008
-    service: AuthService = Depends(get_auth_service)  # noqa: B008
 
-    @router.get(
-        "/initial-setup",
-        response_model=InitialSetupStatus,
-        status_code=status.HTTP_200_OK,
-        summary="Return whether initial admin setup is required",
-        openapi_extra={"security": []},
+AuthServiceDep = Annotated[AuthService, Depends(get_auth_service)]
+AdminAuthServiceDep = Annotated[
+    AuthService,
+    Depends(access_control(require_admin=True)),
+]
+UsersServiceDep = Annotated[UsersService, Depends(get_users_service)]
+UserDep = Annotated[User, Depends(bind_current_user)]
+
+
+@router.get(
+    "/initial-setup",
+    response_model=InitialSetupStatus,
+    status_code=status.HTTP_200_OK,
+    summary="Return whether initial admin setup is required",
+    openapi_extra={"security": []},
+)
+async def read_initial_setup_status(
+    service: AuthServiceDep,
+) -> InitialSetupStatus:
+    required = await service.initial_setup_required()
+    return InitialSetupStatus(initial_setup_required=required)
+
+
+@router.post(
+    "/initial-setup",
+    response_model=SessionEnvelope,
+    status_code=status.HTTP_200_OK,
+    summary="Create the first administrator account",
+    openapi_extra={"security": []},
+    responses={
+        status.HTTP_409_CONFLICT: {
+            "description": "Initial setup already completed or email already in use.",
+            "model": ErrorMessage,
+        }
+    },
+)
+async def perform_initial_setup(
+    request: Request,
+    response: Response,
+    payload: InitialSetupRequest,
+    service: AuthServiceDep,
+) -> SessionEnvelope:
+    user = await service.complete_initial_setup(
+        email=payload.email,
+        password=payload.password.get_secret_value(),
+        display_name=payload.display_name,
     )
-    async def read_initial_setup_status(self) -> InitialSetupStatus:
-        required = await self.service.initial_setup_required()
-        return InitialSetupStatus(initial_setup_required=required)
-
-    @router.post(
-        "/initial-setup",
-        response_model=SessionEnvelope,
-        status_code=status.HTTP_200_OK,
-        summary="Create the first administrator account",
-        openapi_extra={"security": []},
+    tokens = await service.start_session(user=user)
+    secure_cookie = service.is_secure_request(request)
+    service.apply_session_cookies(response, tokens, secure=secure_cookie)
+    profile = UserProfile.model_validate(user)
+    return SessionEnvelope(
+        user=profile,
+        expires_at=tokens.access_expires_at,
+        refresh_expires_at=tokens.refresh_expires_at,
     )
-    async def perform_initial_setup(
-        self,
-        request: Request,
-        response: Response,
-        payload: InitialSetupRequest,
-    ) -> SessionEnvelope:
-        user = await self.service.complete_initial_setup(
-            email=payload.email,
-            password=payload.password.get_secret_value(),
-            display_name=payload.display_name,
-        )
-        tokens = await self.service.start_session(user=user)
-        secure_cookie = self.service.is_secure_request(request)
-        self.service.apply_session_cookies(response, tokens, secure=secure_cookie)
-        profile = UserProfile.model_validate(user)
-        return SessionEnvelope(
-            user=profile,
-            expires_at=tokens.access_expires_at,
-            refresh_expires_at=tokens.refresh_expires_at,
-        )
 
-    @router.post(
-        "/login",
-        response_model=SessionEnvelope,
-        status_code=status.HTTP_200_OK,
-        summary="Authenticate with email and password",
-        openapi_extra={"security": []},
+
+@router.post(
+    "/login",
+    response_model=SessionEnvelope,
+    status_code=status.HTTP_200_OK,
+    summary="Authenticate with email and password",
+    openapi_extra={"security": []},
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials provided.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "User account is inactive or service account credentials were supplied.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def login(
+    request: Request,
+    response: Response,
+    payload: LoginRequest,
+    service: AuthServiceDep,
+) -> SessionEnvelope:
+    """Authenticate with credentials and establish the session cookies."""
+
+    user = await service.authenticate(
+        email=payload.email,
+        password=payload.password.get_secret_value(),
     )
-    async def login(
-        self,
-        request: Request,
-        response: Response,
-        payload: LoginRequest,
-    ) -> SessionEnvelope:
-        """Authenticate with credentials and establish the session cookies."""
-
-        user = await self.service.authenticate(
-            email=payload.email,
-            password=payload.password.get_secret_value(),
-        )
-        tokens = await self.service.start_session(user=user)
-        secure_cookie = self.service.is_secure_request(request)
-        self.service.apply_session_cookies(response, tokens, secure=secure_cookie)
-        profile = UserProfile.model_validate(user)
-        return SessionEnvelope(
-            user=profile,
-            expires_at=tokens.access_expires_at,
-            refresh_expires_at=tokens.refresh_expires_at,
-        )
-
-    @router.post(
-        "/refresh",
-        response_model=SessionEnvelope,
-        status_code=status.HTTP_200_OK,
-        summary="Refresh the active browser session",
-        openapi_extra={"security": []},
+    tokens = await service.start_session(user=user)
+    secure_cookie = service.is_secure_request(request)
+    service.apply_session_cookies(response, tokens, secure=secure_cookie)
+    profile = UserProfile.model_validate(user)
+    return SessionEnvelope(
+        user=profile,
+        expires_at=tokens.access_expires_at,
+        refresh_expires_at=tokens.refresh_expires_at,
     )
-    async def refresh_session(
-        self,
-        request: Request,
-        response: Response,
-    ) -> SessionEnvelope:
-        """Rotate the session using the refresh cookie and re-issue cookies."""
 
-        refresh_cookie = request.cookies.get(
-            self.service.settings.session_refresh_cookie_name
-        )
-        if not refresh_cookie:
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Refresh token missing")
+
+@router.post(
+    "/refresh",
+    response_model=SessionEnvelope,
+    status_code=status.HTTP_200_OK,
+    summary="Refresh the active browser session",
+    openapi_extra={"security": []},
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Refresh token missing or invalid.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "CSRF validation failed for the refresh request.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def refresh_session(
+    request: Request,
+    response: Response,
+    service: AuthServiceDep,
+) -> SessionEnvelope:
+    """Rotate the session using the refresh cookie and re-issue cookies."""
+
+    refresh_cookie = request.cookies.get(service.settings.session_refresh_cookie_name)
+    if not refresh_cookie:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Refresh token missing")
+    try:
+        payload = service.decode_token(refresh_cookie, expected_type="refresh")
+    except jwt.PyJWTError as exc:  # pragma: no cover - dependent on jwt internals
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token") from exc
+
+    service.enforce_csrf(request, payload)
+    user = await service.resolve_user(payload)
+    tokens = await service.refresh_session(payload=payload, user=user)
+    secure_cookie = service.is_secure_request(request)
+    service.apply_session_cookies(response, tokens, secure=secure_cookie)
+    profile = UserProfile.model_validate(user)
+    return SessionEnvelope(
+        user=profile,
+        expires_at=tokens.access_expires_at,
+        refresh_expires_at=tokens.refresh_expires_at,
+    )
+
+
+@router.post(
+    "/logout",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Terminate the active session",
+    openapi_extra={"security": []},
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Session token is missing or invalid.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "CSRF validation failed for the logout request.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def logout(
+    request: Request,
+    response: Response,
+    service: AuthServiceDep,
+) -> Response:
+    """Remove authentication cookies and end the session."""
+
+    session_cookie = request.cookies.get(service.settings.session_cookie_name)
+    if session_cookie:
         try:
-            payload = self.service.decode_token(refresh_cookie, expected_type="refresh")
+            payload = service.decode_token(session_cookie, expected_type="access")
         except jwt.PyJWTError as exc:  # pragma: no cover - dependent on jwt internals
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token") from exc
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid session token") from exc
+        service.enforce_csrf(request, payload)
+    service.clear_session_cookies(response)
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response
 
-        self.service.enforce_csrf(request, payload)
-        user = await self.service.resolve_user(payload)
-        tokens = await self.service.refresh_session(payload=payload, user=user)
-        secure_cookie = self.service.is_secure_request(request)
-        self.service.apply_session_cookies(response, tokens, secure=secure_cookie)
-        profile = UserProfile.model_validate(user)
-        return SessionEnvelope(
-            user=profile,
-            expires_at=tokens.access_expires_at,
-            refresh_expires_at=tokens.refresh_expires_at,
+
+@router.get(
+    "/me",
+    response_model=UserProfile,
+    status_code=status.HTTP_200_OK,
+    response_model_exclude_none=True,
+    summary="Return the authenticated user profile",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to access the profile.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Service account credentials cannot access this endpoint.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def who_am_i(
+    _: UserDep,
+    users_service: UsersServiceDep,
+) -> UserProfile:
+    """Return profile information for the active user."""
+
+    profile = await users_service.get_profile()
+    return profile
+
+
+@router.post(
+    "/api-keys",
+    response_model=APIKeyIssueResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Issue a new API key for a user",
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Email required or target user is inactive.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to manage API keys.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Administrator role required to issue API keys.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Specified user could not be found.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def create_api_key(
+    payload: APIKeyIssueRequest,
+    _: UserDep,
+    service: AdminAuthServiceDep,
+) -> APIKeyIssueResponse:
+    if payload.user_id is not None:
+        result = await service.issue_api_key_for_user_id(
+            user_id=payload.user_id,
+            expires_in_days=payload.expires_in_days,
         )
-
-    @router.post(
-        "/logout",
-        status_code=status.HTTP_204_NO_CONTENT,
-        summary="Terminate the active session",
-        openapi_extra={"security": []},
-    )
-    async def logout(self, request: Request, response: Response) -> Response:
-        """Remove authentication cookies and end the session."""
-
-        session_cookie = request.cookies.get(self.service.settings.session_cookie_name)
-        if session_cookie:
-            try:
-                payload = self.service.decode_token(session_cookie, expected_type="access")
-            except jwt.PyJWTError as exc:  # pragma: no cover - dependent on jwt internals
-                raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid session token") from exc
-            self.service.enforce_csrf(request, payload)
-        self.service.clear_session_cookies(response)
-        response.status_code = status.HTTP_204_NO_CONTENT
-        return response
-
-    @router.get(
-        "/me",
-        response_model=UserProfile,
-        status_code=status.HTTP_200_OK,
-        response_model_exclude_none=True,
-        summary="Return the authenticated user profile",
-    )
-    async def who_am_i(
-        self,
-        _current_user: User = Depends(bind_current_user),  # noqa: B008
-        users_service: UsersService = Depends(get_users_service),  # noqa: B008
-    ) -> UserProfile:
-        """Return profile information for the active user."""
-
-        profile = await users_service.get_profile()
-        return profile
-
-    @router.post(
-        "/api-keys",
-        response_model=APIKeyIssueResponse,
-        status_code=status.HTTP_201_CREATED,
-        summary="Issue a new API key for a user",
-    )
-    @access_control(require_admin=True)
-    async def create_api_key(
-        self,
-        payload: APIKeyIssueRequest,
-        _current_user: User = Depends(bind_current_user),  # noqa: B008
-    ) -> APIKeyIssueResponse:
-        if payload.user_id is not None:
-            result = await self.service.issue_api_key_for_user_id(
-                user_id=payload.user_id,
-                expires_in_days=payload.expires_in_days,
-            )
-        else:
-            email = payload.email
-            if email is None:  # pragma: no cover - validated upstream
-                raise HTTPException(
-                    status.HTTP_400_BAD_REQUEST,
-                    detail="Email required",
-                )
-            result = await self.service.issue_api_key_for_email(
-                email=email,
-                expires_in_days=payload.expires_in_days,
-            )
-
-        return APIKeyIssueResponse(
-            api_key=result.raw_key,
-            principal_type=result.principal_type,
-            principal_id=result.user.id,
-            principal_label=result.principal_label,
-            expires_at=result.api_key.expires_at,
-        )
-
-    @router.get(
-        "/api-keys",
-        response_model=list[APIKeySummary],
-        status_code=status.HTTP_200_OK,
-        summary="List issued API keys",
-    )
-    @access_control(require_admin=True)
-    async def list_api_keys(
-        self,
-        _: User = Depends(bind_current_user),  # noqa: B008
-    ) -> list[APIKeySummary]:
-        records = await self.service.list_api_keys()
-        return [
-            APIKeySummary(
-                api_key_id=record.id,
-                principal_type=(
-                    "service_account"
-                    if record.user is not None and record.user.is_service_account
-                    else "user"
-                ),
-                principal_id=record.user_id,
-                principal_label=(
-                    record.user.label
-                    if record.user is not None
-                    else ""
-                ),
-                token_prefix=record.token_prefix,
-                created_at=record.created_at,
-                expires_at=record.expires_at,
-                last_seen_at=record.last_seen_at,
-                last_seen_ip=record.last_seen_ip,
-                last_seen_user_agent=record.last_seen_user_agent,
-            )
-            for record in records
-        ]
-
-    @router.delete(
-        "/api-keys/{api_key_id}",
-        summary="Revoke an API key",
-    )
-    @access_control(require_admin=True)
-    async def revoke_api_key(
-        self,
-        api_key_id: str,
-        _: User = Depends(bind_current_user),  # noqa: B008
-    ) -> Response:
-        await self.service.revoke_api_key(api_key_id)
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
-
-    @router.get(
-        "/sso/login",
-        status_code=status.HTTP_302_FOUND,
-        summary="Initiate the SSO login flow",
-        openapi_extra={"security": []},
-    )
-    async def start_sso_login(self, request: Request) -> RedirectResponse:
-        challenge = await self.service.prepare_sso_login()
-        redirect = RedirectResponse(challenge.redirect_url, status_code=status.HTTP_302_FOUND)
-        secure_cookie = self.service.is_secure_request(request)
-        redirect.set_cookie(
-            key=SSO_STATE_COOKIE,
-            value=challenge.state_token,
-            httponly=True,
-            secure=secure_cookie,
-            max_age=challenge.expires_in,
-            samesite="lax",
-            path="/auth/sso",
-        )
-        return redirect
-
-    @router.get(
-        "/sso/callback",
-        response_model=SessionEnvelope,
-        status_code=status.HTTP_200_OK,
-        summary="Handle the SSO callback and establish a session",
-        openapi_extra={"security": []},
-    )
-    async def finish_sso_login(
-        self,
-        request: Request,
-        response: Response,
-        code: str | None = None,
-        state: str | None = None,
-    ) -> SessionEnvelope:
-        if not code or not state:
+    else:
+        email = payload.email
+        if email is None:  # pragma: no cover - validated upstream
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
-                detail="Missing authorization code or state",
+                detail="Email required",
             )
-
-        state_cookie = request.cookies.get(SSO_STATE_COOKIE)
-        if not state_cookie:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Missing SSO state cookie",
-            )
-
-        try:
-            user = await self.service.complete_sso_login(
-                code=code,
-                state=state,
-                state_token=state_cookie,
-            )
-        finally:
-            response.delete_cookie(SSO_STATE_COOKIE, path="/auth/sso")
-
-        tokens = await self.service.start_session(user=user)
-        secure_cookie = self.service.is_secure_request(request)
-        self.service.apply_session_cookies(response, tokens, secure=secure_cookie)
-        profile = UserProfile.model_validate(user)
-        return SessionEnvelope(
-            user=profile,
-            expires_at=tokens.access_expires_at,
-            refresh_expires_at=tokens.refresh_expires_at,
+        result = await service.issue_api_key_for_email(
+            email=email,
+            expires_in_days=payload.expires_in_days,
         )
+
+    return APIKeyIssueResponse(
+        api_key=result.raw_key,
+        principal_type=result.principal_type,
+        principal_id=result.user.id,
+        principal_label=result.principal_label,
+        expires_at=result.api_key.expires_at,
+    )
+
+
+@router.get(
+    "/api-keys",
+    response_model=list[APIKeySummary],
+    status_code=status.HTTP_200_OK,
+    summary="List issued API keys",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to list API keys.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Administrator role required to list API keys.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def list_api_keys(
+    _: UserDep,
+    service: AdminAuthServiceDep,
+) -> list[APIKeySummary]:
+    records = await service.list_api_keys()
+    return [
+        APIKeySummary(
+            api_key_id=record.id,
+            principal_type=(
+                "service_account"
+                if record.user is not None and record.user.is_service_account
+                else "user"
+            ),
+            principal_id=record.user_id,
+            principal_label=(
+                record.user.label
+                if record.user is not None
+                else ""
+            ),
+            token_prefix=record.token_prefix,
+            created_at=record.created_at,
+            expires_at=record.expires_at,
+            last_seen_at=record.last_seen_at,
+            last_seen_ip=record.last_seen_ip,
+            last_seen_user_agent=record.last_seen_user_agent,
+        )
+        for record in records
+    ]
+
+
+@router.delete(
+    "/api-keys/{api_key_id}",
+    summary="Revoke an API key",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to revoke API keys.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Administrator role required to revoke API keys.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "API key not found.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def revoke_api_key(
+    api_key_id: str,
+    _: UserDep,
+    service: AdminAuthServiceDep,
+) -> Response:
+    await service.revoke_api_key(api_key_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/sso/login",
+    status_code=status.HTTP_302_FOUND,
+    summary="Initiate the SSO login flow",
+    openapi_extra={"security": []},
+    responses={
+        status.HTTP_404_NOT_FOUND: {
+            "description": "SSO login is not configured for this deployment.",
+            "model": ErrorMessage,
+        }
+    },
+)
+async def start_sso_login(
+    request: Request,
+    service: AuthServiceDep,
+) -> RedirectResponse:
+    challenge = await service.prepare_sso_login()
+    redirect = RedirectResponse(challenge.redirect_url, status_code=status.HTTP_302_FOUND)
+    secure_cookie = service.is_secure_request(request)
+    redirect.set_cookie(
+        key=SSO_STATE_COOKIE,
+        value=challenge.state_token,
+        httponly=True,
+        secure=secure_cookie,
+        max_age=challenge.expires_in,
+        samesite="lax",
+        path="/auth/sso",
+    )
+    return redirect
+
+
+@router.get(
+    "/sso/callback",
+    response_model=SessionEnvelope,
+    status_code=status.HTTP_200_OK,
+    summary="Handle the SSO callback and establish a session",
+    openapi_extra={"security": []},
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Callback parameters invalid or identity provider response rejected.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "User account associated with the SSO identity is disabled.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_502_BAD_GATEWAY: {
+            "description": "ADE could not reach the identity provider during the SSO exchange.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def finish_sso_login(
+    request: Request,
+    response: Response,
+    service: AuthServiceDep,
+    code: str | None = None,
+    state: str | None = None,
+) -> SessionEnvelope:
+    if not code or not state:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Missing authorization code or state",
+        )
+
+    state_cookie = request.cookies.get(SSO_STATE_COOKIE)
+    if not state_cookie:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Missing SSO state cookie",
+        )
+
+    try:
+        user = await service.complete_sso_login(
+            code=code,
+            state=state,
+            state_token=state_cookie,
+        )
+    finally:
+        response.delete_cookie(SSO_STATE_COOKIE, path="/auth/sso")
+
+    tokens = await service.start_session(user=user)
+    secure_cookie = service.is_secure_request(request)
+    service.apply_session_cookies(response, tokens, secure=secure_cookie)
+    profile = UserProfile.model_validate(user)
+    return SessionEnvelope(
+        user=profile,
+        expires_at=tokens.access_expires_at,
+        refresh_expires_at=tokens.refresh_expires_at,
+    )
 
 
 __all__ = ["router"]

--- a/app/configurations/router.py
+++ b/app/configurations/router.py
@@ -1,13 +1,14 @@
 """FastAPI routes for configuration metadata."""
 
+from __future__ import annotations
+
+from typing import Annotated
+
 from fastapi import Body, Depends, HTTPException, Query, status
-from fastapi_utils.cbv import cbv
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.responses import DefaultResponse
-from app.core.db.session import get_session
 from ..auth.security import access_control
-from ..workspaces.dependencies import bind_workspace_context
+from ..workspaces.dependencies import require_workspace_context
 from ..workspaces.routing import workspace_scoped_router
 from ..workspaces.schemas import WorkspaceContext
 from .dependencies import get_configurations_service
@@ -20,153 +21,161 @@ router = workspace_scoped_router(tags=["configurations"])
 CONFIGURATION_CREATE_BODY = Body(...)
 CONFIGURATION_UPDATE_BODY = Body(...)
 
-
-@cbv(router)
-class ConfigurationsRoutes:
-    session: AsyncSession = Depends(get_session)
-    selection: WorkspaceContext = Depends(bind_workspace_context)
-    service: ConfigurationsService = Depends(get_configurations_service)
-
-    @router.get(
-        "/configurations",
-        response_model=list[ConfigurationRecord],
-        status_code=status.HTTP_200_OK,
-        summary="List configurations for the active workspace",
-        response_model_exclude_none=True,
-    )
-    @access_control(
-        permissions={"workspace:configurations:read"},
-        require_workspace=True,
-    )
-    async def list_configurations(
-        self,
-        document_type: str | None = Query(None),
-        is_active: bool | None = Query(None),
-    ) -> list[ConfigurationRecord]:
-        return await self.service.list_configurations(
-            document_type=document_type,
-            is_active=is_active,
+WorkspaceContextDep = Annotated[WorkspaceContext, Depends(require_workspace_context)]
+ConfigurationsReadServiceDep = Annotated[
+    ConfigurationsService,
+    Depends(
+        access_control(
+            permissions={"workspace:configurations:read"},
+            require_workspace=True,
+            service_dependency=get_configurations_service,
         )
+    ),
+]
+ConfigurationsWriteServiceDep = Annotated[
+    ConfigurationsService,
+    Depends(
+        access_control(
+            permissions={"workspace:configurations:write"},
+            require_workspace=True,
+            service_dependency=get_configurations_service,
+        )
+    ),
+]
 
-    @router.post(
-        "/configurations",
-        response_model=ConfigurationRecord,
-        status_code=status.HTTP_201_CREATED,
-        summary="Create a configuration",
-        response_model_exclude_none=True,
+
+@router.get(
+    "/configurations",
+    response_model=list[ConfigurationRecord],
+    status_code=status.HTTP_200_OK,
+    summary="List configurations for the active workspace",
+    response_model_exclude_none=True,
+)
+async def list_configurations(
+    _: WorkspaceContextDep,
+    service: ConfigurationsReadServiceDep,
+    *,
+    document_type: str | None = Query(None),
+    is_active: bool | None = Query(None),
+) -> list[ConfigurationRecord]:
+    return await service.list_configurations(
+        document_type=document_type,
+        is_active=is_active,
     )
-    @access_control(
-        permissions={"workspace:configurations:write"},
-        require_workspace=True,
+
+
+@router.post(
+    "/configurations",
+    response_model=ConfigurationRecord,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a configuration",
+    response_model_exclude_none=True,
+)
+async def create_configuration(
+    _: WorkspaceContextDep,
+    service: ConfigurationsWriteServiceDep,
+    *,
+    payload: ConfigurationCreate = CONFIGURATION_CREATE_BODY,
+) -> ConfigurationRecord:
+    return await service.create_configuration(
+        document_type=payload.document_type,
+        title=payload.title,
+        payload=payload.payload,
     )
-    async def create_configuration(
-        self, payload: ConfigurationCreate = CONFIGURATION_CREATE_BODY
-    ) -> ConfigurationRecord:
-        return await self.service.create_configuration(
-            document_type=payload.document_type,
+
+
+@router.get(
+    "/configurations/active",
+    response_model=list[ConfigurationRecord],
+    status_code=status.HTTP_200_OK,
+    summary="List active configurations",
+    response_model_exclude_none=True,
+)
+async def list_active_configurations(
+    _: WorkspaceContextDep,
+    service: ConfigurationsReadServiceDep,
+    *,
+    document_type: str | None = Query(None),
+) -> list[ConfigurationRecord]:
+    return await service.list_active_configurations(document_type=document_type)
+
+
+@router.get(
+    "/configurations/{configuration_id}",
+    response_model=ConfigurationRecord,
+    status_code=status.HTTP_200_OK,
+    summary="Retrieve a configuration by identifier",
+    response_model_exclude_none=True,
+)
+async def read_configuration(
+    configuration_id: str,
+    _: WorkspaceContextDep,
+    service: ConfigurationsReadServiceDep,
+) -> ConfigurationRecord:
+    try:
+        return await service.get_configuration(configuration_id=configuration_id)
+    except ConfigurationNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.put(
+    "/configurations/{configuration_id}",
+    response_model=ConfigurationRecord,
+    status_code=status.HTTP_200_OK,
+    summary="Replace a configuration",
+    response_model_exclude_none=True,
+)
+async def replace_configuration(
+    configuration_id: str,
+    _: WorkspaceContextDep,
+    service: ConfigurationsWriteServiceDep,
+    *,
+    payload: ConfigurationUpdate = CONFIGURATION_UPDATE_BODY,
+) -> ConfigurationRecord:
+    try:
+        return await service.update_configuration(
+            configuration_id=configuration_id,
             title=payload.title,
             payload=payload.payload,
         )
+    except ConfigurationNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
-    @router.get(
-        "/configurations/active",
-        response_model=list[ConfigurationRecord],
-        status_code=status.HTTP_200_OK,
-        summary="List active configurations",
-        response_model_exclude_none=True,
-    )
-    @access_control(
-        permissions={"workspace:configurations:read"},
-        require_workspace=True,
-    )
-    async def list_active_configurations(
-        self, document_type: str | None = Query(None)
-    ) -> list[ConfigurationRecord]:
-        return await self.service.list_active_configurations(
-            document_type=document_type
-        )
 
-    @router.get(
-        "/configurations/{configuration_id}",
-        response_model=ConfigurationRecord,
-        status_code=status.HTTP_200_OK,
-        summary="Retrieve a configuration by identifier",
-        response_model_exclude_none=True,
-    )
-    @access_control(
-        permissions={"workspace:configurations:read"},
-        require_workspace=True,
-    )
-    async def read_configuration(self, configuration_id: str) -> ConfigurationRecord:
-        try:
-            return await self.service.get_configuration(configuration_id=configuration_id)
-        except ConfigurationNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+@router.delete(
+    "/configurations/{configuration_id}",
+    response_model=DefaultResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Delete a configuration",
+)
+async def delete_configuration(
+    configuration_id: str,
+    _: WorkspaceContextDep,
+    service: ConfigurationsWriteServiceDep,
+) -> DefaultResponse:
+    try:
+        await service.delete_configuration(configuration_id=configuration_id)
+    except ConfigurationNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return DefaultResponse.success("Configuration deleted")
 
-    @router.put(
-        "/configurations/{configuration_id}",
-        response_model=ConfigurationRecord,
-        status_code=status.HTTP_200_OK,
-        summary="Replace a configuration",
-        response_model_exclude_none=True,
-    )
-    @access_control(
-        permissions={"workspace:configurations:write"},
-        require_workspace=True,
-    )
-    async def replace_configuration(
-        self,
-        configuration_id: str,
-        payload: ConfigurationUpdate = CONFIGURATION_UPDATE_BODY,
-    ) -> ConfigurationRecord:
-        try:
-            return await self.service.update_configuration(
-                configuration_id=configuration_id,
-                title=payload.title,
-                payload=payload.payload,
-            )
-        except ConfigurationNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
-    @router.delete(
-        "/configurations/{configuration_id}",
-        response_model=DefaultResponse,
-        status_code=status.HTTP_200_OK,
-        summary="Delete a configuration",
-    )
-    @access_control(
-        permissions={"workspace:configurations:write"},
-        require_workspace=True,
-    )
-    async def delete_configuration(
-        self, configuration_id: str
-    ) -> DefaultResponse:
-        try:
-            await self.service.delete_configuration(configuration_id=configuration_id)
-        except ConfigurationNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-        return DefaultResponse.success("Configuration deleted")
-
-    @router.post(
-        "/configurations/{configuration_id}/activate",
-        response_model=ConfigurationRecord,
-        status_code=status.HTTP_200_OK,
-        summary="Activate a configuration",
-        response_model_exclude_none=True,
-    )
-    @access_control(
-        permissions={"workspace:configurations:write"},
-        require_workspace=True,
-    )
-    async def activate_configuration(
-        self, configuration_id: str
-    ) -> ConfigurationRecord:
-        try:
-            return await self.service.activate_configuration(
-                configuration_id=configuration_id
-            )
-        except ConfigurationNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+@router.post(
+    "/configurations/{configuration_id}/activate",
+    response_model=ConfigurationRecord,
+    status_code=status.HTTP_200_OK,
+    summary="Activate a configuration",
+    response_model_exclude_none=True,
+)
+async def activate_configuration(
+    configuration_id: str,
+    _: WorkspaceContextDep,
+    service: ConfigurationsWriteServiceDep,
+) -> ConfigurationRecord:
+    try:
+        return await service.activate_configuration(configuration_id=configuration_id)
+    except ConfigurationNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
 
 __all__ = ["router"]

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
 from starlette.types import ASGIApp
 
 from .logging import bind_request_context, clear_request_context
@@ -29,7 +30,9 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
     def __init__(self, app: ASGIApp) -> None:
         super().__init__(app)
 
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
         correlation_id = request.headers.get("X-Request-ID", str(uuid4()))
         request.state.correlation_id = correlation_id
         bind_request_context(correlation_id)

--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -35,4 +35,10 @@ class BaseSchema(BaseModel):
         return self.model_dump_json(exclude_none=exclude_none, by_alias=by_alias).encode("utf-8")
 
 
-__all__ = ["BaseSchema"]
+class ErrorMessage(BaseSchema):
+    """Standard error envelope mirroring FastAPI's ``{"detail": ...}`` payload."""
+
+    detail: str
+
+
+__all__ = ["BaseSchema", "ErrorMessage"]

--- a/app/documents/models.py
+++ b/app/documents/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from sqlalchemy import JSON, Index, Integer, String
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column
@@ -41,7 +43,7 @@ class Document(ULIDPrimaryKeyMixin, TimestampMixin, Base):
     def document_id(self) -> str:
         """Expose a stable attribute for integrations expecting ``document_id``."""
 
-        return self.id
+        return cast(str, self.id)
 
 
 __all__ = ["Document"]

--- a/app/documents/router.py
+++ b/app/documents/router.py
@@ -1,7 +1,5 @@
-"""FastAPI routes for document upload and retrieval."""
-
 import json
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import (
     Body,
@@ -14,12 +12,10 @@ from fastapi import (
     status,
 )
 from fastapi.responses import StreamingResponse
-from fastapi_utils.cbv import cbv
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db.session import get_session
+from app.core.schema import ErrorMessage
 from ..auth.security import access_control
-from ..workspaces.dependencies import bind_workspace_context
+from ..workspaces.dependencies import require_workspace_context
 from ..workspaces.routing import workspace_scoped_router
 from ..workspaces.schemas import WorkspaceContext
 from .dependencies import get_documents_service
@@ -33,6 +29,28 @@ from .schemas import DocumentDeleteRequest, DocumentRecord
 from .service import DocumentsService
 
 router = workspace_scoped_router(tags=["documents"])
+
+WorkspaceContextDep = Annotated[WorkspaceContext, Depends(require_workspace_context)]
+DocumentsReadServiceDep = Annotated[
+    DocumentsService,
+    Depends(
+        access_control(
+            permissions={"workspace:documents:read"},
+            require_workspace=True,
+            service_dependency=get_documents_service,
+        )
+    ),
+]
+DocumentsWriteServiceDep = Annotated[
+    DocumentsService,
+    Depends(
+        access_control(
+            permissions={"workspace:documents:write"},
+            require_workspace=True,
+            service_dependency=get_documents_service,
+        )
+    ),
+]
 
 
 def _parse_metadata(metadata: str | None) -> dict[str, Any]:
@@ -53,108 +71,181 @@ def _parse_metadata(metadata: str | None) -> dict[str, Any]:
     return decoded
 
 
-@cbv(router)
-class DocumentsRoutes:
-    session: AsyncSession = Depends(get_session)  # noqa: B008
-    selection: WorkspaceContext = Depends(bind_workspace_context)  # noqa: B008
-    service: DocumentsService = Depends(get_documents_service)  # noqa: B008
+@router.post(
+    "/documents",
+    response_model=DocumentRecord,
+    status_code=status.HTTP_201_CREATED,
+    summary="Upload a document",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Metadata payload or expiration timestamp is invalid.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to upload documents.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow document uploads.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE: {
+            "description": "Uploaded file exceeds the configured size limit.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def upload_document(
+    _: WorkspaceContextDep,
+    service: DocumentsWriteServiceDep,
+    *,
+    file: UploadFile = File(...),
+    metadata: str | None = Form(None),
+    expires_at: str | None = Form(None),
+) -> DocumentRecord:
+    payload = _parse_metadata(metadata)
+    try:
+        return await service.create_document(
+            upload=file,
+            metadata=payload,
+            expires_at=expires_at,
+        )
+    except DocumentTooLargeError as exc:
+        raise HTTPException(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=str(exc)) from exc
+    except InvalidDocumentExpirationError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    @router.post(
-        "/documents",
-        response_model=DocumentRecord,
-        status_code=status.HTTP_201_CREATED,
-        summary="Upload a document",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:documents:write"}, require_workspace=True)
-    async def upload_document(
-        self,
-        file: UploadFile = File(...),  # noqa: B008
-        metadata: str | None = Form(None),  # noqa: B008
-        expires_at: str | None = Form(None),  # noqa: B008
-    ) -> DocumentRecord:
-        payload = _parse_metadata(metadata)
-        try:
-            return await self.service.create_document(
-                upload=file,
-                metadata=payload,
-                expires_at=expires_at,
-            )
-        except DocumentTooLargeError as exc:
-            raise HTTPException(
-                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=str(exc)
-            ) from exc
-        except InvalidDocumentExpirationError as exc:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    @router.get(
-        "/documents",
-        response_model=list[DocumentRecord],
-        status_code=status.HTTP_200_OK,
-        summary="List documents",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:documents:read"}, require_workspace=True)
-    async def list_documents(
-        self,
-        limit: int = Query(50, ge=1, le=200),  # noqa: B008
-        offset: int = Query(0, ge=0),  # noqa: B008
-    ) -> list[DocumentRecord]:
-        return await self.service.list_documents(limit=limit, offset=offset)
+@router.get(
+    "/documents",
+    response_model=list[DocumentRecord],
+    status_code=status.HTTP_200_OK,
+    summary="List documents",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to list documents.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow document access.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def list_documents(
+    _: WorkspaceContextDep,
+    service: DocumentsReadServiceDep,
+    *,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> list[DocumentRecord]:
+    return await service.list_documents(limit=limit, offset=offset)
 
-    @router.get(
-        "/documents/{document_id}",
-        response_model=DocumentRecord,
-        status_code=status.HTTP_200_OK,
-        summary="Retrieve document metadata",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:documents:read"}, require_workspace=True)
-    async def read_document(self, document_id: str) -> DocumentRecord:
-        try:
-            return await self.service.get_document(document_id)
-        except DocumentNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
-    @router.get(
-        "/documents/{document_id}/download",
-        summary="Download a stored document",
-    )
-    @access_control(permissions={"workspace:documents:read"}, require_workspace=True)
-    async def download_document(self, document_id: str) -> StreamingResponse:
-        try:
-            record, stream = await self.service.stream_document(document_id)
-        except DocumentNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-        except DocumentFileMissingError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+@router.get(
+    "/documents/{document_id}",
+    response_model=DocumentRecord,
+    status_code=status.HTTP_200_OK,
+    summary="Retrieve document metadata",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to access documents.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow document access.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Document not found within the workspace.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def read_document(
+    document_id: str,
+    _: WorkspaceContextDep,
+    service: DocumentsReadServiceDep,
+) -> DocumentRecord:
+    try:
+        return await service.get_document(document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
-        media_type = record.content_type or "application/octet-stream"
-        filename = record.original_filename.replace('"', "")
-        response = StreamingResponse(stream, media_type=media_type)
-        response.headers[
-            "Content-Disposition"
-        ] = f'attachment; filename="{filename}"'
-        return response
 
-    @router.delete(
-        "/documents/{document_id}",
-        status_code=status.HTTP_204_NO_CONTENT,
-        summary="Soft delete a document",
-    )
-    @access_control(permissions={"workspace:documents:write"}, require_workspace=True)
-    async def delete_document(
-        self,
-        document_id: str,
-        payload: DocumentDeleteRequest | None = Body(default=None),  # noqa: B008
-    ) -> None:
-        try:
-            await self.service.delete_document(
-                document_id=document_id,
-                reason=payload.reason if payload else None,
-            )
-        except DocumentNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+@router.get(
+    "/documents/{document_id}/download",
+    summary="Download a stored document",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to download documents.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow document downloads.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Document is missing or its stored file is unavailable.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def download_document(
+    document_id: str,
+    _: WorkspaceContextDep,
+    service: DocumentsReadServiceDep,
+) -> StreamingResponse:
+    try:
+        record, stream = await service.stream_document(document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except DocumentFileMissingError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    media_type = record.content_type or "application/octet-stream"
+    filename = record.original_filename.replace('"', "")
+    response = StreamingResponse(stream, media_type=media_type)
+    response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
+
+
+@router.delete(
+    "/documents/{document_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Soft delete a document",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to delete documents.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow document deletion.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Document not found within the workspace.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def delete_document(
+    document_id: str,
+    _: WorkspaceContextDep,
+    service: DocumentsWriteServiceDep,
+    *,
+    payload: DocumentDeleteRequest | None = Body(default=None),
+) -> None:
+    try:
+        await service.delete_document(
+            document_id=document_id,
+            reason=payload.reason if payload else None,
+        )
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
 
 __all__ = ["router"]

--- a/app/jobs/processor.py
+++ b/app/jobs/processor.py
@@ -1,0 +1,88 @@
+"""Typed request/response contracts for job processor integrations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(slots=True)
+class JobProcessorRequest:
+    """Input payload provided to a document extraction processor."""
+
+    job_id: str
+    document_path: Path
+    configuration: Mapping[str, Any]
+    metadata: Mapping[str, Any]
+
+
+@dataclass(slots=True)
+class JobProcessorResult:
+    """Structured response returned by a document extraction processor."""
+
+    status: str
+    tables: list[dict[str, Any]] = field(default_factory=list)
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+    logs: list[dict[str, Any]] = field(default_factory=list)
+
+
+ProcessorCallable = Callable[[JobProcessorRequest], JobProcessorResult]
+
+
+class ProcessorError(RuntimeError):
+    """Raised by processors to indicate business-level failures."""
+
+
+def _stub_processor(request: JobProcessorRequest) -> JobProcessorResult:
+    """Return deterministic tables and metrics for extractor simulations."""
+
+    configuration = dict(request.configuration or {})
+    if configuration.get("simulate_failure"):
+        message = str(configuration.get("failure_message", "Stub processor failure"))
+        raise ProcessorError(message)
+
+    tables = [dict(table) for table in configuration.get("tables", [])]
+    metrics = dict(configuration.get("metrics", {}))
+    if "tables_produced" not in metrics:
+        metrics["tables_produced"] = len(tables)
+    if "rows_processed" not in metrics:
+        metrics["rows_processed"] = sum(len(table.get("rows", [])) for table in tables)
+    logs = [dict(entry) for entry in configuration.get("logs", [])]
+    timestamp = datetime.now(tz=UTC).isoformat(timespec="seconds")
+    logs.insert(0, {"ts": timestamp, "level": "info", "message": "Processor started"})
+    logs.append({"ts": timestamp, "level": "info", "message": "Processor completed"})
+    status = str(configuration.get("status", "succeeded"))
+
+    return JobProcessorResult(status=status, tables=tables, metrics=metrics, logs=logs)
+
+
+_current_processor: ProcessorCallable = _stub_processor
+
+
+def get_job_processor() -> ProcessorCallable:
+    """Return the callable responsible for executing jobs."""
+
+    return _current_processor
+
+
+def set_job_processor(processor: ProcessorCallable | None) -> None:
+    """Override the job processor callable, resetting to the stub when None."""
+
+    global _current_processor
+    if processor is None:
+        _current_processor = _stub_processor
+    else:
+        _current_processor = processor
+
+
+__all__ = [
+    "JobProcessorRequest",
+    "JobProcessorResult",
+    "ProcessorCallable",
+    "ProcessorError",
+    "get_job_processor",
+    "set_job_processor",
+]

--- a/app/jobs/router.py
+++ b/app/jobs/router.py
@@ -1,16 +1,16 @@
-"""FastAPI routes for job submission and tracking."""
+from __future__ import annotations
 
-from fastapi import Body, Depends, HTTPException, Query, Request, status
-from fastapi_utils.cbv import cbv
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Annotated
 
-from app.core.db.session import get_session
+from fastapi import Body, Depends, HTTPException, Query, status
+
+from app.core.schema import ErrorMessage
 from ..auth.security import access_control
 from ..configurations.exceptions import (
     ConfigurationNotFoundError,
     ConfigurationVersionMismatchError,
 )
-from ..workspaces.dependencies import bind_workspace_context
+from ..workspaces.dependencies import require_workspace_context
 from ..workspaces.routing import workspace_scoped_router
 from ..workspaces.schemas import WorkspaceContext
 from .dependencies import get_jobs_service
@@ -19,93 +19,163 @@ from .exceptions import (
     JobExecutionError,
     JobNotFoundError,
 )
-from .schemas import JobRecord, JobSubmissionRequest
+from .schemas import JobFailureMessage, JobRecord, JobSubmissionRequest
 from .service import JobsService
 
 JOB_SUBMISSION_BODY = Body(...)
 
 router = workspace_scoped_router(tags=["jobs"])
 
+WorkspaceContextDep = Annotated[WorkspaceContext, Depends(require_workspace_context)]
+JobsReadServiceDep = Annotated[
+    JobsService,
+    Depends(
+        access_control(
+            permissions={"workspace:jobs:read"},
+            require_workspace=True,
+            service_dependency=get_jobs_service,
+        )
+    ),
+]
+JobsWriteServiceDep = Annotated[
+    JobsService,
+    Depends(
+        access_control(
+            permissions={"workspace:jobs:write"},
+            require_workspace=True,
+            service_dependency=get_jobs_service,
+        )
+    ),
+]
 
-@cbv(router)
-class JobsRoutes:
-    request: Request
-    session: AsyncSession = Depends(get_session)  # noqa: B008
-    selection: WorkspaceContext = Depends(bind_workspace_context)  # noqa: B008
-    service: JobsService = Depends(get_jobs_service)  # noqa: B008
 
-    @router.get(
-        "/jobs",
-        response_model=list[JobRecord],
-        status_code=status.HTTP_200_OK,
-        summary="List jobs",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:jobs:read"}, require_workspace=True)
-    async def list_jobs(
-        self,
-        limit: int = Query(50, ge=1, le=200),  # noqa: B008
-        offset: int = Query(0, ge=0),  # noqa: B008
-        status_filter: str | None = Query(None, alias="status"),  # noqa: B008
-        input_document_id: str | None = Query(None),  # noqa: B008
-    ) -> list[JobRecord]:
-        try:
-            return await self.service.list_jobs(
-                limit=limit,
-                offset=offset,
-                status=status_filter,
-                input_document_id=input_document_id,
-            )
-        except ValueError as exc:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+@router.get(
+    "/jobs",
+    response_model=list[JobRecord],
+    status_code=status.HTTP_200_OK,
+    summary="List jobs",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Query parameters are invalid or unsupported.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to list jobs.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow job access.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def list_jobs(
+    _: WorkspaceContextDep,
+    service: JobsReadServiceDep,
+    *,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    status_filter: str | None = Query(None, alias="status"),
+    input_document_id: str | None = Query(None),
+) -> list[JobRecord]:
+    try:
+        return await service.list_jobs(
+            limit=limit,
+            offset=offset,
+            status=status_filter,
+            input_document_id=input_document_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    @router.get(
-        "/jobs/{job_id}",
-        response_model=JobRecord,
-        status_code=status.HTTP_200_OK,
-        summary="Retrieve a job",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:jobs:read"}, require_workspace=True)
-    async def read_job(self, job_id: str) -> JobRecord:
-        try:
-            return await self.service.get_job(job_id)
-        except JobNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
-    @router.post(
-        "/jobs",
-        response_model=JobRecord,
-        status_code=status.HTTP_201_CREATED,
-        summary="Submit a job",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:jobs:write"}, require_workspace=True)
-    async def submit_job(
-        self,
-        payload: JobSubmissionRequest = JOB_SUBMISSION_BODY,
-    ) -> JobRecord:
-        try:
-            return await self.service.submit_job(
-                input_document_id=payload.input_document_id,
-                configuration_id=payload.configuration_id,
-                configuration_version=payload.configuration_version,
-            )
-        except InputDocumentNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-        except ConfigurationNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-        except ConfigurationVersionMismatchError as exc:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-        except JobExecutionError as exc:
-            detail = {
-                "error": "job_failed",
-                "job_id": exc.job_id,
-                "message": str(exc),
-            }
-            raise HTTPException(
-                status.HTTP_500_INTERNAL_SERVER_ERROR, detail=detail
-            ) from exc
+@router.get(
+    "/jobs/{job_id}",
+    response_model=JobRecord,
+    status_code=status.HTTP_200_OK,
+    summary="Retrieve a job",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to read jobs.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow job access.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Job not found within the workspace.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def read_job(
+    job_id: str,
+    _: WorkspaceContextDep,
+    service: JobsReadServiceDep,
+) -> JobRecord:
+    try:
+        return await service.get_job(job_id)
+    except JobNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.post(
+    "/jobs",
+    response_model=JobRecord,
+    status_code=status.HTTP_201_CREATED,
+    summary="Submit a job",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Configuration mismatch or invalid job parameters.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to submit jobs.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow job submission.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Input document or configuration could not be found.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "description": "Job failed during execution.",
+            "model": JobFailureMessage,
+        },
+    },
+)
+async def submit_job(
+    _: WorkspaceContextDep,
+    service: JobsWriteServiceDep,
+    *,
+    payload: JobSubmissionRequest = JOB_SUBMISSION_BODY,
+) -> JobRecord:
+    try:
+        return await service.submit_job(
+            input_document_id=payload.input_document_id,
+            configuration_id=payload.configuration_id,
+            configuration_version=payload.configuration_version,
+        )
+    except InputDocumentNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ConfigurationNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ConfigurationVersionMismatchError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except JobExecutionError as exc:
+        detail = {
+            "error": "job_failed",
+            "job_id": exc.job_id,
+            "message": str(exc),
+        }
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail=detail) from exc
 
 
 __all__ = ["router"]

--- a/app/jobs/schemas.py
+++ b/app/jobs/schemas.py
@@ -9,6 +9,20 @@ from pydantic import Field
 from app.core.schema import BaseSchema
 
 
+class JobFailureDetail(BaseSchema):
+    """Structured payload returned when a job execution fails."""
+
+    error: str
+    job_id: str
+    message: str
+
+
+class JobFailureMessage(BaseSchema):
+    """Error envelope that wraps :class:`JobFailureDetail`."""
+
+    detail: JobFailureDetail
+
+
 class JobSubmissionRequest(BaseSchema):
     """Payload accepted when clients submit a new job."""
 
@@ -33,4 +47,9 @@ class JobRecord(BaseSchema):
     logs: list[dict[str, Any]] = Field(default_factory=list)
 
 
-__all__ = ["JobRecord", "JobSubmissionRequest"]
+__all__ = [
+    "JobFailureDetail",
+    "JobFailureMessage",
+    "JobRecord",
+    "JobSubmissionRequest",
+]

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ import subprocess
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Mapping
+from collections.abc import AsyncIterator
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
@@ -49,7 +50,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     task_queue = TaskQueue()
 
     @asynccontextmanager
-    async def lifespan(app: FastAPI):
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.settings = settings
         app.state.message_hub = message_hub
         app.state.task_queue = task_queue
@@ -70,6 +71,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         debug=settings.debug,
         lifespan=lifespan,
     )
+
+    app.state.settings = settings
+    app.state.message_hub = message_hub
+    app.state.task_queue = task_queue
 
     register_middleware(app)
     _mount_static(app)

--- a/app/results/router.py
+++ b/app/results/router.py
@@ -1,93 +1,167 @@
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, status
-from fastapi_utils.cbv import cbv
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Annotated
 
-from app.core.db.session import get_session
+from fastapi import Depends, HTTPException, status
+
+from app.core.schema import ErrorMessage
 from ..auth.security import access_control
 from ..documents.exceptions import DocumentNotFoundError
 from ..jobs.exceptions import JobNotFoundError
-from ..workspaces.dependencies import bind_workspace_context
+from ..workspaces.dependencies import require_workspace_context
 from ..workspaces.routing import workspace_scoped_router
 from ..workspaces.schemas import WorkspaceContext
 from .dependencies import get_results_service
 from .exceptions import ExtractedTableNotFoundError, JobResultsUnavailableError
-from .schemas import ExtractedTableRecord
+from .schemas import ExtractedTableRecord, JobResultsUnavailableMessage
 from .service import ExtractionResultsService
 
 router = workspace_scoped_router(tags=["results"])
 
+WorkspaceContextDep = Annotated[WorkspaceContext, Depends(require_workspace_context)]
+JobResultsServiceDep = Annotated[
+    ExtractionResultsService,
+    Depends(
+        access_control(
+            permissions={"workspace:jobs:read"},
+            require_workspace=True,
+            service_dependency=get_results_service,
+        )
+    ),
+]
+DocumentResultsServiceDep = Annotated[
+    ExtractionResultsService,
+    Depends(
+        access_control(
+            permissions={"workspace:documents:read"},
+            require_workspace=True,
+            service_dependency=get_results_service,
+        )
+    ),
+]
 
-@cbv(router)
-class ExtractionResultsRoutes:
-    session: AsyncSession = Depends(get_session)
-    selection: WorkspaceContext = Depends(bind_workspace_context)
-    service: ExtractionResultsService = Depends(get_results_service)
 
-    @router.get(
-        "/jobs/{job_id}/tables",
-        response_model=list[ExtractedTableRecord],
-        status_code=status.HTTP_200_OK,
-        summary="List extracted tables for a job",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:jobs:read"}, require_workspace=True)
-    async def list_job_tables(self, job_id: str) -> list[ExtractedTableRecord]:
-        try:
-            return await self.service.list_tables_for_job(job_id=job_id)
-        except JobNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-        except JobResultsUnavailableError as exc:
-            detail = {
-                "error": "job_results_unavailable",
-                "job_id": exc.job_id,
-                "status": exc.status,
-                "message": str(exc),
-            }
-            raise HTTPException(status.HTTP_409_CONFLICT, detail=detail) from exc
+@router.get(
+    "/jobs/{job_id}/tables",
+    response_model=list[ExtractedTableRecord],
+    status_code=status.HTTP_200_OK,
+    summary="List extracted tables for a job",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to read job results.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow access to this job's results.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Job not found within the workspace.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "Job has not produced results yet or is still running.",
+            "model": JobResultsUnavailableMessage,
+        },
+    },
+)
+async def list_job_tables(
+    job_id: str,
+    _: WorkspaceContextDep,
+    service: JobResultsServiceDep,
+) -> list[ExtractedTableRecord]:
+    try:
+        return await service.list_tables_for_job(job_id=job_id)
+    except JobNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except JobResultsUnavailableError as exc:
+        detail = {
+            "error": "job_results_unavailable",
+            "job_id": exc.job_id,
+            "status": exc.status,
+            "message": str(exc),
+        }
+        raise HTTPException(status.HTTP_409_CONFLICT, detail=detail) from exc
 
-    @router.get(
-        "/jobs/{job_id}/tables/{table_id}",
-        response_model=ExtractedTableRecord,
-        status_code=status.HTTP_200_OK,
-        summary="Retrieve an extracted table for a job",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:jobs:read"}, require_workspace=True)
-    async def read_job_table(
-        self, job_id: str, table_id: str
-    ) -> ExtractedTableRecord:
-        try:
-            return await self.service.get_table(job_id=job_id, table_id=table_id)
-        except JobNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-        except JobResultsUnavailableError as exc:
-            detail = {
-                "error": "job_results_unavailable",
-                "job_id": exc.job_id,
-                "status": exc.status,
-                "message": str(exc),
-            }
-            raise HTTPException(status.HTTP_409_CONFLICT, detail=detail) from exc
-        except ExtractedTableNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
-    @router.get(
-        "/documents/{document_id}/tables",
-        response_model=list[ExtractedTableRecord],
-        status_code=status.HTTP_200_OK,
-        summary="List extracted tables for a document",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:documents:read"}, require_workspace=True)
-    async def list_document_tables(
-        self, document_id: str
-    ) -> list[ExtractedTableRecord]:
-        try:
-            return await self.service.list_tables_for_document(document_id=document_id)
-        except DocumentNotFoundError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+@router.get(
+    "/jobs/{job_id}/tables/{table_id}",
+    response_model=ExtractedTableRecord,
+    status_code=status.HTTP_200_OK,
+    summary="Retrieve an extracted table for a job",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to read job results.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow access to this job's results.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Job or table not found within the workspace.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "Job has not produced results yet or is still running.",
+            "model": JobResultsUnavailableMessage,
+        },
+    },
+)
+async def read_job_table(
+    job_id: str,
+    table_id: str,
+    _: WorkspaceContextDep,
+    service: JobResultsServiceDep,
+) -> ExtractedTableRecord:
+    try:
+        return await service.get_table(job_id=job_id, table_id=table_id)
+    except JobNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except JobResultsUnavailableError as exc:
+        detail = {
+            "error": "job_results_unavailable",
+            "job_id": exc.job_id,
+            "status": exc.status,
+            "message": str(exc),
+        }
+        raise HTTPException(status.HTTP_409_CONFLICT, detail=detail) from exc
+    except ExtractedTableNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.get(
+    "/documents/{document_id}/tables",
+    response_model=list[ExtractedTableRecord],
+    status_code=status.HTTP_200_OK,
+    summary="List extracted tables for a document",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to read document results.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow access to document results.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Document not found within the workspace.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def list_document_tables(
+    document_id: str,
+    _: WorkspaceContextDep,
+    service: DocumentResultsServiceDep,
+) -> list[ExtractedTableRecord]:
+    try:
+        return await service.list_tables_for_document(document_id=document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
 
 __all__ = ["router"]

--- a/app/results/schemas.py
+++ b/app/results/schemas.py
@@ -7,6 +7,21 @@ from pydantic import Field
 from app.core.schema import BaseSchema
 
 
+class JobResultsUnavailableDetail(BaseSchema):
+    """Structured payload when job results are not yet accessible."""
+
+    error: str
+    job_id: str
+    status: str
+    message: str
+
+
+class JobResultsUnavailableMessage(BaseSchema):
+    """Error envelope for :class:`JobResultsUnavailableDetail`."""
+
+    detail: JobResultsUnavailableDetail
+
+
 class ExtractedTableRecord(BaseSchema):
     """Serialised representation of an extracted table."""
 
@@ -27,4 +42,8 @@ class ExtractedTableRecord(BaseSchema):
     updated_at: str
 
 
-__all__ = ["ExtractedTableRecord"]
+__all__ = [
+    "ExtractedTableRecord",
+    "JobResultsUnavailableDetail",
+    "JobResultsUnavailableMessage",
+]

--- a/app/users/router.py
+++ b/app/users/router.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, status
-from fastapi_utils.cbv import cbv
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Annotated
 
-from app.core.db.session import get_session
+from fastapi import APIRouter, Depends, status
+
 from ..auth.dependencies import bind_current_user
 from ..auth.security import access_control
 from .dependencies import get_users_service
@@ -16,34 +15,41 @@ from .service import UsersService
 
 router = APIRouter(tags=["users"])
 
+UserDep = Annotated[User, Depends(bind_current_user)]
+UsersServiceDep = Annotated[UsersService, Depends(get_users_service)]
+AdminUsersServiceDep = Annotated[
+    UsersService,
+    Depends(access_control(require_admin=True, service_dependency=get_users_service)),
+]
 
-@cbv(router)
-class UsersRoutes:
-    current_user: User = Depends(bind_current_user)
-    session: AsyncSession = Depends(get_session)
-    service: UsersService = Depends(get_users_service)
 
-    @router.get(
-        "/users/me",
-        response_model=UserProfile,
-        status_code=status.HTTP_200_OK,
-        response_model_exclude_none=True,
-        summary="Return the authenticated user profile",
-    )
-    async def read_me(self) -> UserProfile:
-        profile = await self.service.get_profile()
-        return profile
+@router.get(
+    "/users/me",
+    response_model=UserProfile,
+    status_code=status.HTTP_200_OK,
+    response_model_exclude_none=True,
+    summary="Return the authenticated user profile",
+)
+async def read_me(
+    _: UserDep,
+    service: UsersServiceDep,
+) -> UserProfile:
+    profile = await service.get_profile()
+    return profile
 
-    @router.get(
-        "/users",
-        response_model=list[UserSummary],
-        status_code=status.HTTP_200_OK,
-        summary="List all users (administrator only)",
-    )
-    @access_control(require_admin=True)
-    async def list_users(self) -> list[UserSummary]:
-        users = await self.service.list_users()
-        return users
+
+@router.get(
+    "/users",
+    response_model=list[UserSummary],
+    status_code=status.HTTP_200_OK,
+    summary="List all users (administrator only)",
+)
+async def list_users(
+    _: UserDep,
+    service: AdminUsersServiceDep,
+) -> list[UserSummary]:
+    users = await service.list_users()
+    return users
 
 
 __all__ = ["router"]

--- a/app/workspaces/repository.py
+++ b/app/workspaces/repository.py
@@ -51,6 +51,25 @@ class WorkspacesRepository:
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_membership_for_workspace(
+        self, *, membership_id: str, workspace_id: str
+    ) -> WorkspaceMembership | None:
+        stmt = (
+            select(WorkspaceMembership)
+            .options(
+                selectinload(WorkspaceMembership.workspace),
+                selectinload(WorkspaceMembership.user),
+            )
+            .where(
+                and_(
+                    WorkspaceMembership.id == membership_id,
+                    WorkspaceMembership.workspace_id == workspace_id,
+                )
+            )
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
     async def get_default_membership(self, *, user_id: str) -> WorkspaceMembership | None:
         stmt = (
             select(WorkspaceMembership)

--- a/app/workspaces/router.py
+++ b/app/workspaces/router.py
@@ -1,15 +1,15 @@
-"""Routes for workspace membership and context resolution."""
+from __future__ import annotations
+
+from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, Path, status
-from fastapi_utils.cbv import cbv
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.responses import DefaultResponse
-from app.core.db.session import get_session
+from app.core.schema import ErrorMessage
 from ..auth.dependencies import bind_current_user
 from ..auth.security import access_control
 from ..users.models import User
-from .dependencies import bind_workspace_context, get_workspaces_service
+from .dependencies import get_workspaces_service, require_workspace_context
 from .schemas import (
     WorkspaceContext,
     WorkspaceCreate,
@@ -29,189 +29,379 @@ WORKSPACE_CREATE_BODY = Body(...)
 WORKSPACE_UPDATE_BODY = Body(...)
 WORKSPACE_MEMBER_UPDATE_BODY = Body(...)
 
-
-@cbv(router)
-class WorkspaceRoutes:
-    current_user: User = Depends(bind_current_user)  # noqa: B008
-    session: AsyncSession = Depends(get_session)  # noqa: B008
-    service: WorkspacesService = Depends(get_workspaces_service)  # noqa: B008
-
-    @router.post(
-        "/workspaces",
-        response_model=WorkspaceProfile,
-        status_code=status.HTTP_201_CREATED,
-        summary="Create a new workspace",
-        response_model_exclude_none=True,
-    )
-    @access_control(require_admin=True)
-    async def create_workspace(
-        self, payload: WorkspaceCreate = WORKSPACE_CREATE_BODY
-    ) -> WorkspaceProfile:
-        workspace = await self.service.create_workspace(
-            user=self.current_user,
-            name=payload.name,
-            slug=payload.slug,
-            owner_user_id=payload.owner_user_id,
-            settings=payload.settings,
+UserDep = Annotated[User, Depends(bind_current_user)]
+WorkspaceContextDep = Annotated[WorkspaceContext, Depends(require_workspace_context)]
+WorkspaceServiceDep = Annotated[WorkspacesService, Depends(get_workspaces_service)]
+AdminWorkspaceServiceDep = Annotated[
+    WorkspacesService,
+    Depends(access_control(require_admin=True, service_dependency=get_workspaces_service)),
+]
+WorkspaceMembersReadServiceDep = Annotated[
+    WorkspacesService,
+    Depends(
+        access_control(
+            permissions={"workspace:members:read"},
+            require_workspace=True,
+            service_dependency=get_workspaces_service,
         )
-        return workspace
-
-    @router.get(
-        "/workspaces",
-        response_model=list[WorkspaceProfile],
-        status_code=status.HTTP_200_OK,
-        summary="List workspaces for the authenticated user",
-    )
-    async def list_workspaces(self) -> list[WorkspaceProfile]:
-        memberships = await self.service.list_memberships(user=self.current_user)
-        return memberships
-
-    @router.get(
-        "/workspaces/{workspace_id}",
-        response_model=WorkspaceContext,
-        status_code=status.HTTP_200_OK,
-        summary="Retrieve workspace context by identifier",
-        response_model_exclude_none=True,
-    )
-    async def read_workspace(
-        self,
-        selection: WorkspaceContext = Depends(bind_workspace_context),  # noqa: B008
-    ) -> WorkspaceContext:
-        return selection
-
-    @router.get(
-        "/workspaces/{workspace_id}/members",
-        response_model=list[WorkspaceMember],
-        status_code=status.HTTP_200_OK,
-        summary="List members within the workspace",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:members:read"}, require_workspace=True)
-    async def list_members(
-        self,
-        workspace_id: str,
-        _: WorkspaceContext = Depends(bind_workspace_context),  # noqa: B008
-    ) -> list[WorkspaceMember]:
-        memberships = await self.service.list_members(workspace_id=workspace_id)
-        return memberships
-
-    @router.post(
-        "/workspaces/{workspace_id}/members",
-        response_model=WorkspaceMember,
-        status_code=status.HTTP_201_CREATED,
-        summary="Add a member to a workspace",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:members:manage"}, require_workspace=True)
-    async def add_member(
-        self,
-        workspace_id: str,
-        payload: WorkspaceMemberCreate = WORKSPACE_MEMBER_BODY,
-        _: WorkspaceContext = Depends(bind_workspace_context),  # noqa: B008
-    ) -> WorkspaceMember:
-        membership = await self.service.add_member(
-            workspace_id=workspace_id,
-            user_id=payload.user_id,
-            role=payload.role,
+    ),
+]
+WorkspaceMembersManageServiceDep = Annotated[
+    WorkspacesService,
+    Depends(
+        access_control(
+            permissions={"workspace:members:manage"},
+            require_workspace=True,
+            service_dependency=get_workspaces_service,
         )
-        return membership
-
-    @router.patch(
-        "/workspaces/{workspace_id}",
-        response_model=WorkspaceProfile,
-        status_code=status.HTTP_200_OK,
-        summary="Update workspace metadata",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:settings:manage"}, require_workspace=True)
-    async def update_workspace(
-        self,
-        workspace_id: str,
-        payload: WorkspaceUpdate = WORKSPACE_UPDATE_BODY,
-        _: WorkspaceContext = Depends(bind_workspace_context),  # noqa: B008
-    ) -> WorkspaceProfile:
-        workspace = await self.service.update_workspace(
-            user=self.current_user,
-            workspace_id=workspace_id,
-            name=payload.name,
-            slug=payload.slug,
-            settings=payload.settings,
+    ),
+]
+WorkspaceSettingsServiceDep = Annotated[
+    WorkspacesService,
+    Depends(
+        access_control(
+            permissions={"workspace:settings:manage"},
+            require_workspace=True,
+            service_dependency=get_workspaces_service,
         )
-        return workspace
-
-    @router.delete(
-        "/workspaces/{workspace_id}",
-        response_model=DefaultResponse,
-        status_code=status.HTTP_200_OK,
-        summary="Delete a workspace",
-    )
-    @access_control(permissions={"workspace:settings:manage"}, require_workspace=True)
-    async def delete_workspace(
-        self,
-        workspace_id: str,
-        _: WorkspaceContext = Depends(bind_workspace_context),  # noqa: B008
-    ) -> DefaultResponse:
-        await self.service.delete_workspace(workspace_id=workspace_id)
-        return DefaultResponse.success("Workspace deleted")
-
-    @router.patch(
-        "/workspaces/{workspace_id}/members/{membership_id}",
-        response_model=WorkspaceMember,
-        status_code=status.HTTP_200_OK,
-        summary="Update a workspace member",
-        response_model_exclude_none=True,
-    )
-    @access_control(permissions={"workspace:members:manage"}, require_workspace=True)
-    async def update_member(
-        self,
-        workspace_id: str,
-        membership_id: str = Path(..., min_length=1, description="Membership identifier"),
-        payload: WorkspaceMemberUpdate = WORKSPACE_MEMBER_UPDATE_BODY,
-        _: WorkspaceContext = Depends(bind_workspace_context),  # noqa: B008
-    ) -> WorkspaceMember:
-        membership = await self.service.update_member_role(
-            workspace_id=workspace_id,
-            membership_id=membership_id,
-            role=payload.role,
+    ),
+]
+WorkspaceScopedServiceDep = Annotated[
+    WorkspacesService,
+    Depends(
+        access_control(
+            require_workspace=True,
+            service_dependency=get_workspaces_service,
         )
-        return membership
+    ),
+]
 
-    @router.delete(
-        "/workspaces/{workspace_id}/members/{membership_id}",
-        response_model=DefaultResponse,
-        status_code=status.HTTP_200_OK,
-        summary="Remove a workspace member",
-    )
-    @access_control(permissions={"workspace:members:manage"}, require_workspace=True)
-    async def remove_member(
-        self,
-        workspace_id: str,
-        membership_id: str = Path(..., min_length=1, description="Membership identifier"),
-        _: WorkspaceContext = Depends(bind_workspace_context),  # noqa: B008
-    ) -> DefaultResponse:
-        await self.service.remove_member(
-            workspace_id=workspace_id,
-            membership_id=membership_id,
-        )
-        return DefaultResponse.success("Workspace member removed")
 
-    @router.post(
-        "/workspaces/{workspace_id}/default",
-        response_model=WorkspaceDefaultSelection,
-        status_code=status.HTTP_200_OK,
-        summary="Mark a workspace as the caller's default",
+@router.post(
+    "/workspaces",
+    response_model=WorkspaceProfile,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new workspace",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to manage workspaces.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Administrator role required to create workspaces.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Specified owner could not be found or is inactive.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "Workspace slug already exists.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "description": "Workspace name or slug is invalid.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def create_workspace(
+    current_user: UserDep,
+    service: AdminWorkspaceServiceDep,
+    *,
+    payload: WorkspaceCreate = WORKSPACE_CREATE_BODY,
+) -> WorkspaceProfile:
+    workspace = await service.create_workspace(
+        user=current_user,
+        name=payload.name,
+        slug=payload.slug,
+        owner_user_id=payload.owner_user_id,
+        settings=payload.settings,
     )
-    @access_control(require_workspace=True)
-    async def set_default_workspace(
-        self,
-        workspace_id: str,
-        _: WorkspaceContext = Depends(bind_workspace_context),  # noqa: B008
-    ) -> WorkspaceDefaultSelection:
-        selection = await self.service.set_default_workspace(
-            user=self.current_user,
-            workspace_id=workspace_id,
-        )
-        return selection
+    return workspace
+
+
+@router.get(
+    "/workspaces",
+    response_model=list[WorkspaceProfile],
+    status_code=status.HTTP_200_OK,
+    summary="List workspaces for the authenticated user",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to list workspaces.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Service account credentials cannot access workspace listings.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def list_workspaces(
+    current_user: UserDep,
+    service: WorkspaceServiceDep,
+) -> list[WorkspaceProfile]:
+    memberships = await service.list_memberships(user=current_user)
+    return memberships
+
+
+@router.get(
+    "/workspaces/{workspace_id}",
+    response_model=WorkspaceContext,
+    status_code=status.HTTP_200_OK,
+    summary="Retrieve workspace context by identifier",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to view workspace context.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace access denied for the authenticated user.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Workspace not found.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def read_workspace(selection: WorkspaceContextDep) -> WorkspaceContext:
+    return selection
+
+
+@router.get(
+    "/workspaces/{workspace_id}/members",
+    response_model=list[WorkspaceMember],
+    status_code=status.HTTP_200_OK,
+    summary="List members within the workspace",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to list workspace members.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow member access.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def list_members(
+    _: WorkspaceContextDep,
+    service: WorkspaceMembersReadServiceDep,
+) -> list[WorkspaceMember]:
+    memberships = await service.list_members()
+    return memberships
+
+
+@router.post(
+    "/workspaces/{workspace_id}/members",
+    response_model=WorkspaceMember,
+    status_code=status.HTTP_201_CREATED,
+    summary="Add a member to a workspace",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to manage workspace members.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow member management.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Workspace or user not found.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "User is already a member of the workspace.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def add_member(
+    _: WorkspaceContextDep,
+    service: WorkspaceMembersManageServiceDep,
+    *,
+    payload: WorkspaceMemberCreate = WORKSPACE_MEMBER_BODY,
+) -> WorkspaceMember:
+    membership = await service.add_member(
+        user_id=payload.user_id,
+        role=payload.role,
+    )
+    return membership
+
+
+@router.patch(
+    "/workspaces/{workspace_id}",
+    response_model=WorkspaceProfile,
+    status_code=status.HTTP_200_OK,
+    summary="Update workspace metadata",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to update workspaces.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow settings management.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Workspace not found.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "Workspace slug already exists.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "description": "Workspace name or slug is invalid.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def update_workspace(
+    current_user: UserDep,
+    _: WorkspaceContextDep,
+    service: WorkspaceSettingsServiceDep,
+    *,
+    payload: WorkspaceUpdate = WORKSPACE_UPDATE_BODY,
+) -> WorkspaceProfile:
+    workspace = await service.update_workspace(
+        user=current_user,
+        name=payload.name,
+        slug=payload.slug,
+        settings=payload.settings,
+    )
+    return workspace
+
+
+@router.delete(
+    "/workspaces/{workspace_id}",
+    response_model=DefaultResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Delete a workspace",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to delete workspaces.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow workspace deletion.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Workspace not found.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def delete_workspace(
+    _: WorkspaceContextDep,
+    service: WorkspaceSettingsServiceDep,
+) -> DefaultResponse:
+    await service.delete_workspace()
+    return DefaultResponse.success("Workspace deleted")
+
+
+@router.patch(
+    "/workspaces/{workspace_id}/members/{membership_id}",
+    response_model=WorkspaceMember,
+    status_code=status.HTTP_200_OK,
+    summary="Update a workspace member",
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Workspace must retain at least one owner.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to manage workspace members.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow member management.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Membership not found within the workspace.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def update_member(
+    _: WorkspaceContextDep,
+    service: WorkspaceMembersManageServiceDep,
+    membership_id: str = Path(..., min_length=1, description="Membership identifier"),
+    *,
+    payload: WorkspaceMemberUpdate = WORKSPACE_MEMBER_UPDATE_BODY,
+) -> WorkspaceMember:
+    membership = await service.update_member_role(
+        membership_id=membership_id,
+        role=payload.role,
+    )
+    return membership
+
+
+@router.delete(
+    "/workspaces/{workspace_id}/members/{membership_id}",
+    response_model=DefaultResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Remove a workspace member",
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Workspace must retain at least one owner.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to manage workspace members.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace permissions do not allow member management.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Membership not found within the workspace.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def remove_member(
+    _: WorkspaceContextDep,
+    service: WorkspaceMembersManageServiceDep,
+    membership_id: str = Path(..., min_length=1, description="Membership identifier"),
+) -> DefaultResponse:
+    await service.remove_member(membership_id=membership_id)
+    return DefaultResponse.success("Workspace member removed")
+
+
+@router.post(
+    "/workspaces/{workspace_id}/default",
+    response_model=WorkspaceDefaultSelection,
+    status_code=status.HTTP_200_OK,
+    summary="Mark a workspace as the caller's default",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Authentication required to set the default workspace.",
+            "model": ErrorMessage,
+        },
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Workspace access denied for the authenticated user.",
+            "model": ErrorMessage,
+        },
+    },
+)
+async def set_default_workspace(
+    current_user: UserDep,
+    _: WorkspaceContextDep,
+    service: WorkspaceScopedServiceDep,
+) -> WorkspaceDefaultSelection:
+    selection = await service.set_default_workspace(user=current_user)
+    return selection
 
 
 __all__ = ["router"]

--- a/app/workspaces/routing.py
+++ b/app/workspaces/routing.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from enum import Enum
+from typing import Any, cast
 
 from fastapi import APIRouter
 
@@ -20,7 +21,8 @@ def workspace_scoped_router(
         normalized = f"/{normalized}"
 
     prefix = f"/workspaces/{{workspace_id}}{normalized}"
-    return APIRouter(prefix=prefix, tags=tags, **router_kwargs)
+    router_tags = cast(list[str | Enum] | None, tags)
+    return APIRouter(prefix=prefix, tags=router_tags, **router_kwargs)
 
 
 __all__ = ["workspace_scoped_router"]

--- a/docs/admin-guide/README.md
+++ b/docs/admin-guide/README.md
@@ -7,11 +7,12 @@ Administrators install, configure, and operate the Automatic Data Extractor. Thi
 - Development defaults to a single process: `ade start` runs FastAPI with reload enabled and serves the compiled SPA. Use `--rebuild-frontend` when you need to refresh the production bundle before testing, and `--frontend-dir` if the SPA lives outside the default `frontend/` directory. For Vite hot module reload, start `uvicorn` and `npm run dev -- --host` in separate terminals instead.
 - Production deployments build the frontend once (`npm run build`) and serve the static bundle behind the same reverse proxy that forwards API traffic to a managed ASGI process (Uvicorn, Uvicorn+Gunicorn, systemd, or a container orchestrator).
 - Persistent state lives under the `var/` directory by default. SQLite databases and uploaded documents sit beneath `var/db/` and `var/documents/`; both paths can be overridden through environment variables.
+- API and CLI entry points call the shared database bootstrap helper before opening sessions. It creates the SQLite directory, runs Alembic migrations, and surfaces progress in the logs before mirroring the manual fallback documented in the [admin getting started guide](getting_started.md#manual-migrations-and-recovery).
 
 ## Configuration snapshot
 - Settings are loaded once at startup through `get_settings()` and cached on `app.state.settings`. Routes and background workers read from this state rather than reloading environment variables on every request.
 - Environment variables use the `ADE_` prefix (for example `ADE_DATABASE_DSN`, `ADE_STORAGE_UPLOAD_MAX_BYTES`). A local `.env` file is respected during development.
-- Host and port configuration splits into `ADE_SERVER_HOST` / `ADE_SERVER_PORT` for the uvicorn listener and `ADE_SERVER_PUBLIC_URL` for the externally reachable origin. When ADE sits behind HTTPS on a domain such as `https://ade.example.com`, set the public URL and list it in `ADE_SERVER_CORS_ORIGINS` (comma or whitespace separated) so browsers can connect.
+- Host and port configuration splits into `ADE_SERVER_HOST` / `ADE_SERVER_PORT` for the uvicorn listener and `ADE_SERVER_PUBLIC_URL` for the externally reachable origin. When ADE sits behind HTTPS on a domain such as `https://ade.example.com`, set the public URL and provide a JSON array in `ADE_SERVER_CORS_ORIGINS` so browsers can connect (for example `["https://ade.example.com"]`).
 - Documentation endpoints (`/docs`, `/redoc`, `/openapi.json`) default on for the `local` and `staging` environments and can be
   toggled explicitly through the `ADE_API_DOCS_ENABLED` flag to keep production surfaces minimal.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ urls = { "Repository" = "https://github.com/your-org/automatic-data-extractor" }
 # Runtime deps — pinned for reproducible builds
 dependencies = [
   "fastapi==0.117.0",
-  "fastapi-utils==0.8.0",
   "uvicorn[standard]==0.36.0",
   "sqlalchemy==2.0.43",
   "alembic==1.16.5",

--- a/tests/modules/auth/test_auth.py
+++ b/tests/modules/auth/test_auth.py
@@ -320,7 +320,9 @@ async def test_sso_callback_rejects_state_mismatch(
     monkeypatch.setenv(
         "ADE_OIDC_REDIRECT_URL", "https://ade.example.com/auth/sso/callback"
     )
-    monkeypatch.setenv("ADE_OIDC_SCOPES", "openid email profile")
+    monkeypatch.setenv(
+        "ADE_OIDC_SCOPES", '["openid","email","profile"]'
+    )
     reload_settings()
     override_app_settings()
 


### PR DESCRIPTION
## Summary
- rewrite `app/settings.py` with grouped FastAPI-style fields, direct Pydantic types, and deterministic directory handling
- point document, job, and reset workflows at `storage_documents_dir` from the new settings surface
- refresh environment templates, docs, and tests for the JSON-based configuration inputs and add a tracked `.env` default profile

## Testing
- mypy app
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68de90907fa0832ebf4201f0041c5bfb