### PR TITLE
Fix TypeScript type imports and React Query calls

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react'
+
 import { AppProviders } from './providers'
 import { AppRouter } from './router'
 

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
+import type { ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 import { createQueryClient } from './query-client'
 
-export function AppProviders({ children }: { children: React.ReactNode }) {
+export function AppProviders({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => createQueryClient())
 
   return (

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import {
   Navigate,
   Outlet,

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '../../shared/api/client'
-import {
+import type {
   ProviderDiscoveryResponse,
   SessionEnvelope,
   LoginRequest,

--- a/frontend/src/features/auth/components/LoginPage.tsx
+++ b/frontend/src/features/auth/components/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import type { JSX } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
@@ -74,7 +75,7 @@ export function LoginPage(): JSX.Element {
 
     loginMutation.mutate(parsed.data, {
       onSuccess: () => {
-        queryClient.invalidateQueries(queryKeys.providers)
+        queryClient.invalidateQueries({ queryKey: queryKeys.providers })
         navigate(redirectTo, { replace: true })
       },
       onError: (error: ApiError) => {

--- a/frontend/src/features/auth/components/LogoutRoute.tsx
+++ b/frontend/src/features/auth/components/LogoutRoute.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import type { JSX } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 

--- a/frontend/src/features/auth/components/RequireSession.tsx
+++ b/frontend/src/features/auth/components/RequireSession.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 
 import { Alert } from '../../../shared/components/Alert'

--- a/frontend/src/features/auth/hooks/useAuthProviders.ts
+++ b/frontend/src/features/auth/hooks/useAuthProviders.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { queryKeys } from '../../../shared/api/query-keys'
-import { ProviderDiscoveryResponse } from '../../../shared/api/types'
+import type { ProviderDiscoveryResponse } from '../../../shared/api/types'
 import { fetchAuthProviders } from '../api'
 
 export function useAuthProviders() {

--- a/frontend/src/features/auth/hooks/useLoginMutation.ts
+++ b/frontend/src/features/auth/hooks/useLoginMutation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { ApiError } from '../../../shared/api/client'
 import { queryKeys } from '../../../shared/api/query-keys'
-import { LoginRequest, SessionEnvelope } from '../../../shared/api/types'
+import type { LoginRequest, SessionEnvelope } from '../../../shared/api/types'
 import { createSession } from '../api'
 
 export function useLoginMutation() {

--- a/frontend/src/features/auth/hooks/useSessionQuery.ts
+++ b/frontend/src/features/auth/hooks/useSessionQuery.ts
@@ -2,7 +2,7 @@ import { QueryClient, useQuery } from '@tanstack/react-query'
 
 import { ApiError } from '../../../shared/api/client'
 import { queryKeys } from '../../../shared/api/query-keys'
-import { SessionEnvelope } from '../../../shared/api/types'
+import type { SessionEnvelope } from '../../../shared/api/types'
 import { fetchSession } from '../api'
 
 export function useSessionQuery() {

--- a/frontend/src/features/setup/api.ts
+++ b/frontend/src/features/setup/api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '../../shared/api/client'
-import {
+import type {
   SessionEnvelope,
   SetupRequest,
   SetupStatus,

--- a/frontend/src/features/setup/components/SetupWizard.tsx
+++ b/frontend/src/features/setup/components/SetupWizard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import type { JSX } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
@@ -12,7 +13,7 @@ import { Card } from '../../../shared/components/Card'
 import { FormField } from '../../../shared/components/FormField'
 import { Input } from '../../../shared/components/Input'
 import { Spinner } from '../../../shared/components/Spinner'
-import { SetupRequest, SessionEnvelope } from '../../../shared/api/types'
+import type { SetupRequest, SessionEnvelope } from '../../../shared/api/types'
 import { useAuthProviders } from '../../auth/hooks/useAuthProviders'
 import { setSessionQueryData } from '../../auth/hooks/useSessionQuery'
 import { fetchSetupStatus, submitSetup } from '../api'
@@ -73,7 +74,10 @@ export function SetupWizard(): JSX.Element {
     },
     onError: async (error) => {
       if (error.status === 409) {
-        await queryClient.fetchQuery(queryKeys.setupStatus, fetchSetupStatus)
+        await queryClient.fetchQuery({
+          queryKey: queryKeys.setupStatus,
+          queryFn: fetchSetupStatus,
+        })
         setFormError('Setup is already complete. Please sign in instead.')
         setStep('welcome')
         return

--- a/frontend/src/features/setup/components/__tests__/SetupWizard.test.tsx
+++ b/frontend/src/features/setup/components/__tests__/SetupWizard.test.tsx
@@ -4,7 +4,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { queryKeys } from '../../../../shared/api/query-keys'
-import { SessionEnvelope } from '../../../../shared/api/types'
+import type { SessionEnvelope } from '../../../../shared/api/types'
 import { createTestQueryClient, renderWithQueryClient } from '../../../../test/test-utils'
 import * as setupApi from '../../api'
 import { SetupWizard } from '../SetupWizard'

--- a/frontend/src/features/workspaces/api.ts
+++ b/frontend/src/features/workspaces/api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '../../shared/api/client'
-import {
+import type {
   ConfigurationSummary,
   DocumentTypeSummary,
   WorkspaceProfile,

--- a/frontend/src/features/workspaces/components/DocumentTypePage.tsx
+++ b/frontend/src/features/workspaces/components/DocumentTypePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import type { JSX } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { Alert } from '../../../shared/components/Alert'

--- a/frontend/src/features/workspaces/components/WorkspaceLayout.tsx
+++ b/frontend/src/features/workspaces/components/WorkspaceLayout.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import type { JSX } from 'react'
 import { Link, NavLink, Outlet, useNavigate, useParams } from 'react-router-dom'
 import { clsx } from 'clsx'
 

--- a/frontend/src/features/workspaces/components/WorkspaceOverviewPage.tsx
+++ b/frontend/src/features/workspaces/components/WorkspaceOverviewPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import type { JSX } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { Alert } from '../../../shared/components/Alert'

--- a/frontend/src/features/workspaces/components/WorkspaceRedirect.tsx
+++ b/frontend/src/features/workspaces/components/WorkspaceRedirect.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Navigate } from 'react-router-dom'
 
 import { Alert } from '../../../shared/components/Alert'

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,4 +1,4 @@
-import { ProblemDetail } from './types'
+import type { ProblemDetail } from './types'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 

--- a/frontend/src/shared/components/Alert.tsx
+++ b/frontend/src/shared/components/Alert.tsx
@@ -1,9 +1,10 @@
 import { clsx } from 'clsx'
+import type { JSX, ReactNode } from 'react'
 
 interface AlertProps {
   variant?: 'info' | 'warning' | 'error' | 'success'
   title?: string
-  children?: React.ReactNode
+  children?: ReactNode
 }
 
 const variantStyles: Record<Required<AlertProps>['variant'], string> = {

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from 'react'
+import type { ButtonHTMLAttributes } from 'react'
 import { clsx } from 'clsx'
 
 type ButtonVariant = 'primary' | 'secondary' | 'ghost'
 
 type ButtonSize = 'md' | 'sm'
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant
   size?: ButtonSize
   isLoading?: boolean

--- a/frontend/src/shared/components/Card.tsx
+++ b/frontend/src/shared/components/Card.tsx
@@ -1,8 +1,10 @@
+import type { JSX, ReactNode } from 'react'
+
 export interface CardProps {
   title?: string
   description?: string
-  children: React.ReactNode
-  actions?: React.ReactNode
+  children: ReactNode
+  actions?: ReactNode
   className?: string
 }
 

--- a/frontend/src/shared/components/Drawer.tsx
+++ b/frontend/src/shared/components/Drawer.tsx
@@ -1,11 +1,13 @@
+import type { JSX, ReactNode } from 'react'
+
 interface DrawerProps {
   title: string
   isOpen: boolean
   onClose: () => void
-  children: React.ReactNode
+  children: ReactNode
 }
 
-export function Drawer({ title, isOpen, onClose, children }: DrawerProps) {
+export function Drawer({ title, isOpen, onClose, children }: DrawerProps): JSX.Element | null {
   if (!isOpen) {
     return null
   }

--- a/frontend/src/shared/components/FormField.tsx
+++ b/frontend/src/shared/components/FormField.tsx
@@ -1,4 +1,5 @@
 import { clsx } from 'clsx'
+import type { JSX, ReactNode } from 'react'
 
 interface FormFieldProps {
   label: string
@@ -6,7 +7,7 @@ interface FormFieldProps {
   required?: boolean
   description?: string
   error?: string | null
-  children: React.ReactNode
+  children: ReactNode
 }
 
 export function FormField({

--- a/frontend/src/shared/components/Input.tsx
+++ b/frontend/src/shared/components/Input.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from 'react'
+import type { InputHTMLAttributes } from 'react'
 import { clsx } from 'clsx'
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   error?: string | null
 }
 

--- a/frontend/src/shared/components/Spinner.tsx
+++ b/frontend/src/shared/components/Spinner.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react'
+
 export function Spinner({ label }: { label?: string }): JSX.Element {
   return (
     <div className="flex flex-col items-center justify-center gap-2 py-12" role="status">

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import type { ReactElement } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render } from '@testing-library/react'
 


### PR DESCRIPTION
## Summary
- switch shared API usage to type-only imports and add explicit JSX typings across the frontend to satisfy `verbatimModuleSyntax`
- clean up shared UI components to rely on imported React type aliases instead of the global React namespace
- align React Query helpers with the current API when invalidating and refetching setup-related queries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5d8e9fd44832eac0b73f50b4c3f78