### PR TITLE
Fix frontend form validation feedback and setup flow

### DIFF
--- a/frontend/src/features/auth/components/LoginPage.tsx
+++ b/frontend/src/features/auth/components/LoginPage.tsx
@@ -138,7 +138,12 @@ export function LoginPage(): JSX.Element {
           </div>
         ) : (
           <form className="space-y-6" noValidate onSubmit={handleSubmit}>
-            <FormField label="Email" htmlFor="email" required>
+            <FormField
+              label="Email"
+              htmlFor="email"
+              required
+              error={form.formState.errors.email?.message ?? null}
+            >
               <Input
                 id="email"
                 type="email"
@@ -148,7 +153,12 @@ export function LoginPage(): JSX.Element {
               />
             </FormField>
 
-            <FormField label="Password" htmlFor="password" required>
+            <FormField
+              label="Password"
+              htmlFor="password"
+              required
+              error={form.formState.errors.password?.message ?? null}
+            >
               <Input
                 id="password"
                 type="password"

--- a/frontend/src/features/setup/components/SetupWizard.tsx
+++ b/frontend/src/features/setup/components/SetupWizard.tsx
@@ -55,10 +55,10 @@ export function SetupWizard(): JSX.Element {
   })
 
   useEffect(() => {
-    if (!setupStatus.data?.requires_setup) {
+    if (!setupStatus.data?.requires_setup && step !== 'confirmation') {
       navigate('/login', { replace: true })
     }
-  }, [navigate, setupStatus.data?.requires_setup])
+  }, [navigate, setupStatus.data?.requires_setup, step])
 
   const setupMutation = useMutation<SessionEnvelope, ApiError, SetupRequest>({
     mutationFn: (payload) => submitSetup(payload),
@@ -134,7 +134,7 @@ export function SetupWizard(): JSX.Element {
     )
   }
 
-  if (!setupStatus.data?.requires_setup) {
+  if (!setupStatus.data?.requires_setup && step !== 'confirmation') {
     return <Spinner label="Redirecting to login" />
   }
 
@@ -198,7 +198,12 @@ export function SetupWizard(): JSX.Element {
             noValidate
             onSubmit={onSubmit}
           >
-            <FormField label="Display name" htmlFor="displayName" required>
+            <FormField
+              label="Display name"
+              htmlFor="displayName"
+              required
+              error={form.formState.errors.displayName?.message ?? null}
+            >
               <Input
                 id="displayName"
                 autoFocus
@@ -207,7 +212,12 @@ export function SetupWizard(): JSX.Element {
               />
             </FormField>
 
-            <FormField label="Email" htmlFor="email" required>
+            <FormField
+              label="Email"
+              htmlFor="email"
+              required
+              error={form.formState.errors.email?.message ?? null}
+            >
               <Input
                 id="email"
                 type="email"
@@ -222,6 +232,7 @@ export function SetupWizard(): JSX.Element {
               htmlFor="password"
               required
               description="Minimum 12 characters including a number and uppercase letter"
+              error={form.formState.errors.password?.message ?? null}
             >
               <Input
                 id="password"
@@ -232,7 +243,14 @@ export function SetupWizard(): JSX.Element {
               />
             </FormField>
 
-            <FormField label="Confirm password" htmlFor="confirmPassword" required>
+            <FormField
+              label="Confirm password"
+              htmlFor="confirmPassword"
+              required
+              error={
+                form.formState.errors.confirmPassword?.message ?? null
+              }
+            >
               <Input
                 id="confirmPassword"
                 type="password"

--- a/frontend/src/shared/components/FormField.tsx
+++ b/frontend/src/shared/components/FormField.tsx
@@ -19,13 +19,16 @@ export function FormField({
 }: FormFieldProps): JSX.Element {
   return (
     <div className="space-y-2">
-      <label
-        htmlFor={htmlFor}
-        className="text-sm font-medium text-slate-900"
-      >
-        {label}
-        {required && <span className="ml-1 text-red-500">*</span>}
-      </label>
+      <div className="flex items-center gap-1">
+        <label htmlFor={htmlFor} className="text-sm font-medium text-slate-900">
+          {label}
+        </label>
+        {required && (
+          <span aria-hidden="true" className="text-sm font-medium text-red-500">
+            *
+          </span>
+        )}
+      </div>
       {description && (
         <p className="text-xs text-slate-500" id={`${htmlFor}-description`}>
           {description}


### PR DESCRIPTION
## Summary
- surface login and setup field errors by wiring validation messages through FormField
- keep the setup wizard on the confirmation step instead of redirecting immediately
- adjust FormField to show a required indicator without polluting accessible labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5d6ceba54832e8e225d59869a961c