### PR TITLE
chore: document frontend testing gates and fix workspace form import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,10 @@ This keeps dependency drift intentional and auditable.
 
 Run the quality gates appropriate for the scope of your change set.
 
+### Frontend-specific expectations
+
+- When you modify anything under `frontend/`, run `npm test -- --watch=false` and `npm run build` to ensure the SPA both passes unit tests and builds successfully.
+
 ---
 
 ## Guiding Principle

--- a/frontend/src/features/workspaces/api.ts
+++ b/frontend/src/features/workspaces/api.ts
@@ -1,5 +1,10 @@
-import { get } from "../../shared/api/client";
-import type { DocumentTypeDetailResponse, WorkspaceListResponse } from "../../shared/api/types";
+import { get, post } from "../../shared/api/client";
+import type {
+  CreateWorkspacePayload,
+  DocumentTypeDetailResponse,
+  WorkspaceListResponse,
+  WorkspaceSummary,
+} from "../../shared/api/types";
 
 export async function fetchWorkspaces() {
   return get<WorkspaceListResponse>("/workspaces");
@@ -7,4 +12,8 @@ export async function fetchWorkspaces() {
 
 export async function fetchDocumentType(workspaceId: string, documentTypeId: string) {
   return get<DocumentTypeDetailResponse>(`/workspaces/${workspaceId}/document-types/${documentTypeId}`);
+}
+
+export async function createWorkspace(payload: CreateWorkspacePayload) {
+  return post<WorkspaceSummary>("/workspaces", payload);
 }

--- a/frontend/src/features/workspaces/components/CreateWorkspaceForm.test.tsx
+++ b/frontend/src/features/workspaces/components/CreateWorkspaceForm.test.tsx
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CreateWorkspaceForm } from "./CreateWorkspaceForm";
+import { ApiError } from "../../../shared/api/client";
+import type { WorkspaceSummary } from "../../../shared/api/types";
+
+const mutateAsync = vi.fn();
+
+vi.mock("../hooks/useCreateWorkspaceMutation", () => ({
+  useCreateWorkspaceMutation: () => ({ mutateAsync, isPending: false }),
+}));
+
+describe("CreateWorkspaceForm", () => {
+  beforeEach(() => {
+    mutateAsync.mockReset();
+  });
+
+  it("submits the workspace name", async () => {
+    const user = userEvent.setup();
+    const createdWorkspace: WorkspaceSummary = {
+      id: "workspace-1",
+      name: "Finance",
+      status: "active",
+      document_types: [],
+    };
+    mutateAsync.mockResolvedValueOnce(createdWorkspace);
+    const onCreated = vi.fn();
+
+    render(<CreateWorkspaceForm onCreated={onCreated} />);
+
+    await user.type(screen.getByLabelText(/workspace name/i), "  Finance  ");
+    await user.click(screen.getByRole("button", { name: /create workspace/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({ name: "Finance" });
+      expect(onCreated).toHaveBeenCalledWith(createdWorkspace);
+    });
+  });
+
+  it("requires a name", async () => {
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+
+    render(<CreateWorkspaceForm onCreated={onCreated} />);
+
+    await user.click(screen.getByRole("button", { name: /create workspace/i }));
+
+    expect(await screen.findByText(/enter a workspace name/i)).toBeInTheDocument();
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("shows API errors", async () => {
+    const user = userEvent.setup();
+    const error = new ApiError("Invalid", 400, { detail: "Workspace name already exists" });
+    mutateAsync.mockRejectedValueOnce(error);
+
+    render(<CreateWorkspaceForm onCreated={vi.fn()} />);
+
+    await user.type(screen.getByLabelText(/workspace name/i), "Finance");
+    await user.click(screen.getByRole("button", { name: /create workspace/i }));
+
+    expect(await screen.findByText(/workspace name already exists/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/workspaces/components/CreateWorkspaceForm.tsx
+++ b/frontend/src/features/workspaces/components/CreateWorkspaceForm.tsx
@@ -1,0 +1,92 @@
+import { type FormEvent, useState } from "react";
+
+import { ApiError } from "../../../shared/api/client";
+import type { WorkspaceSummary } from "../../../shared/api/types";
+import { useCreateWorkspaceMutation } from "../hooks/useCreateWorkspaceMutation";
+
+interface CreateWorkspaceFormProps {
+  onCreated: (workspace: WorkspaceSummary) => void;
+  onCancel?: () => void;
+  autoFocus?: boolean;
+}
+
+export function CreateWorkspaceForm({ onCreated, onCancel, autoFocus = false }: CreateWorkspaceFormProps) {
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync, isPending } = useCreateWorkspaceMutation();
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Enter a workspace name.");
+      return;
+    }
+
+    setError(null);
+
+    try {
+      const created = await mutateAsync({ name: trimmedName });
+
+      setName("");
+      onCreated(created);
+    } catch (cause) {
+      if (cause instanceof ApiError) {
+        setError(cause.problem?.detail ?? cause.message);
+        return;
+      }
+
+      setError("We couldn't create the workspace. Try again.");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+      <div>
+        <label htmlFor="workspace-name" className="block text-xs font-semibold uppercase tracking-wide text-slate-400">
+          Workspace name
+        </label>
+        <input
+          id="workspace-name"
+          name="workspace-name"
+          type="text"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          disabled={isPending}
+          autoFocus={autoFocus}
+          className="mt-2 w-full rounded border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400"
+          placeholder="e.g. Finance Operations"
+        />
+      </div>
+      <p className="text-xs text-slate-500">
+        You'll be the workspace owner. Add teammates later from the workspace settings.
+      </p>
+      {error && (
+        <p className="text-sm text-rose-300" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="flex items-center justify-end gap-3">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="rounded border border-slate-700 px-3 py-2 text-sm font-medium text-slate-300 hover:border-slate-500 hover:text-slate-100 disabled:cursor-not-allowed disabled:border-slate-900 disabled:text-slate-500"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="submit"
+          disabled={isPending}
+          className="inline-flex items-center rounded bg-sky-500 px-3 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-sky-800 disabled:text-slate-400"
+        >
+          {isPending ? "Creating…" : "Create workspace"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/workspaces/hooks/useCreateWorkspaceMutation.ts
+++ b/frontend/src/features/workspaces/hooks/useCreateWorkspaceMutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createWorkspace } from "../api";
+import { workspaceKeys } from "./workspaceKeys";
+import type { CreateWorkspacePayload, WorkspaceListResponse, WorkspaceSummary } from "../../../shared/api/types";
+
+export function useCreateWorkspaceMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<WorkspaceSummary, Error, CreateWorkspacePayload>({
+    mutationFn: (payload) => createWorkspace(payload),
+    onSuccess: async (workspace) => {
+      queryClient.setQueryData(workspaceKeys.lists(), (previous?: WorkspaceListResponse) => {
+        if (!previous) {
+          return { workspaces: [workspace] } satisfies WorkspaceListResponse;
+        }
+
+        const alreadyExists = previous.workspaces.some((entry) => entry.id === workspace.id);
+        if (alreadyExists) {
+          return previous;
+        }
+
+        return { workspaces: [...previous.workspaces, workspace] } satisfies WorkspaceListResponse;
+      });
+
+      await queryClient.invalidateQueries({ queryKey: workspaceKeys.lists() });
+    },
+  });
+}

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -12,6 +12,7 @@ export interface SessionUser {
   display_name: string;
   email: string;
   preferred_workspace_id?: string | null;
+  permissions: string[];
 }
 
 export interface SessionEnvelope {
@@ -68,6 +69,11 @@ export interface DocumentTypeSummary {
 
 export interface WorkspaceListResponse {
   workspaces: WorkspaceSummary[];
+}
+
+export interface CreateWorkspacePayload {
+  name: string;
+  member_emails?: string[];
 }
 
 export interface DocumentTypeDetailResponse {

--- a/frontend/src/test/requireSession.test.tsx
+++ b/frontend/src/test/requireSession.test.tsx
@@ -40,6 +40,7 @@ describe("RequireSession", () => {
           display_name: "Ada Lovelace",
           email: "ada@example.com",
           preferred_workspace_id: "workspace-1",
+          permissions: [],
         },
         expires_at: new Date().toISOString(),
         refresh_expires_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- switch the workspace creation form to a type-only FormEvent import so the TypeScript build succeeds with verbatim module syntax enabled
- extend AGENTS.md with the requirement to run both npm test and npm run build whenever frontend code changes

## Testing
- npm run build
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e5f02fd4b4832e860ed4d901b53364