### PR TITLE
Simplify workspace permission gating

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, Outlet, RouterProvider } from "react-router-dom";
 
 import { RootRoute } from "./RootRoute";
 import { NotFoundRoute } from "./NotFoundRoute";
@@ -10,6 +10,15 @@ import { RequireSession } from "../features/auth/components/RequireSession";
 import { WorkspaceLayout } from "../features/workspaces/components/WorkspaceLayout";
 import { WorkspaceOverviewRoute } from "../features/workspaces/routes/WorkspaceOverviewRoute";
 import { DocumentTypeRoute } from "../features/workspaces/routes/DocumentTypeRoute";
+import { WorkspaceDocumentsRoute } from "../features/workspaces/routes/WorkspaceDocumentsRoute";
+import { WorkspaceJobsRoute } from "../features/workspaces/routes/WorkspaceJobsRoute";
+import { WorkspaceConfigurationsRoute } from "../features/workspaces/routes/WorkspaceConfigurationsRoute";
+import { WorkspaceMembersRoute } from "../features/workspaces/routes/WorkspaceMembersRoute";
+import { WorkspaceRolesRoute } from "../features/workspaces/routes/WorkspaceRolesRoute";
+import { WorkspaceSettingsRoute } from "../features/workspaces/routes/WorkspaceSettingsRoute";
+import { RequirePermission } from "../shared/rbac/RequirePermission";
+import { AccessDenied } from "../shared/rbac/AccessDenied";
+import { RBAC } from "../shared/rbac/permissions";
 
 export function createAppRouter() {
   return createBrowserRouter([
@@ -31,8 +40,76 @@ export function createAppRouter() {
               children: [
                 { index: true, element: <WorkspaceOverviewRoute /> },
                 {
-                  path: "document-types/:documentTypeId",
-                  element: <DocumentTypeRoute />,
+                  path: "documents",
+                  element: (
+                    <RequirePermission
+                      needed={[RBAC.Workspace.Documents.Read, RBAC.Workspace.Documents.ReadWrite]}
+                      fallback={<AccessDenied>You do not have permission to view documents.</AccessDenied>}
+                    >
+                      <Outlet />
+                    </RequirePermission>
+                  ),
+                  children: [
+                    { index: true, element: <WorkspaceDocumentsRoute /> },
+                    { path: ":documentTypeId", element: <DocumentTypeRoute /> },
+                  ],
+                },
+                {
+                  path: "jobs",
+                  element: (
+                    <RequirePermission
+                      needed={[RBAC.Workspace.Jobs.Read, RBAC.Workspace.Jobs.ReadWrite]}
+                      fallback={<AccessDenied>You do not have permission to view job history.</AccessDenied>}
+                    >
+                      <WorkspaceJobsRoute />
+                    </RequirePermission>
+                  ),
+                },
+                {
+                  path: "configurations",
+                  element: (
+                    <RequirePermission
+                      needed={[RBAC.Workspace.Configurations.Read, RBAC.Workspace.Configurations.ReadWrite]}
+                      fallback={<AccessDenied>You do not have permission to view configurations.</AccessDenied>}
+                    >
+                      <WorkspaceConfigurationsRoute />
+                    </RequirePermission>
+                  ),
+                },
+                {
+                  path: "members",
+                  element: (
+                    <RequirePermission
+                      needed={[RBAC.Workspace.Members.Read, RBAC.Workspace.Members.ReadWrite]}
+                      fallback={<AccessDenied>You do not have permission to view workspace members.</AccessDenied>}
+                    >
+                      <WorkspaceMembersRoute />
+                    </RequirePermission>
+                  ),
+                },
+                {
+                  path: "roles",
+                  element: (
+                    <RequirePermission
+                      needed={[RBAC.Workspace.Roles.Read, RBAC.Workspace.Roles.ReadWrite]}
+                      fallback={<AccessDenied>You do not have permission to view the role catalog.</AccessDenied>}
+                    >
+                      <WorkspaceRolesRoute />
+                    </RequirePermission>
+                  ),
+                },
+                {
+                  path: "settings",
+                  element: (
+                    <RequirePermission
+                      needed={[RBAC.Workspace.Settings.ReadWrite]}
+                      fallback={
+                        <AccessDenied>Workspace settings require Workspace.Settings.ReadWrite permissions.</AccessDenied>
+                      }
+                    >
+                      <WorkspaceSettingsRoute />
+                    </RequirePermission>
+                  ),
                 },
               ],
             },

--- a/frontend/src/features/workspaces/api.ts
+++ b/frontend/src/features/workspaces/api.ts
@@ -1,18 +1,50 @@
-import { get, post } from "../../shared/api/client";
+import { del, get, post, put, type ApiClientOptions } from "../../shared/api/client";
 import type {
   CreateWorkspacePayload,
   DocumentTypeDetailResponse,
+  UserRole,
+  WorkspaceMember,
+  WorkspaceMemberCreatePayload,
+  WorkspaceMemberRolesUpdatePayload,
   WorkspaceProfile,
-  WorkspaceRole,
+  WorkspaceRoleDefinition,
 } from "../../shared/api/types";
 
 interface WorkspaceProfileResponse {
   workspace_id: string;
   name: string;
   slug: string;
-  role: WorkspaceRole;
+  roles: string[];
   permissions: string[];
   is_default: boolean;
+}
+
+interface WorkspaceMemberResponse {
+  workspace_membership_id: string;
+  workspace_id: string;
+  roles: string[];
+  permissions: string[];
+  is_default: boolean;
+  user: {
+    user_id: string;
+    email: string;
+    role: UserRole;
+    is_active: boolean;
+    is_service_account: boolean;
+    display_name?: string | null;
+  };
+}
+
+interface WorkspaceRoleResponse {
+  role_id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  scope: "global" | "workspace";
+  workspace_id?: string | null;
+  permissions: string[];
+  is_system: boolean;
+  editable: boolean;
 }
 
 function mapWorkspaceProfile(payload: WorkspaceProfileResponse): WorkspaceProfile {
@@ -20,22 +52,85 @@ function mapWorkspaceProfile(payload: WorkspaceProfileResponse): WorkspaceProfil
     id: payload.workspace_id,
     name: payload.name,
     slug: payload.slug,
-    role: payload.role,
+    roles: payload.roles ?? [],
     permissions: payload.permissions ?? [],
     is_default: payload.is_default,
   } satisfies WorkspaceProfile;
 }
 
-export async function fetchWorkspaces() {
-  const response = await get<WorkspaceProfileResponse[]>("/workspaces");
+function mapWorkspaceMember(payload: WorkspaceMemberResponse): WorkspaceMember {
+  return {
+    id: payload.workspace_membership_id,
+    workspace_id: payload.workspace_id,
+    roles: payload.roles ?? [],
+    permissions: payload.permissions ?? [],
+    is_default: payload.is_default,
+    user: {
+      user_id: payload.user.user_id,
+      email: payload.user.email,
+      role: payload.user.role,
+      is_active: payload.user.is_active,
+      is_service_account: payload.user.is_service_account,
+      display_name: payload.user.display_name ?? null,
+    },
+  } satisfies WorkspaceMember;
+}
+
+function mapWorkspaceRole(payload: WorkspaceRoleResponse): WorkspaceRoleDefinition {
+  return {
+    id: payload.role_id,
+    slug: payload.slug,
+    name: payload.name,
+    description: payload.description ?? null,
+    scope: payload.scope,
+    workspace_id: payload.workspace_id ?? null,
+    permissions: payload.permissions ?? [],
+    is_system: payload.is_system,
+    editable: payload.editable,
+  } satisfies WorkspaceRoleDefinition;
+}
+
+export async function fetchWorkspaces(options?: ApiClientOptions) {
+  const response = await get<WorkspaceProfileResponse[]>("/workspaces", options);
   return response.map(mapWorkspaceProfile);
 }
 
-export async function fetchDocumentType(workspaceId: string, documentTypeId: string) {
-  return get<DocumentTypeDetailResponse>(`/workspaces/${workspaceId}/document-types/${documentTypeId}`);
+export async function fetchDocumentType(workspaceId: string, documentTypeId: string, options?: ApiClientOptions) {
+  return get<DocumentTypeDetailResponse>(`/workspaces/${workspaceId}/document-types/${documentTypeId}`, options);
 }
 
 export async function createWorkspace(payload: CreateWorkspacePayload) {
   const response = await post<WorkspaceProfileResponse>("/workspaces", payload);
   return mapWorkspaceProfile(response);
+}
+
+export async function fetchWorkspaceMembers(workspaceId: string, options?: ApiClientOptions) {
+  const response = await get<WorkspaceMemberResponse[]>(`/workspaces/${workspaceId}/members`, options);
+  return response.map(mapWorkspaceMember);
+}
+
+export async function fetchWorkspaceRoles(workspaceId: string, options?: ApiClientOptions) {
+  const response = await get<WorkspaceRoleResponse[]>(`/workspaces/${workspaceId}/roles`, options);
+  return response.map(mapWorkspaceRole);
+}
+
+export async function addWorkspaceMember(workspaceId: string, payload: WorkspaceMemberCreatePayload) {
+  const response = await post<WorkspaceMemberResponse>(`/workspaces/${workspaceId}/members`, payload);
+  return mapWorkspaceMember(response);
+}
+
+export async function updateWorkspaceMemberRoles(
+  workspaceId: string,
+  membershipId: string,
+  payload: WorkspaceMemberRolesUpdatePayload,
+) {
+  const response = await put<WorkspaceMemberResponse>(
+    `/workspaces/${workspaceId}/members/${membershipId}/roles`,
+    payload,
+  );
+  return mapWorkspaceMember(response);
+}
+
+export async function removeWorkspaceMember(workspaceId: string, membershipId: string) {
+  await del(`/workspaces/${workspaceId}/members/${membershipId}`);
 }

--- a/frontend/src/features/workspaces/components/CreateWorkspaceForm.test.tsx
+++ b/frontend/src/features/workspaces/components/CreateWorkspaceForm.test.tsx
@@ -23,8 +23,8 @@ describe("CreateWorkspaceForm", () => {
       id: "workspace-1",
       name: "Finance",
       slug: "finance",
-      role: "owner",
-      permissions: ["workspace:members:manage"],
+      roles: ["workspace-owner"],
+      permissions: ["Workspace.Members.ReadWrite"],
       is_default: false,
     };
     mutateAsync.mockResolvedValueOnce(createdWorkspace);

--- a/frontend/src/features/workspaces/components/CreateWorkspaceForm.tsx
+++ b/frontend/src/features/workspaces/components/CreateWorkspaceForm.tsx
@@ -61,6 +61,7 @@ export function CreateWorkspaceForm({ onCreated, onCancel, autoFocus = false }: 
           }}
           disabled={isPending}
           autoFocus={autoFocus}
+          data-autofocus={autoFocus ? "true" : undefined}
           className="mt-2 w-full rounded border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400"
           placeholder="e.g. Finance Operations"
         />

--- a/frontend/src/features/workspaces/components/WorkspaceLayout.test.tsx
+++ b/frontend/src/features/workspaces/components/WorkspaceLayout.test.tsx
@@ -1,13 +1,14 @@
+import { type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import type { SessionEnvelope } from "../../../shared/api/types";
+import type { SessionEnvelope, WorkspaceProfile } from "../../../shared/api/types";
 
 const useWorkspacesQueryMock = vi.fn();
 const useSessionQueryMock = vi.fn();
 const navigateMock = vi.fn();
-const createWorkspaceMutationMock = { mutateAsync: vi.fn(), isPending: false };
+const useParamsMock = vi.fn(() => ({}));
 
 vi.mock("../hooks/useWorkspacesQuery", () => ({
   useWorkspacesQuery: () => useWorkspacesQueryMock(),
@@ -18,7 +19,7 @@ vi.mock("../../auth/hooks/useSessionQuery", () => ({
 }));
 
 vi.mock("../hooks/useCreateWorkspaceMutation", () => ({
-  useCreateWorkspaceMutation: () => createWorkspaceMutationMock,
+  useCreateWorkspaceMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -27,35 +28,57 @@ vi.mock("react-router-dom", async () => {
   return {
     ...actual,
     useNavigate: () => navigateMock,
-    useParams: () => ({}),
+    useParams: () => useParamsMock(),
+    useLocation: () => ({ pathname: "/workspaces", search: "", hash: "", state: null, key: "test" }),
+    NavLink: ({ children, to }: { children: ReactNode; to: string }) => <a href={String(to)}>{children}</a>,
     Outlet: () => null,
   };
 });
 
 import { WorkspaceLayout } from "./WorkspaceLayout";
 
+const baseSession: SessionEnvelope = {
+  user: {
+    user_id: "user-1",
+    email: "user@example.com",
+    role: "user",
+    is_active: true,
+    is_service_account: false,
+    display_name: "Regular User",
+    preferred_workspace_id: null,
+    permissions: [],
+  },
+  expires_at: new Date().toISOString(),
+  refresh_expires_at: new Date().toISOString(),
+};
+
+const workspace = (overrides: Partial<WorkspaceProfile> = {}): WorkspaceProfile => ({
+  id: "workspace-1",
+  name: "Finance",
+  slug: "finance",
+  roles: ["workspace-owner"],
+  permissions: ["Workspace.Members.Read", "Workspace.Documents.Read"],
+  is_default: true,
+  ...overrides,
+});
+
 describe("WorkspaceLayout", () => {
   beforeEach(() => {
     useWorkspacesQueryMock.mockReset();
     useSessionQueryMock.mockReset();
     navigateMock.mockReset();
-    createWorkspaceMutationMock.mutateAsync.mockReset();
+    useParamsMock.mockReset();
+    useParamsMock.mockReturnValue({});
   });
 
-  it("shows an actionable empty state for administrators with no workspaces", async () => {
+  it("shows an actionable empty state for users with workspace creation rights", async () => {
     const user = userEvent.setup();
     const session: SessionEnvelope = {
+      ...baseSession,
       user: {
-        user_id: "admin-1",
-        email: "admin@example.com",
-        role: "admin",
-        is_active: true,
-        is_service_account: false,
-        display_name: "Admin User",
-        preferred_workspace_id: null,
+        ...baseSession.user,
+        permissions: ["Workspaces.Create"],
       },
-      expires_at: new Date().toISOString(),
-      refresh_expires_at: new Date().toISOString(),
     };
     useSessionQueryMock.mockReturnValue({ data: session, isLoading: false, error: null });
     useWorkspacesQueryMock.mockReturnValue({ data: [], isLoading: false, error: null });
@@ -64,31 +87,12 @@ describe("WorkspaceLayout", () => {
 
     expect(screen.getByText(/create your first workspace/i)).toBeInTheDocument();
     const createButton = screen.getByRole("button", { name: /create workspace/i });
-    expect(createButton).toBeInTheDocument();
-
     await user.click(createButton);
     expect(screen.getByRole("dialog", { name: /create workspace/i })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: /cancel/i }));
-    expect(screen.queryByRole("dialog", { name: /create workspace/i })).not.toBeInTheDocument();
   });
 
   it("shows a restricted message when the user cannot create workspaces", () => {
-    const session: SessionEnvelope = {
-      user: {
-        user_id: "user-1",
-        email: "user@example.com",
-        role: "user",
-        is_active: true,
-        is_service_account: false,
-        display_name: "Regular User",
-        preferred_workspace_id: null,
-        permissions: [],
-      },
-      expires_at: new Date().toISOString(),
-      refresh_expires_at: new Date().toISOString(),
-    };
-    useSessionQueryMock.mockReturnValue({ data: session, isLoading: false, error: null });
+    useSessionQueryMock.mockReturnValue({ data: baseSession, isLoading: false, error: null });
     useWorkspacesQueryMock.mockReturnValue({ data: [], isLoading: false, error: null });
 
     render(<WorkspaceLayout />);
@@ -98,138 +102,75 @@ describe("WorkspaceLayout", () => {
     ).toBeInTheDocument();
   });
 
-  it("allows permitted users to start workspace creation when no workspaces exist", () => {
+  it("hides workspace creation for service accounts", () => {
     const session: SessionEnvelope = {
+      ...baseSession,
       user: {
-        user_id: "user-1",
-        email: "user@example.com",
-        role: "user",
-        is_active: true,
-        is_service_account: false,
-        display_name: "Regular User",
-        preferred_workspace_id: null,
-        permissions: ["workspaces:create"],
-      },
-      expires_at: new Date().toISOString(),
-      refresh_expires_at: new Date().toISOString(),
-    };
-    useSessionQueryMock.mockReturnValue({ data: session, isLoading: false, error: null });
-    useWorkspacesQueryMock.mockReturnValue({ data: [], isLoading: false, error: null });
-
-    render(<WorkspaceLayout />);
-
-    expect(screen.getByRole("button", { name: /create workspace/i })).toBeInTheDocument();
-  });
-
-  it("treats service accounts as read-only even if marked as admin", () => {
-    const session: SessionEnvelope = {
-      user: {
-        user_id: "service-1",
-        email: "svc@example.com",
-        role: "admin",
-        is_active: true,
+        ...baseSession.user,
         is_service_account: true,
-        preferred_workspace_id: null,
+        permissions: ["Workspaces.Create"],
       },
-      expires_at: new Date().toISOString(),
-      refresh_expires_at: new Date().toISOString(),
     };
     useSessionQueryMock.mockReturnValue({ data: session, isLoading: false, error: null });
     useWorkspacesQueryMock.mockReturnValue({ data: [], isLoading: false, error: null });
 
     render(<WorkspaceLayout />);
 
-    expect(
-      screen.getByText(/no workspaces are available for your account yet\. ask an administrator to grant access\./i),
-    ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /create workspace/i })).not.toBeInTheDocument();
   });
 
-  it("opens and closes the create workspace dialog from the top bar", async () => {
+  it("opens the dialog from the top bar for eligible users", async () => {
     const user = userEvent.setup();
     const session: SessionEnvelope = {
+      ...baseSession,
       user: {
-        user_id: "admin-1",
-        email: "admin@example.com",
-        role: "admin",
-        is_active: true,
-        is_service_account: false,
-        display_name: "Admin User",
-        preferred_workspace_id: null,
+        ...baseSession.user,
+        permissions: ["Workspaces.Create"],
       },
-      expires_at: new Date().toISOString(),
-      refresh_expires_at: new Date().toISOString(),
     };
     useSessionQueryMock.mockReturnValue({ data: session, isLoading: false, error: null });
     useWorkspacesQueryMock.mockReturnValue({
-      data: [
-        {
-          id: "workspace-1",
-          name: "Finance",
-          slug: "finance",
-          role: "owner",
-          permissions: ["workspace:members:manage"],
-          is_default: true,
-        },
-      ],
+      data: [workspace()],
       isLoading: false,
       error: null,
     });
 
     render(<WorkspaceLayout />);
 
-    expect(screen.queryByRole("dialog", { name: /create workspace/i })).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /new workspace/i }));
     expect(screen.getByRole("dialog", { name: /create workspace/i })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /cancel/i }));
-    expect(screen.queryByRole("dialog", { name: /create workspace/i })).not.toBeInTheDocument();
   });
 
   it("navigates when switching workspaces from the selector", async () => {
     const user = userEvent.setup();
-    const session: SessionEnvelope = {
-      user: {
-        user_id: "user-1",
-        email: "user@example.com",
-        role: "user",
-        is_active: true,
-        is_service_account: false,
-        display_name: "Regular User",
-        preferred_workspace_id: null,
-        permissions: [],
-      },
-      expires_at: new Date().toISOString(),
-      refresh_expires_at: new Date().toISOString(),
-    };
-    useSessionQueryMock.mockReturnValue({ data: session, isLoading: false, error: null });
+    useSessionQueryMock.mockReturnValue({ data: baseSession, isLoading: false, error: null });
     useWorkspacesQueryMock.mockReturnValue({
       data: [
-        {
-          id: "workspace-1",
-          name: "Finance",
-          slug: "finance",
-          role: "owner",
-          permissions: [],
-          is_default: true,
-        },
-        {
-          id: "workspace-2",
-          name: "Operations",
-          slug: "operations",
-          role: "member",
-          permissions: [],
-          is_default: false,
-        },
+        workspace({ id: "workspace-1", name: "Finance", roles: ["workspace-owner"] }),
+        workspace({ id: "workspace-2", name: "Operations", slug: "operations", roles: ["workspace-member"], is_default: false }),
       ],
       isLoading: false,
       error: null,
     });
 
     render(<WorkspaceLayout />);
-    navigateMock.mockClear();
 
     await user.selectOptions(screen.getByLabelText(/workspace/i), "workspace-2");
 
     expect(navigateMock).toHaveBeenCalledWith("/workspaces/workspace-2");
+  });
+
+  it("redirects to the workspace list when the route workspace is unknown", () => {
+    useSessionQueryMock.mockReturnValue({ data: baseSession, isLoading: false, error: null });
+    useWorkspacesQueryMock.mockReturnValue({
+      data: [workspace({ id: "workspace-1" })],
+      isLoading: false,
+      error: null,
+    });
+    useParamsMock.mockReturnValue({ workspaceId: "missing-workspace" });
+
+    render(<WorkspaceLayout />);
+
+    expect(navigateMock).toHaveBeenCalledWith("/workspaces", { replace: true });
   });
 });

--- a/frontend/src/features/workspaces/components/WorkspaceLayout.tsx
+++ b/frontend/src/features/workspaces/components/WorkspaceLayout.tsx
@@ -1,20 +1,101 @@
-import { useEffect, useState } from "react";
-import { Outlet, useNavigate, useParams } from "react-router-dom";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { NavLink, Outlet, useNavigate, useParams } from "react-router-dom";
 
 import type { SessionEnvelope, WorkspaceProfile } from "../../../shared/api/types";
 import { CreateWorkspaceForm } from "./CreateWorkspaceForm";
 import { useWorkspacesQuery } from "../hooks/useWorkspacesQuery";
 import { useSessionQuery } from "../../auth/hooks/useSessionQuery";
+import { RBAC } from "../../../shared/rbac/permissions";
+import { hasAnyPermission } from "../../../shared/rbac/utils";
+import { globalCan } from "../../../shared/rbac/can";
+
+export interface WorkspaceLayoutContext {
+  workspace?: WorkspaceProfile;
+}
+
+interface WorkspaceNavItem {
+  id: string;
+  label: string;
+  to: string;
+  end?: boolean;
+  requiredPermissions?: readonly string[];
+}
+
+const NAVIGATION: WorkspaceNavItem[] = [
+  { id: "overview", label: "Overview", to: ".", end: true },
+  {
+    id: "documents",
+    label: "Documents",
+    to: "documents",
+    requiredPermissions: [RBAC.Workspace.Documents.Read, RBAC.Workspace.Documents.ReadWrite],
+  },
+  {
+    id: "jobs",
+    label: "Jobs",
+    to: "jobs",
+    requiredPermissions: [RBAC.Workspace.Jobs.Read, RBAC.Workspace.Jobs.ReadWrite],
+  },
+  {
+    id: "configurations",
+    label: "Configurations",
+    to: "configurations",
+    requiredPermissions: [RBAC.Workspace.Configurations.Read, RBAC.Workspace.Configurations.ReadWrite],
+  },
+  {
+    id: "members",
+    label: "Members",
+    to: "members",
+    requiredPermissions: [RBAC.Workspace.Members.Read, RBAC.Workspace.Members.ReadWrite],
+  },
+  {
+    id: "roles",
+    label: "Roles",
+    to: "roles",
+    requiredPermissions: [RBAC.Workspace.Roles.Read, RBAC.Workspace.Roles.ReadWrite],
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    to: "settings",
+    requiredPermissions: [RBAC.Workspace.Settings.ReadWrite],
+  },
+];
 
 export function WorkspaceLayout() {
-  const { data, isLoading, error } = useWorkspacesQuery();
+  const { data: workspacesData, isLoading, error } = useWorkspacesQuery();
   const sessionQuery = useSessionQuery();
   const session = sessionQuery.data ?? null;
   const navigate = useNavigate();
   const params = useParams<{ workspaceId?: string }>();
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
 
-  const canCreateWorkspaces = canUserCreateWorkspaces(session ?? null);
+  const captureFocus = () => {
+    lastFocusedElementRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  };
+
+  const restoreFocus = () => {
+    const element = lastFocusedElementRef.current;
+    lastFocusedElementRef.current = null;
+    if (element) {
+      window.setTimeout(() => {
+        element.focus();
+      }, 0);
+    }
+  };
+
+  const openCreateWorkspaceDialog = () => {
+    captureFocus();
+    setIsCreateDialogOpen(true);
+  };
+
+  const closeCreateWorkspaceDialog = () => {
+    setIsCreateDialogOpen(false);
+    restoreFocus();
+  };
+
+  const canCreateWorkspaces = canUserCreateWorkspaces(session);
 
   if (isLoading || (sessionQuery.isLoading && typeof sessionQuery.data === "undefined")) {
     return (
@@ -46,30 +127,58 @@ export function WorkspaceLayout() {
     );
   }
 
-  const workspaces = data ?? [];
+  const workspaces = workspacesData ?? [];
   const hasWorkspaces = workspaces.length > 0;
   const showEmptyState = !hasWorkspaces;
 
-  const resolvedWorkspaceId =
-    params.workspaceId || session?.user.preferred_workspace_id || workspaces[0]?.id || undefined;
+  const preferredWorkspaceId = session?.user.preferred_workspace_id;
+  const fallbackWorkspaceId =
+    preferredWorkspaceId && workspaces.some((workspace) => workspace.id === preferredWorkspaceId)
+      ? preferredWorkspaceId
+      : workspaces[0]?.id;
+  const hasRouteWorkspace =
+    params.workspaceId && workspaces.some((workspace) => workspace.id === params.workspaceId);
+  const activeWorkspace = hasRouteWorkspace
+    ? workspaces.find((workspace) => workspace.id === params.workspaceId)
+    : fallbackWorkspaceId
+    ? workspaces.find((workspace) => workspace.id === fallbackWorkspaceId) ?? workspaces[0]
+    : workspaces[0];
+  const resolvedWorkspaceId = activeWorkspace?.id ?? undefined;
 
   useEffect(() => {
-    if (!params.workspaceId && resolvedWorkspaceId) {
+    if (!workspaces.length) {
+      return;
+    }
+
+    if (params.workspaceId) {
+      const exists = workspaces.some((workspace) => workspace.id === params.workspaceId);
+      if (!exists) {
+        navigate("/workspaces", { replace: true });
+      }
+      return;
+    }
+
+    if (resolvedWorkspaceId) {
       navigate(`/workspaces/${resolvedWorkspaceId}`, { replace: true });
     }
-  }, [params.workspaceId, resolvedWorkspaceId, navigate]);
+  }, [params.workspaceId, workspaces, resolvedWorkspaceId, navigate]);
 
-  const activeWorkspace = workspaces.find((workspace) => workspace.id === resolvedWorkspaceId) ?? workspaces[0];
+  const navigationItems = useMemo(() => {
+    const permissions = activeWorkspace?.permissions ?? [];
+    return NAVIGATION.filter(
+      (item) => !item.requiredPermissions || hasAnyPermission(permissions, item.requiredPermissions),
+    );
+  }, [activeWorkspace]);
 
   return (
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
       <WorkspaceTopBar
-        session={session ?? null}
+        session={session}
         workspaces={workspaces}
         activeWorkspaceId={activeWorkspace?.id}
         onSelectWorkspace={(workspaceId) => navigate(`/workspaces/${workspaceId}`)}
         canCreateWorkspaces={canCreateWorkspaces}
-        onCreateWorkspace={() => setIsCreateDialogOpen(true)}
+        onCreateWorkspace={openCreateWorkspaceDialog}
       />
       <div className="flex flex-1">
         <WorkspaceSidebar
@@ -81,14 +190,15 @@ export function WorkspaceLayout() {
           {showEmptyState ? (
             <WorkspaceEmptyState
               canCreateWorkspaces={canCreateWorkspaces}
-              onCreateWorkspace={() => setIsCreateDialogOpen(true)}
-              session={session ?? null}
+              onCreateWorkspace={openCreateWorkspaceDialog}
+              session={session}
             />
           ) : (
             <>
               <WorkspaceHeader workspace={activeWorkspace} />
+              <WorkspaceNavigation items={navigationItems} />
               <div className="flex-1 overflow-y-auto px-8 py-10">
-                <Outlet context={{ workspace: activeWorkspace }} />
+                <Outlet context={{ workspace: activeWorkspace } satisfies WorkspaceLayoutContext} />
               </div>
             </>
           )}
@@ -96,10 +206,11 @@ export function WorkspaceLayout() {
       </div>
       <CreateWorkspaceDialog
         open={isCreateDialogOpen}
-        onClose={() => setIsCreateDialogOpen(false)}
+        onClose={closeCreateWorkspaceDialog}
         onCreated={(workspace) => {
           setIsCreateDialogOpen(false);
           navigate(`/workspaces/${workspace.id}`);
+          restoreFocus();
         }}
       />
     </div>
@@ -108,20 +219,66 @@ export function WorkspaceLayout() {
 
 function WorkspaceHeader({ workspace }: { workspace?: WorkspaceProfile }) {
   const name = workspace?.name ?? "Workspace";
-  const roleLabel = workspace?.role === "owner" ? "Owner" : workspace?.role === "member" ? "Member" : undefined;
-  const subtitleParts = [roleLabel ? `Role: ${roleLabel}` : null, workspace?.slug ? `Slug: ${workspace.slug}` : null].filter(
-    Boolean,
-  );
-  const subtitle =
-    subtitleParts.length > 0 ? subtitleParts.join(" • ") : "Monitor extraction activity and review configuration details.";
+  const subtitleParts = [
+    workspace?.slug ? `Slug: ${workspace.slug}` : null,
+    workspace?.is_default ? "Default" : null,
+  ].filter(Boolean);
 
   return (
-    <header className="flex h-16 items-center justify-between border-b border-slate-900 bg-slate-950/70 px-8">
+    <header className="flex flex-col gap-2 border-b border-slate-900 bg-slate-950/70 px-8 py-5 md:flex-row md:items-center md:justify-between">
       <div>
         <h1 className="text-xl font-semibold text-slate-100">{name}</h1>
-        <p className="text-xs text-slate-500">{subtitle}</p>
+        <p className="text-xs text-slate-500">
+          {subtitleParts.length > 0
+            ? subtitleParts.join(" • ")
+            : "Monitor extraction activity, configure processing, and manage workspace access."}
+        </p>
       </div>
+      {workspace?.roles && workspace.roles.length > 0 && (
+        <ul className="flex flex-wrap items-center gap-2 text-xs text-slate-100">
+          {workspace.roles.map((role) => (
+            <li
+              key={role}
+              className="rounded border border-slate-800 bg-slate-950 px-2 py-1 uppercase tracking-wide text-slate-300"
+            >
+              {formatRoleSlug(role)}
+            </li>
+          ))}
+        </ul>
+      )}
     </header>
+  );
+}
+
+interface WorkspaceNavigationProps {
+  items: WorkspaceNavItem[];
+}
+
+function WorkspaceNavigation({ items }: WorkspaceNavigationProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav className="border-b border-slate-900 bg-slate-950/50 px-8">
+      <ul className="flex flex-wrap gap-3 py-3 text-sm text-slate-400">
+        {items.map((item) => (
+          <li key={item.id}>
+            <NavLink
+              to={item.to}
+              end={item.end}
+              className={({ isActive }) =>
+                `inline-flex items-center rounded px-3 py-2 font-medium transition ${
+                  isActive ? "bg-sky-500/20 text-sky-200" : "hover:bg-slate-900/80 hover:text-slate-200"
+                }`
+              }
+            >
+              {item.label}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 }
 
@@ -239,11 +396,7 @@ function WorkspaceSidebar({ workspaces, activeWorkspaceId, onSelectWorkspace }: 
               >
                 <div className="font-medium">{workspace.name}</div>
                 <div className="text-xs text-slate-500">
-                  {[
-                    workspace.role === "owner" ? "Owner" : "Member",
-                    workspace.slug,
-                    workspace.is_default ? "Default" : null,
-                  ]
+                  {[formatRoleList(workspace.roles), workspace.slug, workspace.is_default ? "Default" : null]
                     .filter(Boolean)
                     .join(" • ")}
                 </div>
@@ -263,13 +416,24 @@ interface CreateWorkspaceDialogProps {
 }
 
 function CreateWorkspaceDialog({ open, onClose, onCreated }: CreateWorkspaceDialogProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const descriptionId = useId();
+
   useEffect(() => {
     if (!open) {
       return;
     }
 
+    const focusTarget =
+      containerRef.current?.querySelector<HTMLElement>('[data-autofocus]') ??
+      containerRef.current?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+    focusTarget?.focus();
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
         onClose();
       }
     };
@@ -287,9 +451,12 @@ function CreateWorkspaceDialog({ open, onClose, onCreated }: CreateWorkspaceDial
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-6">
       <div
+        ref={containerRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="create-workspace-title"
+        aria-describedby={descriptionId}
+        tabIndex={-1}
         className="w-full max-w-lg rounded border border-slate-900 bg-slate-950 p-6 text-slate-100 shadow-xl"
       >
         <div className="flex items-start justify-between gap-4">
@@ -297,8 +464,8 @@ function CreateWorkspaceDialog({ open, onClose, onCreated }: CreateWorkspaceDial
             <h2 id="create-workspace-title" className="text-xl font-semibold">
               Create workspace
             </h2>
-            <p className="mt-1 text-sm text-slate-400">
-              Name your workspace. You can invite teammates from the workspace settings after creation.
+            <p id={descriptionId} className="mt-1 text-sm text-slate-400">
+              Name your workspace. Invite teammates from the Members tab after creation.
             </p>
           </div>
           <button
@@ -362,22 +529,26 @@ function WorkspaceEmptyState({ canCreateWorkspaces, onCreateWorkspace, session }
 }
 
 function canUserCreateWorkspaces(session: SessionEnvelope | null): boolean {
-  if (!session?.user || session.user.is_service_account) {
+  const user = session?.user;
+  if (!user || user.is_service_account) {
     return false;
   }
 
-  const normalizedRole = String(session.user.role).toLowerCase();
-  if (normalizedRole === "admin") {
-    return true;
+  const permissions = Array.isArray(user.permissions) ? user.permissions : [];
+  return globalCan.createWorkspaces(permissions);
+}
+
+function formatRoleSlug(slug: string): string {
+  return slug
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatRoleList(roles: string[]): string {
+  if (!roles || roles.length === 0) {
+    return "";
   }
 
-  const permissions = Array.isArray(session.user.permissions) ? session.user.permissions : [];
-  return permissions
-    .map((permission) => permission.toLowerCase())
-    .some((permission) =>
-      permission === "workspace:create" ||
-      permission === "workspaces:create" ||
-      permission.startsWith("workspace:create:") ||
-      permission.startsWith("workspaces:create:")
-    );
+  return roles.map(formatRoleSlug).join(", ");
 }

--- a/frontend/src/features/workspaces/hooks/useAddWorkspaceMemberMutation.ts
+++ b/frontend/src/features/workspaces/hooks/useAddWorkspaceMemberMutation.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { addWorkspaceMember } from "../api";
+import { workspaceKeys } from "./workspaceKeys";
+import type {
+  WorkspaceMember,
+  WorkspaceMemberCreatePayload,
+} from "../../../shared/api/types";
+
+export function useAddWorkspaceMemberMutation(workspaceId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<WorkspaceMember, unknown, WorkspaceMemberCreatePayload>({
+    mutationFn: (payload) => addWorkspaceMember(workspaceId, payload),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: workspaceKeys.members(workspaceId) });
+    },
+  });
+}

--- a/frontend/src/features/workspaces/hooks/useDocumentTypeQuery.ts
+++ b/frontend/src/features/workspaces/hooks/useDocumentTypeQuery.ts
@@ -6,7 +6,7 @@ import { workspaceKeys } from "./workspaceKeys";
 export function useDocumentTypeQuery(workspaceId: string, documentTypeId: string) {
   return useQuery({
     queryKey: workspaceKeys.documentType(workspaceId, documentTypeId),
-    queryFn: () => fetchDocumentType(workspaceId, documentTypeId),
+    queryFn: ({ signal }) => fetchDocumentType(workspaceId, documentTypeId, { signal }),
     staleTime: 30_000,
   });
 }

--- a/frontend/src/features/workspaces/hooks/useRemoveWorkspaceMemberMutation.ts
+++ b/frontend/src/features/workspaces/hooks/useRemoveWorkspaceMemberMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { removeWorkspaceMember } from "../api";
+import { workspaceKeys } from "./workspaceKeys";
+
+export function useRemoveWorkspaceMemberMutation(workspaceId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, unknown, string>({
+    mutationFn: (membershipId) => removeWorkspaceMember(workspaceId, membershipId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: workspaceKeys.members(workspaceId) });
+    },
+  });
+}

--- a/frontend/src/features/workspaces/hooks/useUpdateWorkspaceMemberRolesMutation.ts
+++ b/frontend/src/features/workspaces/hooks/useUpdateWorkspaceMemberRolesMutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { updateWorkspaceMemberRoles } from "../api";
+import { workspaceKeys } from "./workspaceKeys";
+import type {
+  WorkspaceMember,
+  WorkspaceMemberRolesUpdatePayload,
+} from "../../../shared/api/types";
+
+interface UpdateMemberRolesVariables {
+  membershipId: string;
+  payload: WorkspaceMemberRolesUpdatePayload;
+}
+
+export function useUpdateWorkspaceMemberRolesMutation(workspaceId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<WorkspaceMember, unknown, UpdateMemberRolesVariables>({
+    mutationFn: ({ membershipId, payload }) => updateWorkspaceMemberRoles(workspaceId, membershipId, payload),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: workspaceKeys.members(workspaceId) });
+    },
+  });
+}

--- a/frontend/src/features/workspaces/hooks/useWorkspaceMembersQuery.ts
+++ b/frontend/src/features/workspaces/hooks/useWorkspaceMembersQuery.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchWorkspaceMembers } from "../api";
+import { workspaceKeys } from "./workspaceKeys";
+import type { WorkspaceMember } from "../../../shared/api/types";
+
+export function useWorkspaceMembersQuery(workspaceId: string, enabled: boolean = true) {
+  return useQuery<WorkspaceMember[]>({
+    queryKey: workspaceKeys.members(workspaceId),
+    queryFn: ({ signal }) => fetchWorkspaceMembers(workspaceId, { signal }),
+    enabled,
+    staleTime: 15_000,
+  });
+}

--- a/frontend/src/features/workspaces/hooks/useWorkspaceRolesQuery.ts
+++ b/frontend/src/features/workspaces/hooks/useWorkspaceRolesQuery.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchWorkspaceRoles } from "../api";
+import { workspaceKeys } from "./workspaceKeys";
+import type { WorkspaceRoleDefinition } from "../../../shared/api/types";
+
+export function useWorkspaceRolesQuery(workspaceId: string, enabled: boolean = true) {
+  return useQuery<WorkspaceRoleDefinition[]>({
+    queryKey: workspaceKeys.roles(workspaceId),
+    queryFn: ({ signal }) => fetchWorkspaceRoles(workspaceId, { signal }),
+    enabled,
+    staleTime: 60_000,
+  });
+}

--- a/frontend/src/features/workspaces/hooks/useWorkspacesQuery.ts
+++ b/frontend/src/features/workspaces/hooks/useWorkspacesQuery.ts
@@ -7,7 +7,7 @@ import type { WorkspaceProfile } from "../../../shared/api/types";
 export function useWorkspacesQuery() {
   return useQuery<WorkspaceProfile[]>({
     queryKey: workspaceKeys.lists(),
-    queryFn: fetchWorkspaces,
+    queryFn: ({ signal }) => fetchWorkspaces({ signal }),
     staleTime: 30_000,
   });
 }

--- a/frontend/src/features/workspaces/hooks/workspaceKeys.ts
+++ b/frontend/src/features/workspaces/hooks/workspaceKeys.ts
@@ -4,4 +4,6 @@ export const workspaceKeys = {
   detail: (workspaceId: string) => [...workspaceKeys.all, "detail", workspaceId] as const,
   documentType: (workspaceId: string, documentTypeId: string) =>
     [...workspaceKeys.detail(workspaceId), "document-type", documentTypeId] as const,
+  members: (workspaceId: string) => [...workspaceKeys.detail(workspaceId), "members"] as const,
+  roles: (workspaceId: string) => [...workspaceKeys.detail(workspaceId), "roles"] as const,
 };

--- a/frontend/src/features/workspaces/routes/DocumentTypeRoute.tsx
+++ b/frontend/src/features/workspaces/routes/DocumentTypeRoute.tsx
@@ -2,18 +2,22 @@ import { useOutletContext, useParams } from "react-router-dom";
 
 import { useDocumentTypeQuery } from "../hooks/useDocumentTypeQuery";
 import { formatDateTime } from "../../../shared/dates";
-import type { WorkspaceProfile } from "../../../shared/api/types";
-
-interface WorkspaceOutletContext {
-  workspace?: WorkspaceProfile;
-}
+import type { WorkspaceLayoutContext } from "../components/WorkspaceLayout";
 
 export function DocumentTypeRoute() {
   const params = useParams<{ workspaceId: string; documentTypeId: string }>();
-  const { workspace } = useOutletContext<WorkspaceOutletContext>();
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
 
   const workspaceId = params.workspaceId ?? workspace?.id;
   const documentTypeId = params.documentTypeId;
+
+  if (!workspace) {
+    return (
+      <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+        Select a workspace document to view its details.
+      </div>
+    );
+  }
 
   if (!workspaceId || !documentTypeId) {
     return (

--- a/frontend/src/features/workspaces/routes/WorkspaceConfigurationsRoute.tsx
+++ b/frontend/src/features/workspaces/routes/WorkspaceConfigurationsRoute.tsx
@@ -1,0 +1,39 @@
+import { useOutletContext } from "react-router-dom";
+
+import type { WorkspaceLayoutContext } from "../components/WorkspaceLayout";
+import { RBAC } from "../../../shared/rbac/permissions";
+import { hasPermission } from "../../../shared/rbac/utils";
+
+export function WorkspaceConfigurationsRoute() {
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
+
+  if (!workspace) {
+    return (
+      <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+        Choose a workspace to view configuration history.
+      </div>
+    );
+  }
+
+  const canManage = hasPermission(workspace.permissions, RBAC.Workspace.Configurations.ReadWrite);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded border border-slate-800 bg-slate-900/60 p-6">
+        <h2 className="text-lg font-semibold text-slate-100">Configurations</h2>
+        <p className="mt-2 text-sm text-slate-300">
+          Active and draft configurations will surface here once configuration APIs are available.
+        </p>
+        {canManage ? (
+          <p className="mt-4 text-xs text-slate-400">
+            You'll be able to publish revisions and manage drafts when write APIs are deployed.
+          </p>
+        ) : (
+          <p className="mt-4 text-xs text-slate-500">
+            Managing configurations requires Workspace.Configurations.ReadWrite permissions.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/workspaces/routes/WorkspaceDocumentsRoute.tsx
+++ b/frontend/src/features/workspaces/routes/WorkspaceDocumentsRoute.tsx
@@ -1,0 +1,47 @@
+import { useOutletContext } from "react-router-dom";
+
+import type { WorkspaceLayoutContext } from "../components/WorkspaceLayout";
+import { RBAC } from "../../../shared/rbac/permissions";
+import { hasPermission } from "../../../shared/rbac/utils";
+
+export function WorkspaceDocumentsRoute() {
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
+
+  if (!workspace) {
+    return (
+      <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+        Choose a workspace to view documents.
+      </div>
+    );
+  }
+
+  const canUpload = hasPermission(workspace.permissions, RBAC.Workspace.Documents.ReadWrite);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded border border-slate-800 bg-slate-900/60 p-6">
+        <header className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Documents</h2>
+            <p className="text-sm text-slate-300">
+              Monitor uploaded files and review extraction status for workspace {workspace.name}.
+            </p>
+          </div>
+          {canUpload ? (
+            <button
+              type="button"
+              className="inline-flex items-center rounded bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-950"
+            >
+              Upload document
+            </button>
+          ) : (
+            <span className="text-xs text-slate-500">Upload access requires Workspace.Documents.ReadWrite.</span>
+          )}
+        </header>
+        <p className="mt-6 text-sm text-slate-400">
+          Document listings will appear here once the backend endpoints are wired up. For now, this area confirms your access level.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/workspaces/routes/WorkspaceJobsRoute.tsx
+++ b/frontend/src/features/workspaces/routes/WorkspaceJobsRoute.tsx
@@ -1,0 +1,39 @@
+import { useOutletContext } from "react-router-dom";
+
+import type { WorkspaceLayoutContext } from "../components/WorkspaceLayout";
+import { RBAC } from "../../../shared/rbac/permissions";
+import { hasPermission } from "../../../shared/rbac/utils";
+
+export function WorkspaceJobsRoute() {
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
+
+  if (!workspace) {
+    return (
+      <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+        Choose a workspace to review job history.
+      </div>
+    );
+  }
+
+  const canRetry = hasPermission(workspace.permissions, RBAC.Workspace.Jobs.ReadWrite);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded border border-slate-800 bg-slate-900/60 p-6">
+        <h2 className="text-lg font-semibold text-slate-100">Extraction jobs</h2>
+        <p className="mt-2 text-sm text-slate-300">
+          Job activity and retry controls will appear here once the orchestration endpoints are exposed.
+        </p>
+        {canRetry ? (
+          <p className="mt-4 text-xs text-slate-400">
+            You will be able to restart or cancel jobs once queue integration lands.
+          </p>
+        ) : (
+          <p className="mt-4 text-xs text-slate-500">
+            Retrying jobs requires Workspace.Jobs.ReadWrite permissions.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/workspaces/routes/WorkspaceMembersRoute.test.tsx
+++ b/frontend/src/features/workspaces/routes/WorkspaceMembersRoute.test.tsx
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+
+import type { WorkspaceMember, WorkspaceProfile, WorkspaceRoleDefinition } from "../../../shared/api/types";
+
+const useWorkspaceMembersQueryMock = vi.fn();
+const useWorkspaceRolesQueryMock = vi.fn();
+
+vi.mock("../hooks/useWorkspaceMembersQuery", () => ({
+  useWorkspaceMembersQuery: (...args: unknown[]) => useWorkspaceMembersQueryMock(...args),
+}));
+
+vi.mock("../hooks/useWorkspaceRolesQuery", () => ({
+  useWorkspaceRolesQuery: (...args: unknown[]) => useWorkspaceRolesQueryMock(...args),
+}));
+
+const mockWorkspace: WorkspaceProfile = {
+  id: "workspace-1",
+  name: "Finance",
+  slug: "finance",
+  roles: ["workspace-owner"],
+  permissions: ["Workspace.Members.Read", "Workspace.Members.ReadWrite", "Workspace.Roles.Read"],
+  is_default: false,
+};
+
+const useOutletContextMock = vi.fn(() => ({ workspace: mockWorkspace }));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useOutletContext: () => useOutletContextMock(),
+  };
+});
+
+import { WorkspaceMembersRoute } from "./WorkspaceMembersRoute";
+
+describe("WorkspaceMembersRoute", () => {
+  beforeEach(() => {
+    useWorkspaceMembersQueryMock.mockReset();
+    useWorkspaceRolesQueryMock.mockReset();
+    useOutletContextMock.mockReset();
+    useOutletContextMock.mockReturnValue({ workspace: mockWorkspace });
+  });
+
+  it("renders member details", () => {
+    const member: WorkspaceMember = {
+      id: "membership-1",
+      workspace_id: "workspace-1",
+      roles: ["workspace-owner"],
+      permissions: ["Workspace.Settings.ReadWrite"],
+      is_default: true,
+      user: {
+        user_id: "user-1",
+        email: "user@example.com",
+        role: "user",
+        is_active: true,
+        is_service_account: false,
+        display_name: "User One",
+      },
+    };
+    const roles: WorkspaceRoleDefinition[] = [
+      {
+        id: "role-1",
+        slug: "workspace-owner",
+        name: "Workspace owner",
+        description: null,
+        scope: "workspace",
+        workspace_id: "workspace-1",
+        permissions: ["Workspace.Settings.ReadWrite"],
+        is_system: true,
+        editable: false,
+      },
+    ];
+
+    useWorkspaceMembersQueryMock.mockReturnValue({ data: [member], isLoading: false, error: null });
+    useWorkspaceRolesQueryMock.mockReturnValue({ data: roles, isLoading: false, error: null });
+
+    useOutletContextMock.mockReturnValue({ workspace: mockWorkspace });
+
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceMembersRoute />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText(/user one/i)).toBeInTheDocument();
+    expect(screen.getByText(/workspace owner/i)).toBeInTheDocument();
+  });
+
+  it("focuses the first interactive control when opening the add member dialog and restores focus", async () => {
+    const user = userEvent.setup();
+    useWorkspaceMembersQueryMock.mockReturnValue({ data: [], isLoading: false, error: null });
+    useWorkspaceRolesQueryMock.mockReturnValue({
+      data: [
+        {
+          id: "role-1",
+          slug: "workspace-owner",
+          name: "Workspace owner",
+          description: null,
+          scope: "workspace",
+          workspace_id: "workspace-1",
+          permissions: ["Workspace.Settings.ReadWrite"],
+          is_system: true,
+          editable: false,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceMembersRoute />
+      </QueryClientProvider>,
+    );
+
+    const inviteButton = screen.getByRole("button", { name: /invite member/i });
+    inviteButton.focus();
+
+    await user.click(inviteButton);
+
+    const userIdField = await screen.findByLabelText(/user id/i);
+    expect(userIdField).toHaveFocus();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(inviteButton).toHaveFocus();
+    });
+  });
+});

--- a/frontend/src/features/workspaces/routes/WorkspaceMembersRoute.tsx
+++ b/frontend/src/features/workspaces/routes/WorkspaceMembersRoute.tsx
@@ -1,0 +1,736 @@
+import { type FormEvent, useEffect, useMemo, useRef, useState, useId } from "react";
+import { useOutletContext } from "react-router-dom";
+
+import { ApiError } from "../../../shared/api/client";
+import type { WorkspaceMember, WorkspaceRoleDefinition } from "../../../shared/api/types";
+import type { WorkspaceLayoutContext } from "../components/WorkspaceLayout";
+import { useAddWorkspaceMemberMutation } from "../hooks/useAddWorkspaceMemberMutation";
+import { useRemoveWorkspaceMemberMutation } from "../hooks/useRemoveWorkspaceMemberMutation";
+import { useUpdateWorkspaceMemberRolesMutation } from "../hooks/useUpdateWorkspaceMemberRolesMutation";
+import { useWorkspaceMembersQuery } from "../hooks/useWorkspaceMembersQuery";
+import { useWorkspaceRolesQuery } from "../hooks/useWorkspaceRolesQuery";
+import { workspaceCan } from "../../../shared/rbac/can";
+
+export function WorkspaceMembersRoute() {
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
+
+  if (!workspace) {
+    return (
+      <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+        Choose a workspace to view member access.
+      </div>
+    );
+  }
+
+  const workspaceId = workspace.id;
+  return <WorkspaceMembersContent workspaceId={workspaceId} workspacePermissions={workspace.permissions} />;
+}
+
+interface WorkspaceMembersContentProps {
+  workspaceId: string;
+  workspacePermissions: string[];
+}
+
+function WorkspaceMembersContent({ workspaceId, workspacePermissions }: WorkspaceMembersContentProps) {
+  const canManageMembers = workspaceCan.manageMembers(workspacePermissions);
+  const canReadRoles =
+    canManageMembers ||
+    workspaceCan.viewRoles(workspacePermissions) ||
+    workspaceCan.manageRoles(workspacePermissions);
+
+  const membersQuery = useWorkspaceMembersQuery(workspaceId, true);
+  const rolesQuery = useWorkspaceRolesQuery(workspaceId, canReadRoles);
+
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [editingMember, setEditingMember] = useState<WorkspaceMember | null>(null);
+  const [memberPendingRemoval, setMemberPendingRemoval] = useState<WorkspaceMember | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  const captureFocus = () => {
+    lastFocusedElementRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  };
+
+  const restoreFocus = () => {
+    const element = lastFocusedElementRef.current;
+    lastFocusedElementRef.current = null;
+    if (element) {
+      window.setTimeout(() => {
+        element.focus();
+      }, 0);
+    }
+  };
+
+  const addMemberMutation = useAddWorkspaceMemberMutation(workspaceId);
+  const updateRolesMutation = useUpdateWorkspaceMemberRolesMutation(workspaceId);
+  const removeMemberMutation = useRemoveWorkspaceMemberMutation(workspaceId);
+
+  const roleMap = useMemo(() => {
+    const roles = rolesQuery.data ?? [];
+    return new Map(roles.map((role) => [role.slug, role]));
+  }, [rolesQuery.data]);
+
+  const members = membersQuery.data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-100">Members</h2>
+          <p className="text-sm text-slate-300">
+            View workspace memberships and effective permissions provided by assigned roles.
+          </p>
+        </div>
+        {canManageMembers && (
+          <button
+            type="button"
+            onClick={() => {
+              captureFocus();
+              setActionError(null);
+              setIsAddDialogOpen(true);
+            }}
+            className="inline-flex items-center rounded bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-950"
+          >
+            + Invite member
+          </button>
+        )}
+      </header>
+
+      {membersQuery.isLoading ? (
+        <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">Loading members…</div>
+      ) : membersQuery.error ? (
+        <div className="rounded border border-rose-500/40 bg-rose-500/10 p-6 text-sm text-rose-100">
+          We were unable to load the members for this workspace.
+        </div>
+      ) : members.length === 0 ? (
+        <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+          No members have been added to this workspace yet.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded border border-slate-800">
+          <table className="min-w-full divide-y divide-slate-800 text-sm">
+            <thead className="bg-slate-900/80 text-left text-xs uppercase tracking-wide text-slate-400">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Member</th>
+                <th className="px-4 py-3 font-semibold">Roles</th>
+                <th className="px-4 py-3 font-semibold">Permissions</th>
+                <th className="px-4 py-3 font-semibold">Default</th>
+                {canManageMembers && <th className="px-4 py-3 font-semibold text-right">Actions</th>}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-900 bg-slate-950/60 text-slate-200">
+              {members.map((member) => (
+                <tr key={member.id}>
+                  <td className="px-4 py-3 align-top">
+                    <div className="font-medium text-slate-100">{member.user.display_name ?? member.user.email}</div>
+                    <div className="text-xs text-slate-500">{member.user.email}</div>
+                  </td>
+                  <td className="px-4 py-3 align-top">
+                    <RoleList member={member} roleMap={roleMap} />
+                  </td>
+                  <td className="px-4 py-3 align-top">
+                    {member.permissions.length > 0 ? (
+                      <ul className="flex flex-wrap gap-2 text-xs text-slate-200">
+                        {member.permissions.map((permission) => (
+                          <li key={permission} className="rounded border border-slate-800 bg-slate-900 px-2 py-1">
+                            {permission}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <span className="text-xs text-slate-500">—</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 align-top text-xs text-slate-300">{member.is_default ? "Yes" : "No"}</td>
+                  {canManageMembers && (
+                    <td className="px-4 py-3 align-top text-right">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            captureFocus();
+                            setActionError(null);
+                            setEditingMember(member);
+                          }}
+                          className="rounded border border-slate-700 px-2 py-1 text-xs font-medium text-slate-200 transition hover:border-slate-500 hover:text-slate-50"
+                        >
+                          Edit roles
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            captureFocus();
+                            setActionError(null);
+                            setMemberPendingRemoval(member);
+                          }}
+                          disabled={removeMemberMutation.isPending}
+                          className="rounded border border-transparent px-2 py-1 text-xs font-medium text-rose-200 transition hover:text-rose-100"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {actionError && (
+        <div className="rounded border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-100" role="alert">
+          {actionError}
+        </div>
+      )}
+
+      <AddMemberDialog
+        open={isAddDialogOpen}
+        onClose={() => {
+          setIsAddDialogOpen(false);
+          setActionError(null);
+          restoreFocus();
+        }}
+        roles={rolesQuery.data ?? []}
+        isSubmitting={addMemberMutation.isPending}
+        onSubmit={async (payload) => {
+          setActionError(null);
+          try {
+            await addMemberMutation.mutateAsync(payload);
+            setIsAddDialogOpen(false);
+            restoreFocus();
+          } catch (error) {
+            if (error instanceof ApiError) {
+              setActionError(error.problem?.detail ?? error.message);
+              return;
+            }
+            setActionError("We couldn't add the member. Try again.");
+          }
+        }}
+      />
+
+      <EditMemberRolesDialog
+        open={editingMember !== null}
+        member={editingMember}
+        roles={rolesQuery.data ?? []}
+        isSubmitting={updateRolesMutation.isPending}
+        onClose={() => {
+          setEditingMember(null);
+          setActionError(null);
+          restoreFocus();
+        }}
+        onSubmit={async (membershipId, roleIds) => {
+          setActionError(null);
+          try {
+            await updateRolesMutation.mutateAsync({ membershipId, payload: { role_ids: roleIds } });
+            setEditingMember(null);
+            restoreFocus();
+          } catch (error) {
+            if (error instanceof ApiError) {
+              setActionError(error.problem?.detail ?? error.message);
+              return;
+            }
+            setActionError("We couldn't update the member's roles. Try again.");
+          }
+        }}
+      />
+
+      <RemoveMemberDialog
+        open={memberPendingRemoval !== null}
+        member={memberPendingRemoval}
+        isSubmitting={removeMemberMutation.isPending}
+        onClose={() => {
+          setMemberPendingRemoval(null);
+          setActionError(null);
+          restoreFocus();
+        }}
+        onConfirm={async (membershipId) => {
+          setActionError(null);
+          try {
+            await removeMemberMutation.mutateAsync(membershipId);
+            setMemberPendingRemoval(null);
+            restoreFocus();
+          } catch (error) {
+            if (error instanceof ApiError) {
+              setActionError(error.problem?.detail ?? error.message);
+              return;
+            }
+            setActionError("We couldn't remove the member. Try again.");
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+function RoleList({
+  member,
+  roleMap,
+}: {
+  member: WorkspaceMember;
+  roleMap: Map<string, WorkspaceRoleDefinition>;
+}) {
+  if (member.roles.length === 0) {
+    return <span className="text-xs text-slate-500">workspace-member (default)</span>;
+  }
+
+  return (
+    <ul className="flex flex-wrap gap-2 text-xs text-slate-200">
+      {member.roles.map((role) => {
+        const definition = roleMap.get(role);
+        return (
+          <li key={role} className="rounded border border-slate-800 bg-slate-900 px-2 py-1">
+            {definition?.name ?? `Unknown role (${role})`}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+interface AddMemberDialogProps {
+  open: boolean;
+  onClose: () => void;
+  roles: WorkspaceRoleDefinition[];
+  isSubmitting: boolean;
+  onSubmit: (payload: { user_id: string; role_ids?: string[] }) => Promise<void>;
+}
+
+function AddMemberDialog({ open, onClose, roles, isSubmitting, onSubmit }: AddMemberDialogProps) {
+  const [userId, setUserId] = useState("");
+  const [selectedRoleIds, setSelectedRoleIds] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const dialogTitleId = useId();
+  const descriptionId = useId();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setUserId("");
+      setSelectedRoleIds([]);
+      setError(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const focusTarget =
+      containerRef.current?.querySelector<HTMLElement>('[data-autofocus]') ??
+      containerRef.current?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+    focusTarget?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedUserId = userId.trim();
+    if (!trimmedUserId) {
+      setError("Enter the user ID to invite.");
+      return;
+    }
+
+    try {
+      await onSubmit({ user_id: trimmedUserId, role_ids: selectedRoleIds.length > 0 ? selectedRoleIds : undefined });
+      setUserId("");
+      setSelectedRoleIds([]);
+      setError(null);
+    } catch {
+      // errors are surfaced by the caller via actionError
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-6">
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={dialogTitleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className="w-full max-w-lg rounded border border-slate-900 bg-slate-950 p-6 text-slate-100 shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 id={dialogTitleId} className="text-xl font-semibold">
+              Add workspace member
+            </h2>
+            <p id={descriptionId} className="mt-1 text-sm text-slate-400">
+              Provide the user's identifier and optional roles. Members inherit permissions from all assigned roles.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close add workspace member dialog"
+            className="rounded border border-transparent p-1 text-slate-400 transition hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-950"
+          >
+            <span aria-hidden>×</span>
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <div>
+            <label htmlFor="member-user-id" className="block text-xs font-semibold uppercase tracking-wide text-slate-400">
+              User ID
+            </label>
+            <input
+              id="member-user-id"
+              name="member-user-id"
+              type="text"
+              value={userId}
+              onChange={(event) => {
+                setUserId(event.target.value);
+                if (error) {
+                  setError(null);
+                }
+              }}
+              disabled={isSubmitting}
+              className="mt-2 w-full rounded border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400"
+              placeholder="usr_01h7x..."
+              data-autofocus="true"
+            />
+          </div>
+          <RoleChecklist
+            roles={roles}
+            selectedRoleIds={selectedRoleIds}
+            onChange={setSelectedRoleIds}
+            disabled={isSubmitting}
+          />
+          <p className="text-xs text-slate-500">
+            Leaving all roles unchecked assigns the default workspace-member role.
+          </p>
+          {error && (
+            <p className="text-sm text-rose-300" role="alert">
+              {error}
+            </p>
+          )}
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded border border-slate-700 px-3 py-2 text-sm font-medium text-slate-300 hover:border-slate-500 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center rounded bg-sky-500 px-3 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-sky-800 disabled:text-slate-400"
+            >
+              {isSubmitting ? "Adding…" : "Add member"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface EditMemberRolesDialogProps {
+  open: boolean;
+  member: WorkspaceMember | null;
+  roles: WorkspaceRoleDefinition[];
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (membershipId: string, roleIds: string[]) => Promise<void>;
+}
+
+function EditMemberRolesDialog({ open, member, roles, isSubmitting, onClose, onSubmit }: EditMemberRolesDialogProps) {
+  const [selectedRoleIds, setSelectedRoleIds] = useState<string[]>([]);
+  const dialogTitleId = useId();
+  const descriptionId = useId();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!member) {
+      setSelectedRoleIds([]);
+      return;
+    }
+
+    const availableRolesBySlug = new Map(roles.map((role) => [role.slug, role]));
+    const resolvedRoleIds = member.roles
+      .map((slug) => availableRolesBySlug.get(slug)?.id)
+      .filter((id): id is string => typeof id === "string");
+    setSelectedRoleIds(resolvedRoleIds);
+  }, [member, roles]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const checkbox = containerRef.current?.querySelector<HTMLInputElement>('input[type="checkbox"]:not([disabled])');
+    const focusTarget =
+      checkbox ??
+      containerRef.current?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+    focusTarget?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  if (!open || !member) {
+    return null;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await onSubmit(member.id, selectedRoleIds);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-6">
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={dialogTitleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className="w-full max-w-lg rounded border border-slate-900 bg-slate-950 p-6 text-slate-100 shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 id={dialogTitleId} className="text-xl font-semibold">
+              Edit member roles
+            </h2>
+            <p id={descriptionId} className="mt-1 text-sm text-slate-400">
+              Select the roles that apply to {member.user.display_name ?? member.user.email}. Removing all roles assigns the default workspace-member role.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close edit member roles dialog"
+            className="rounded border border-transparent p-1 text-slate-400 transition hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-950"
+          >
+            <span aria-hidden>×</span>
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <RoleChecklist
+            roles={roles}
+            selectedRoleIds={selectedRoleIds}
+            onChange={setSelectedRoleIds}
+            disabled={isSubmitting}
+          />
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="rounded border border-slate-700 px-3 py-2 text-sm font-medium text-slate-300 hover:border-slate-500 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center rounded bg-sky-500 px-3 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-sky-800 disabled:text-slate-400"
+            >
+              {isSubmitting ? "Saving…" : "Save changes"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface RemoveMemberDialogProps {
+  open: boolean;
+  member: WorkspaceMember | null;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onConfirm: (membershipId: string) => Promise<void>;
+}
+
+function RemoveMemberDialog({ open, member, isSubmitting, onClose, onConfirm }: RemoveMemberDialogProps) {
+  const dialogTitleId = useId();
+  const descriptionId = useId();
+  const containerRef = useRef<HTMLFormElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const focusTarget =
+      containerRef.current?.querySelector<HTMLElement>('[data-autofocus]') ??
+      containerRef.current?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+    focusTarget?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  if (!open || !member) {
+    return null;
+  }
+
+  const displayName = member.user.display_name ?? member.user.email;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await onConfirm(member.id);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-6">
+      <form
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={dialogTitleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className="w-full max-w-md rounded border border-slate-900 bg-slate-950 p-6 text-slate-100 shadow-xl"
+        onSubmit={handleSubmit}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 id={dialogTitleId} className="text-xl font-semibold">
+              Remove member
+            </h2>
+            <p id={descriptionId} className="mt-1 text-sm text-slate-400">
+              Removing {displayName} revokes their access to this workspace. You can re-invite them at any time.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close remove member dialog"
+            className="rounded border border-transparent p-1 text-slate-400 transition hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-950"
+          >
+            <span aria-hidden>×</span>
+          </button>
+        </div>
+        <div className="mt-6 space-y-4 text-sm text-slate-200">
+          <p>
+            {displayName} currently holds roles:{" "}
+            {member.roles.length > 0 ? member.roles.join(", ") : "workspace-member (default)"}.
+          </p>
+          <p className="text-xs text-slate-500">
+            Guardrails prevent removing the last governor, so this action may fail if they are the only remaining workspace administrator.
+          </p>
+        </div>
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="rounded border border-slate-700 px-3 py-2 text-sm font-medium text-slate-300 hover:border-slate-500 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            data-autofocus="true"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex items-center rounded bg-rose-500 px-3 py-2 text-sm font-semibold text-slate-950 transition hover:bg-rose-400 disabled:cursor-not-allowed disabled:bg-rose-900 disabled:text-rose-200"
+          >
+            {isSubmitting ? "Removing…" : "Remove member"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function RoleChecklist({
+  roles,
+  selectedRoleIds,
+  onChange,
+  disabled,
+}: {
+  roles: WorkspaceRoleDefinition[];
+  selectedRoleIds: string[];
+  onChange: (next: string[]) => void;
+  disabled?: boolean;
+}) {
+  if (roles.length === 0) {
+    return (
+      <p className="text-xs text-slate-500">
+        System roles are loading. The workspace-member role will be assigned by default.
+      </p>
+    );
+  }
+
+  return (
+    <fieldset className="space-y-3">
+      <legend className="text-xs font-semibold uppercase tracking-wide text-slate-400">Assign roles</legend>
+      {roles.map((role) => {
+        const checked = selectedRoleIds.includes(role.id);
+        return (
+          <label key={role.id} className="flex items-start gap-3 text-sm text-slate-200">
+            <input
+              type="checkbox"
+              className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-950 text-sky-500 focus:ring-sky-500"
+              checked={checked}
+              onChange={(event) => {
+                if (event.target.checked) {
+                  onChange([...selectedRoleIds, role.id]);
+                } else {
+                  onChange(selectedRoleIds.filter((id) => id !== role.id));
+                }
+              }}
+              disabled={disabled}
+            />
+            <div>
+              <div className="font-medium text-slate-100">{role.name}</div>
+              <div className="text-xs text-slate-500">
+                {role.is_system ? "System role" : "Custom role"}
+                {role.editable ? " • Editable" : " • Locked"}
+              </div>
+            </div>
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/frontend/src/features/workspaces/routes/WorkspaceOverviewRoute.tsx
+++ b/frontend/src/features/workspaces/routes/WorkspaceOverviewRoute.tsx
@@ -1,13 +1,9 @@
 import { useOutletContext } from "react-router-dom";
 
-import type { WorkspaceProfile } from "../../../shared/api/types";
-
-interface WorkspaceOutletContext {
-  workspace?: WorkspaceProfile;
-}
+import type { WorkspaceLayoutContext } from "../components/WorkspaceLayout";
 
 export function WorkspaceOverviewRoute() {
-  const { workspace } = useOutletContext<WorkspaceOutletContext>();
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
 
   if (!workspace) {
     return (
@@ -22,9 +18,7 @@ export function WorkspaceOverviewRoute() {
       <section className="rounded border border-slate-800 bg-slate-900/60 p-6">
         <header className="space-y-2">
           <h2 className="text-lg font-semibold text-slate-100">Workspace access</h2>
-          <p className="text-sm text-slate-300">
-            {workspace.role === "owner" ? "You are the owner of this workspace." : "You are a member of this workspace."}
-          </p>
+          <p className="text-sm text-slate-300">{describeRoles(workspace.roles)}</p>
         </header>
         <dl className="mt-4 grid gap-4 text-sm text-slate-300 md:grid-cols-2">
           <div>
@@ -54,10 +48,29 @@ export function WorkspaceOverviewRoute() {
       <section className="space-y-2 rounded border border-slate-800 bg-slate-900/60 p-6">
         <h3 className="text-lg font-semibold text-slate-100">Next steps</h3>
         <p className="text-sm text-slate-300">
-          Owners can invite teammates and configure document extraction once workspace management tools are available. For now,
-          use this area to review your access and confirm workspace details.
+          Use the navigation to explore documents, jobs, configurations, and member management based on your permissions.
+          Owners can configure the workspace and manage roles.
         </p>
       </section>
     </div>
   );
+}
+
+function describeRoles(roles: string[]): string {
+  if (!roles || roles.length === 0) {
+    return "You have read-only access to this workspace.";
+  }
+
+  const formatted = roles.map((role) =>
+    role
+      .split("-")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" "),
+  );
+
+  if (roles.includes("workspace-owner")) {
+    return `You are a workspace owner (${formatted.join(", ")}).`;
+  }
+
+  return `You are assigned to: ${formatted.join(", ")}.`;
 }

--- a/frontend/src/features/workspaces/routes/WorkspaceRolesRoute.tsx
+++ b/frontend/src/features/workspaces/routes/WorkspaceRolesRoute.tsx
@@ -1,0 +1,116 @@
+import { useOutletContext } from "react-router-dom";
+
+import type { WorkspaceLayoutContext } from "../components/WorkspaceLayout";
+import { useWorkspaceRolesQuery } from "../hooks/useWorkspaceRolesQuery";
+import { RBAC } from "../../../shared/rbac/permissions";
+import { hasPermission } from "../../../shared/rbac/utils";
+
+export function WorkspaceRolesRoute() {
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
+
+  if (!workspace) {
+    return (
+      <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+        Choose a workspace to review available roles.
+      </div>
+    );
+  }
+
+  const canManageRoles = hasPermission(workspace.permissions, RBAC.Workspace.Roles.ReadWrite);
+  const rolesQuery = useWorkspaceRolesQuery(workspace.id, true);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-lg font-semibold text-slate-100">Role catalog</h2>
+        <p className="text-sm text-slate-300">
+          Review system and custom roles assigned to members. Custom role management will be enabled once backend APIs are
+          available.
+        </p>
+      </header>
+
+      {rolesQuery.isLoading ? (
+        <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">Loading roles…</div>
+      ) : rolesQuery.error ? (
+        <div className="rounded border border-rose-500/40 bg-rose-500/10 p-6 text-sm text-rose-100">
+          We were unable to load roles for this workspace.
+        </div>
+      ) : rolesQuery.data && rolesQuery.data.length > 0 ? (
+        <ul className="space-y-4">
+          {rolesQuery.data.map((role) => (
+            <li key={role.id} className="rounded border border-slate-800 bg-slate-900/60 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-base font-semibold text-slate-100">{role.name}</h3>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">{role.slug}</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-xs">
+                  <span className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-slate-300">
+                    {role.scope === "global" ? "Global" : "Workspace"}
+                  </span>
+                  <span
+                    className={`rounded border px-2 py-1 ${
+                      role.is_system
+                        ? "border-sky-500/40 bg-sky-500/10 text-sky-200"
+                        : "border-emerald-500/40 bg-emerald-500/10 text-emerald-100"
+                    }`}
+                  >
+                    {role.is_system ? "System" : "Custom"}
+                  </span>
+                  <span
+                    className={`rounded border px-2 py-1 ${
+                      role.editable
+                        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-100"
+                        : "border-slate-700 bg-slate-900 text-slate-300"
+                    }`}
+                  >
+                    {role.editable ? "Editable" : "Locked"}
+                  </span>
+                </div>
+              </div>
+              {role.description && <p className="mt-3 text-sm text-slate-300">{role.description}</p>}
+              <div className="mt-4 space-y-2">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Permissions</h4>
+                {role.permissions.length > 0 ? (
+                  <ul className="flex flex-wrap gap-2 text-xs text-slate-200">
+                    {role.permissions.map((permission) => (
+                      <li key={permission} className="rounded border border-slate-800 bg-slate-950 px-2 py-1">
+                        {permission}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-slate-500">No permissions assigned yet.</p>
+                )}
+              </div>
+              {canManageRoles && (
+                <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-500">
+                  <button
+                    type="button"
+                    disabled
+                    className="cursor-not-allowed rounded border border-slate-800 bg-slate-900 px-3 py-2 font-medium text-slate-500"
+                    title="Custom role editing will be available once APIs ship."
+                  >
+                    Edit role
+                  </button>
+                  <button
+                    type="button"
+                    disabled
+                    className="cursor-not-allowed rounded border border-slate-800 bg-slate-900 px-3 py-2 font-medium text-slate-500"
+                    title="Role deletion will be enabled once backend support is added."
+                  >
+                    Delete role
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+          No roles are defined for this workspace yet.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/workspaces/routes/WorkspaceSettingsRoute.tsx
+++ b/frontend/src/features/workspaces/routes/WorkspaceSettingsRoute.tsx
@@ -1,0 +1,48 @@
+import { useOutletContext } from "react-router-dom";
+
+import type { WorkspaceLayoutContext } from "../components/WorkspaceLayout";
+import { RBAC } from "../../../shared/rbac/permissions";
+import { hasPermission } from "../../../shared/rbac/utils";
+
+export function WorkspaceSettingsRoute() {
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
+
+  if (!workspace) {
+    return (
+      <div className="rounded border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+        Choose a workspace to manage settings.
+      </div>
+    );
+  }
+
+  const canDeleteWorkspace = hasPermission(workspace.permissions, RBAC.Workspace.Delete);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded border border-slate-800 bg-slate-900/60 p-6">
+        <h2 className="text-lg font-semibold text-slate-100">General settings</h2>
+        <p className="mt-2 text-sm text-slate-300">
+          Workspace rename, slug management, and configuration controls will appear here once write APIs are available.
+        </p>
+      </section>
+      <section className="rounded border border-rose-500/40 bg-rose-500/10 p-6">
+        <h3 className="text-lg font-semibold text-rose-100">Danger zone</h3>
+        <p className="mt-2 text-sm text-rose-100/80">
+          Deleting a workspace permanently removes documents, jobs, and configuration history.
+        </p>
+        {canDeleteWorkspace ? (
+          <button
+            type="button"
+            disabled
+            className="mt-4 inline-flex items-center rounded border border-rose-500/60 bg-rose-500/20 px-4 py-2 text-sm font-semibold text-rose-100 opacity-70"
+            title="Workspace deletion will be wired up when the backend endpoint is ready."
+          >
+            Delete workspace
+          </button>
+        ) : (
+          <p className="mt-4 text-xs text-rose-200/80">Workspace.Delete permission is required to remove this workspace.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -115,6 +115,14 @@ export async function post<T>(path: string, body?: unknown, init?: ApiClientOpti
   });
 }
 
+export async function put<T>(path: string, body?: unknown, init?: ApiClientOptions) {
+  return apiClient.request<T>(path, {
+    method: "PUT",
+    body: body === undefined ? undefined : JSON.stringify(body),
+    ...init,
+  });
+}
+
 export async function del<T>(path: string, init?: ApiClientOptions) {
   return apiClient.request<T>(path, { method: "DELETE", ...init });
 }

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -64,15 +64,52 @@ export interface CreateWorkspacePayload {
   settings?: Record<string, unknown>;
 }
 
-export type WorkspaceRole = "member" | "owner";
-
 export interface WorkspaceProfile {
   id: string;
   name: string;
   slug: string;
-  role: WorkspaceRole;
+  roles: string[];
   permissions: string[];
   is_default: boolean;
+}
+
+export interface WorkspaceRoleDefinition {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  scope: "global" | "workspace";
+  workspace_id?: string | null;
+  permissions: string[];
+  is_system: boolean;
+  editable: boolean;
+}
+
+export interface WorkspaceMemberUser {
+  user_id: string;
+  email: string;
+  role: UserRole;
+  is_active: boolean;
+  is_service_account: boolean;
+  display_name?: string | null;
+}
+
+export interface WorkspaceMember {
+  id: string;
+  workspace_id: string;
+  roles: string[];
+  permissions: string[];
+  is_default: boolean;
+  user: WorkspaceMemberUser;
+}
+
+export interface WorkspaceMemberCreatePayload {
+  user_id: string;
+  role_ids?: string[];
+}
+
+export interface WorkspaceMemberRolesUpdatePayload {
+  role_ids: string[];
 }
 
 export interface DocumentTypeDetailResponse {

--- a/frontend/src/shared/rbac/AccessDenied.tsx
+++ b/frontend/src/shared/rbac/AccessDenied.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+interface AccessDeniedProps {
+  children?: ReactNode;
+}
+
+export function AccessDenied({ children }: AccessDeniedProps) {
+  return (
+    <div className="rounded border border-amber-500/40 bg-amber-500/10 p-6 text-sm text-amber-100">
+      {children ?? "You do not have permission to view this area."}
+    </div>
+  );
+}

--- a/frontend/src/shared/rbac/RequirePermission.test.tsx
+++ b/frontend/src/shared/rbac/RequirePermission.test.tsx
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { RequirePermission } from "./RequirePermission";
+import { AccessDenied } from "./AccessDenied";
+
+const useOutletContextMock = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useOutletContext: () => useOutletContextMock(),
+  };
+});
+
+describe("RequirePermission", () => {
+  beforeEach(() => {
+    useOutletContextMock.mockReset();
+  });
+
+  it("renders children when the workspace has at least one required permission", () => {
+    useOutletContextMock.mockReturnValue({ workspace: { permissions: ["Workspace.Members.Read"] } });
+
+    render(
+      <RequirePermission needed={["Workspace.Members.Read", "Workspace.Members.ReadWrite"]}>
+        <div>allowed</div>
+      </RequirePermission>,
+    );
+
+    expect(screen.getByText("allowed")).toBeInTheDocument();
+  });
+
+  it("renders the fallback when permissions are missing", () => {
+    useOutletContextMock.mockReturnValue({ workspace: { permissions: [] } });
+
+    render(
+      <RequirePermission
+        needed={["Workspace.Settings.ReadWrite"]}
+        fallback={<AccessDenied>You do not have permission.</AccessDenied>}
+      >
+        <div>allowed</div>
+      </RequirePermission>,
+    );
+
+    expect(screen.getByText(/you do not have permission\./i)).toBeInTheDocument();
+    expect(screen.queryByText("allowed")).not.toBeInTheDocument();
+  });
+
+  it("requires all permissions when mode is set to all", () => {
+    useOutletContextMock.mockReturnValue({ workspace: { permissions: ["Workspace.Members.Read"] } });
+
+    render(
+      <RequirePermission
+        needed={["Workspace.Members.Read", "Workspace.Members.ReadWrite"]}
+        mode="all"
+        fallback={<div>no access</div>}
+      >
+        <div>allowed</div>
+      </RequirePermission>,
+    );
+
+    expect(screen.getByText("no access")).toBeInTheDocument();
+    expect(screen.queryByText("allowed")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/rbac/RequirePermission.tsx
+++ b/frontend/src/shared/rbac/RequirePermission.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { useOutletContext } from "react-router-dom";
+
+import type { WorkspaceLayoutContext } from "../../features/workspaces/components/WorkspaceLayout";
+import { hasAnyPermission } from "./utils";
+
+interface RequirePermissionProps {
+  needed: string | readonly string[];
+  mode?: "any" | "all";
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+export function RequirePermission({ needed, mode = "any", children, fallback = null }: RequirePermissionProps) {
+  const { workspace } = useOutletContext<WorkspaceLayoutContext>();
+  const permissions = workspace?.permissions ?? [];
+  const required = Array.isArray(needed) ? needed : [needed];
+
+  const allowed =
+    required.length === 0 ||
+    (mode === "all"
+      ? required.every((permission) => permissions.includes(permission))
+      : hasAnyPermission(permissions, required));
+
+  if (!allowed) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/shared/rbac/can.ts
+++ b/frontend/src/shared/rbac/can.ts
@@ -1,0 +1,27 @@
+import { RBAC } from "./permissions";
+import { hasAnyPermission, hasPermission, type PermissionList } from "./utils";
+
+export const workspaceCan = {
+  viewDocuments: (permissions: PermissionList) =>
+    hasAnyPermission(permissions, [RBAC.Workspace.Documents.Read, RBAC.Workspace.Documents.ReadWrite]),
+  manageDocuments: (permissions: PermissionList) => hasPermission(permissions, RBAC.Workspace.Documents.ReadWrite),
+  viewJobs: (permissions: PermissionList) =>
+    hasAnyPermission(permissions, [RBAC.Workspace.Jobs.Read, RBAC.Workspace.Jobs.ReadWrite]),
+  manageJobs: (permissions: PermissionList) => hasPermission(permissions, RBAC.Workspace.Jobs.ReadWrite),
+  viewConfigurations: (permissions: PermissionList) =>
+    hasAnyPermission(permissions, [RBAC.Workspace.Configurations.Read, RBAC.Workspace.Configurations.ReadWrite]),
+  manageConfigurations: (permissions: PermissionList) => hasPermission(permissions, RBAC.Workspace.Configurations.ReadWrite),
+  viewMembers: (permissions: PermissionList) =>
+    hasAnyPermission(permissions, [RBAC.Workspace.Members.Read, RBAC.Workspace.Members.ReadWrite]),
+  manageMembers: (permissions: PermissionList) => hasPermission(permissions, RBAC.Workspace.Members.ReadWrite),
+  viewRoles: (permissions: PermissionList) =>
+    hasAnyPermission(permissions, [RBAC.Workspace.Roles.Read, RBAC.Workspace.Roles.ReadWrite]),
+  manageRoles: (permissions: PermissionList) => hasPermission(permissions, RBAC.Workspace.Roles.ReadWrite),
+  manageSettings: (permissions: PermissionList) => hasPermission(permissions, RBAC.Workspace.Settings.ReadWrite),
+  deleteWorkspace: (permissions: PermissionList) => hasPermission(permissions, RBAC.Workspace.Delete),
+};
+
+export const globalCan = {
+  createWorkspaces: (permissions: PermissionList) =>
+    hasAnyPermission(permissions, [RBAC.Global.Workspaces.Create, RBAC.Global.Workspaces.ReadWriteAll]),
+};

--- a/frontend/src/shared/rbac/permissions.ts
+++ b/frontend/src/shared/rbac/permissions.ts
@@ -1,0 +1,61 @@
+export const RBAC = {
+  Global: {
+    Workspaces: {
+      Create: "Workspaces.Create",
+      ReadAll: "Workspaces.Read.All",
+      ReadWriteAll: "Workspaces.ReadWrite.All",
+    },
+    Roles: {
+      ReadAll: "Roles.Read.All",
+      ReadWriteAll: "Roles.ReadWrite.All",
+    },
+    Users: {
+      ReadAll: "Users.Read.All",
+      ReadWriteAll: "Users.ReadWrite.All",
+      Manage: "Users.Manage",
+    },
+  },
+  Workspace: {
+    Read: "Workspace.Read",
+    Documents: {
+      Read: "Workspace.Documents.Read",
+      ReadWrite: "Workspace.Documents.ReadWrite",
+    },
+    Jobs: {
+      Read: "Workspace.Jobs.Read",
+      ReadWrite: "Workspace.Jobs.ReadWrite",
+    },
+    Configurations: {
+      Read: "Workspace.Configurations.Read",
+      ReadWrite: "Workspace.Configurations.ReadWrite",
+    },
+    Members: {
+      Read: "Workspace.Members.Read",
+      ReadWrite: "Workspace.Members.ReadWrite",
+    },
+    Roles: {
+      Read: "Workspace.Roles.Read",
+      ReadWrite: "Workspace.Roles.ReadWrite",
+    },
+    Settings: {
+      ReadWrite: "Workspace.Settings.ReadWrite",
+    },
+    Delete: "Workspace.Delete",
+  },
+} as const;
+
+export type WorkspacePermission = (typeof RBAC)["Workspace"][keyof typeof RBAC.Workspace] extends infer Group
+  ? Group extends string
+    ? Group
+    : Group extends Record<string, string>
+      ? Group[keyof Group]
+      : never
+  : never;
+
+export type GlobalPermission = (typeof RBAC)["Global"][keyof typeof RBAC.Global] extends infer Group
+  ? Group extends string
+    ? Group
+    : Group extends Record<string, string>
+      ? Group[keyof Group]
+      : never
+  : never;

--- a/frontend/src/shared/rbac/utils.ts
+++ b/frontend/src/shared/rbac/utils.ts
@@ -1,0 +1,21 @@
+export type PermissionList = readonly string[] | undefined | null;
+
+export function hasPermission(permissions: PermissionList, required: string): boolean {
+  if (!required) {
+    return true;
+  }
+
+  if (!permissions || permissions.length === 0) {
+    return false;
+  }
+
+  return permissions.includes(required);
+}
+
+export function hasAnyPermission(permissions: PermissionList, required: readonly string[]): boolean {
+  if (!permissions || permissions.length === 0) {
+    return false;
+  }
+
+  return required.some((permission) => permissions.includes(permission));
+}


### PR DESCRIPTION
## Summary
- streamline router RBAC gating with a reusable AccessDenied fallback and extend RequirePermission to support all-of checks
- rely on route-level guards by removing duplicate in-component permission checks and refining dialog accessibility, including Create Workspace
- add coverage for permission fallbacks and dialog focus restoration in the workspace members flow

## Testing
- npm test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6fa0f5128832e83a10cac46d129de