### PR TITLE
Fix frontend API base URL handling

### DIFF
--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -1,11 +1,5 @@
 import { ApiError, del, get, post } from "../../shared/api/client";
-import type {
-  AuthProvider,
-  CompleteSetupPayload,
-  LoginPayload,
-  SessionEnvelope,
-  SetupStatusResponse,
-} from "../../shared/api/types";
+import type { AuthProvider, LoginPayload, SessionEnvelope } from "../../shared/api/types";
 
 export async function fetchSession() {
   try {
@@ -33,12 +27,4 @@ export async function refreshSession() {
 
 export async function fetchAuthProviders() {
   return get<{ providers: AuthProvider[]; force_sso: boolean }>("/auth/providers");
-}
-
-export async function fetchSetupStatus() {
-  return get<SetupStatusResponse>("/setup/status");
-}
-
-export async function completeSetup(payload: CompleteSetupPayload) {
-  return post<SessionEnvelope>("/setup", payload);
 }

--- a/frontend/src/features/setup/api.ts
+++ b/frontend/src/features/setup/api.ts
@@ -1,0 +1,10 @@
+import { get, post } from "../../shared/api/client";
+import type { CompleteSetupPayload, SetupStatusResponse, SessionEnvelope } from "../../shared/api/types";
+
+export async function fetchSetupStatus() {
+  return get<SetupStatusResponse>("/setup/status");
+}
+
+export async function completeSetup(payload: CompleteSetupPayload) {
+  return post<SessionEnvelope>("/setup", payload);
+}

--- a/frontend/src/features/setup/hooks/useCompleteSetupMutation.ts
+++ b/frontend/src/features/setup/hooks/useCompleteSetupMutation.ts
@@ -1,7 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
-import { completeSetup, fetchSetupStatus, fetchSession } from "../../auth/api";
+import { fetchSession } from "../../auth/api";
+import { completeSetup, fetchSetupStatus } from "../api";
 import { setupKeys } from "./useSetupStatusQuery";
 import { sessionKeys } from "../../auth/hooks/sessionKeys";
 import type { CompleteSetupPayload } from "../../../shared/api/types";

--- a/frontend/src/features/setup/hooks/useSetupStatusQuery.ts
+++ b/frontend/src/features/setup/hooks/useSetupStatusQuery.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { fetchSetupStatus } from "../../auth/api";
+import { fetchSetupStatus } from "../api";
 
 export const setupKeys = {
   all: ["setup"] as const,

--- a/frontend/src/test/apiClient.test.ts
+++ b/frontend/src/test/apiClient.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiClient, get } from "../shared/api/client";
+
+const originalFetch = globalThis.fetch;
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response;
+}
+
+describe("ApiClient", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as typeof fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    } else {
+      // @ts-expect-error -- allow clearing fetch when unavailable.
+      delete globalThis.fetch;
+    }
+  });
+
+  it("prefixes API requests with the default base URL", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: "ok" }));
+
+    await get("/setup/status");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/setup/status",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("normalizes trailing slashes on custom base URLs", async () => {
+    const client = new ApiClient("https://example.com/api/");
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: "ok" }));
+
+    await client.request("/health", { method: "GET" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/api/health",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("rejects relative paths without a leading slash", async () => {
+    const client = new ApiClient();
+
+    await expect(client.request("health")).rejects.toThrow(
+      /leading slash/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- default the shared API client to the FastAPI /api prefix and normalize configured base URLs
- move setup-specific API calls into a dedicated feature module and update hooks to use it
- add unit coverage for the API client base URL behaviour

## Testing
- npm test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5ecf38c64832eb0955ecc19402cdd