### PR TITLE
Address workflow review feedback

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,115 @@
+name: ci: container (ghcr)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: container-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-publish:
+    name: build-and-publish
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Read project version
+        id: version
+        run: |
+          python <<'PY'
+          import os
+          import re
+          import tomllib
+
+          with open('pyproject.toml', 'rb') as f:
+            data = tomllib.load(f)
+
+          version = (
+              data.get('project', {}).get('version')
+              or data.get('tool', {}).get('poetry', {}).get('version')
+          )
+
+          semver_pattern = re.compile(r'^[0-9]+(?:\.[0-9]+){2}(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$')
+          outputs = {
+              'version': version or ''
+          }
+
+          if version and semver_pattern.fullmatch(version):
+              repo = os.environ['GITHUB_REPOSITORY'].lower()
+              outputs['version_tag'] = f'ghcr.io/{repo}:v{version}'
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              for key, value in outputs.items():
+                  fh.write(f"{key}={value}\n")
+          PY
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,format=short,prefix=sha-
+          labels: |
+            type=raw,value=org.opencontainers.image.version=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
+
+      - name: Compose tags
+        id: tags
+        run: |
+          tags="${{ steps.meta.outputs.tags }}"
+          if [ -n "${{ steps.version.outputs.version_tag }}" ]; then
+            tags="${tags}"$'\n'"${{ steps.version.outputs.version_tag }}"
+          fi
+          {
+            echo 'tags<<EOF'
+            echo "$tags"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.ref == 'refs/heads/main' }}
+          platforms: linux/amd64
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summarize published image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "Published tags:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.tags.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- ensure the workflow uses Python 3.11 before reading the pyproject version
- reuse the REGISTRY_IMAGE env var for metadata and stamp the OCI version label when available
- add a publication summary so main pushes show the tags produced

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e7ff4484e0832e9e9c609932b8a9d9