### PR TITLE
Ensure React JSX types are available during frontend build

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client", "vitest/globals"],
+    "types": ["react", "react-dom", "vite/client", "vitest/globals"],
     "skipLibCheck": true,
 
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- include the React and React DOM ambient type packages in the frontend TypeScript configuration
- restore the JSX namespace so JSX.Element references compile during the Vite build

## Testing
- not run (npm install blocked by registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68e5d4b867f8832e88c8532bf5627141