### PR TITLE
fix: harden ghcr release automation

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Normalize image name
+        run: echo "REGISTRY_IMAGE=ghcr.io/${REPO,,}" >> "$GITHUB_ENV"
+        env:
+          REPO: ${{ github.repository }}
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -56,7 +61,11 @@ jobs:
               or data.get('tool', {}).get('poetry', {}).get('version')
           )
 
-          semver_pattern = re.compile(r'^[0-9]+(?:\.[0-9]+){2}(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$')
+          semver_pattern = re.compile(
+              r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+              r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+              r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+          )
           valid_version = version if version and semver_pattern.fullmatch(version) else ''
           outputs = {
               'version': valid_version
@@ -72,10 +81,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
+          flavor: |
+            latest=false
           tags: |
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short,prefix=sha-
-            type=raw,value=${{ env.REGISTRY_IMAGE }}:v${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
+            type=raw,value=v${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
           labels: |
             type=raw,value=org.opencontainers.image.version=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  changelog-release:
+    name: changelog-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Determine project version
+        id: versions
+        run: |
+          python <<'PY'
+          from __future__ import annotations
+
+          import os
+          import re
+          import subprocess
+          import tomllib
+
+          SEMVER_RE = re.compile(
+              r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+              r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+              r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+          )
+
+          def version_for_ref(ref: str) -> str:
+              try:
+                  output = subprocess.check_output(["git", "show", f"{ref}:pyproject.toml"], text=True)
+              except subprocess.CalledProcessError:
+                  return ""
+
+              data = tomllib.loads(output)
+              return data.get("project", {}).get("version", "")
+
+          current = version_for_ref("HEAD")
+          is_semver = "true" if current and SEMVER_RE.fullmatch(current) else "false"
+
+          tag = f"v{current}" if current else ""
+          try:
+              subprocess.check_call(["git", "rev-parse", "--verify", tag], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+          except subprocess.CalledProcessError:
+              tag_exists = "false"
+          else:
+              tag_exists = "true"
+
+          outputs = {
+              "version": current,
+              "is_semver": is_semver,
+              "tag": tag,
+              "tag_exists": tag_exists,
+          }
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              for key, value in outputs.items():
+                  fh.write(f"{key}={value}\n")
+          PY
+
+      - name: Extract changelog entry
+        id: changelog
+        if: steps.versions.outputs.is_semver == 'true' && steps.versions.outputs.tag_exists == 'false'
+        env:
+          RELEASE_TAG: ${{ steps.versions.outputs.tag }}
+        run: |
+          python <<'PY'
+          from __future__ import annotations
+
+          import os
+          import re
+          from pathlib import Path
+
+          changelog_path = Path("CHANGELOG.md")
+          if not changelog_path.is_file():
+              raise SystemExit("CHANGELOG.md is required to publish release notes")
+
+          tag = os.environ["RELEASE_TAG"]
+          changelog = changelog_path.read_text(encoding="utf-8")
+
+          pattern = re.compile(rf"## \[{re.escape(tag)}\] - [^\n]+\n(?P<body>.*?)(?=\n## \[|$)", re.S)
+          match = pattern.search(changelog)
+          if not match:
+              raise SystemExit(f"Unable to find changelog entry for {tag}")
+
+          notes = match.group("body").strip() or "_No notable changes._"
+
+          output_path = Path("release-notes.md")
+          output_path.write_text(notes + "\n", encoding="utf-8")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write("notes<<EOF\n")
+              fh.write(notes)
+              fh.write("\nEOF\n")
+          PY
+
+      - name: Create GitHub release
+        if: steps.versions.outputs.is_semver == 'true' && steps.versions.outputs.tag_exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.versions.outputs.tag }}
+          name: ${{ steps.versions.outputs.tag }}
+          body: ${{ steps.changelog.outputs.notes }}
+          draft: false
+          prerelease: false
+
+      - name: Summarize release
+        if: steps.versions.outputs.is_semver == 'true' && steps.versions.outputs.tag_exists == 'false'
+        run: |
+          {
+            echo "## Release" >> "$GITHUB_STEP_SUMMARY";
+            echo "- Tag: ${{ steps.versions.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY";
+          }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,15 @@ Run the quality gates appropriate for the scope of your change set.
 
 ---
 
+## CHANGELOG expectations
+
+- Maintain `CHANGELOG.md` using the [Keep a Changelog](https://keepachangelog.com/) structure already seeded in the repo.
+- Update the `## [Unreleased]` section whenever you ship a behaviour change, workflow tweak, or documentation update that users or operators should know about. Examples include API changes, CLI flags, release automation adjustments, and notable bug fixes.
+- File entries under the appropriate subsection (`### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`). Add the subsection if it does not yet exist beneath `## [Unreleased]`.
+- Use short, imperative bullet points ("Add", "Fix", "Document") that describe the effect of the change—not the git diff.
+- Only promote `## [Unreleased]` to a dated release when explicitly instructed. Use `scripts/finalize_changelog.py` to roll the unreleased notes into a tagged version and regenerate the empty `Unreleased` skeleton.
+- Never manually duplicate, rename, or otherwise "roll" the `Unreleased` heading—running `scripts/finalize_changelog.py` automatically moves the section into the new release and restores a fresh `Unreleased` template.
+
 ## Guiding Principle
 
 > **Consistency, clarity, and pragmatism beat cleverness.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Placeholder for upcoming changes.
+
+## [v0.1.0] - 2025-10-09
+
+### Added
+- Initial release of ADE with the FastAPI backend, CLI utilities, and frontend build pipeline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thanks for contributing to ADE! Keep changes focused and deterministic so deployments remain predictable.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for every commit. The `type(scope): subject` format keeps automation predictable and helps with changelog generation. Examples:
+
+- `feat(api): add job retry endpoint`
+- `fix(docs): correct admin CLI flag`
+- `chore(ci): refresh docker cache`
+
+## Pull requests
+
+Keep pull requests small and scoped. Describe the behaviour change, testing performed, and any follow-up work in the PR description. Update relevant docs, including the changelog, whenever behaviour changes.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ Guides now live under the [`docs/`](docs/README.md) directory:
 - [Admin Guide](docs/admin-guide/README.md) – deployment, configuration, and operational building blocks.
 - [Reference glossary](docs/reference/glossary.md) – shared terminology across API payloads and database entities.
 
+## Versioning, releases, and Docker images
+
+ADE's published container images are built from `main` and hosted on GitHub Container Registry (GHCR) under `ghcr.io/<org>/automatic-data-extractor`.
+
+- The FastAPI application version is defined once in [`pyproject.toml`](pyproject.toml) and must follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Pull requests trigger the Docker build to ensure the image continues to compile.
+- Merges to `main` authenticate to GHCR, reuse the build cache, and push three tags:
+  - `main` – the latest successful build from the default branch.
+  - `sha-<short>` – the short commit SHA for traceability.
+  - `vX.Y.Z` – emitted only when `project.version` is a valid semantic version.
+
+### Cutting a release
+
+1. Bump `project.version` in [`pyproject.toml`](pyproject.toml).
+2. Add notes beneath the `## [Unreleased]` heading in [`CHANGELOG.md`](CHANGELOG.md).
+3. Run `python scripts/finalize_changelog.py` to promote the unreleased section to the new `vX.Y.Z` entry. The script resets the "Unreleased" stub for the next iteration.
+4. Commit the version, changelog, and related code changes using [Conventional Commits](CONTRIBUTING.md#commit-messages).
+5. Open a pull request. Once it merges, the container workflow will publish the updated image to GHCR.
+
 ## Quickstart (local)
 
 ### Get set up
@@ -136,8 +155,8 @@ Shared infrastructure lives under [`app/core`](app/core) (logging, middleware, s
 
 Uploaded files and the SQLite database are stored beneath the [`var/`](var) directory by default. Override locations with the `ADE_STORAGE_DATA_DIR`, `ADE_DATABASE_DSN`, or `ADE_STORAGE_DOCUMENTS_DIR` environment variables when deploying to production systems.
 
-> **TODO**
-> Publish the official Docker image to GitHub Container Registry and update the admin guide once the frontend onboarding flow ships.
+> **Note**
+> Automated GHCR publishing now runs from the `main` branch. Update the admin guide with downstream deployment steps once the frontend onboarding flow ships.
 
 ## Frontend readiness
 

--- a/scripts/finalize_changelog.py
+++ b/scripts/finalize_changelog.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Promote the Unreleased changelog section to a tagged release.
+
+The script reads ``CHANGELOG.md`` in Keep a Changelog format, moves the
+"Unreleased" section under a new ``vX.Y.Z`` heading, and restores a stub
+Unreleased template for future entries. The release version defaults to the
+``project.version`` field in ``pyproject.toml``.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError as exc:  # pragma: no cover - dependency missing
+        raise SystemExit(
+            "Python 3.11+ or the 'tomli' package is required to parse pyproject.toml"
+        ) from exc
+
+CHANGELOG_PATH = Path("CHANGELOG.md")
+PYPROJECT_PATH = Path("pyproject.toml")
+UNRELEASED_TEMPLATE = (
+    "## [Unreleased]\n\n"
+    "### Added\n"
+    "- Placeholder for upcoming changes.\n\n"
+)
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+def read_project_version() -> str:
+    if not PYPROJECT_PATH.is_file():
+        raise SystemExit("pyproject.toml is required but was not found")
+
+    with PYPROJECT_PATH.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    version = data.get("project", {}).get("version")
+    if not version:
+        raise SystemExit("project.version is required in pyproject.toml")
+
+    return version
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert the changelog's Unreleased section into a tagged release."
+    )
+    parser.add_argument(
+        "--version",
+        help="Release version (defaults to project.version)",
+    )
+    parser.add_argument(
+        "--date",
+        help="Release date in YYYY-MM-DD (defaults to today in UTC)",
+    )
+    return parser.parse_args()
+
+
+def ensure_semver(version: str) -> str:
+    raw = version.lstrip("v")
+    if not SEMVER_RE.fullmatch(raw):
+        raise SystemExit(f"{version!r} is not a valid semantic version")
+    return f"v{raw}"
+
+
+def read_unreleased_block(changelog: str) -> tuple[str, str, str]:
+    pattern = re.compile(r"## \[Unreleased\]\n(?P<body>.*?)(?=\n## \[|\Z)", re.S)
+    match = pattern.search(changelog)
+    if not match:
+        raise SystemExit("Could not find an '## [Unreleased]' section in CHANGELOG.md")
+
+    start, end = match.span()
+    body = match.group("body").strip("\n")
+    before = changelog[:start]
+    after = changelog[end:]
+    return before, body, after
+
+
+def main() -> None:
+    args = parse_args()
+    version = ensure_semver(args.version or read_project_version())
+
+    if args.date:
+        try:
+            release_date = dt.date.fromisoformat(args.date)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise SystemExit(f"Invalid date {args.date!r}: {exc}")
+    else:
+        release_date = dt.datetime.utcnow().date()
+
+    if not CHANGELOG_PATH.is_file():
+        raise SystemExit("CHANGELOG.md does not exist")
+
+    changelog_text = CHANGELOG_PATH.read_text(encoding="utf-8")
+    before, body, after = read_unreleased_block(changelog_text)
+
+    release_body = body.strip()
+    if not release_body or release_body == "### Added\n- Placeholder for upcoming changes.":
+        release_body = "_No notable changes._"
+
+    release_section = (
+        f"## [{version}] - {release_date.isoformat()}\n\n"
+        f"{release_body.rstrip()}\n\n"
+    )
+
+    updated = before + UNRELEASED_TEMPLATE + release_section + after.lstrip("\n")
+    CHANGELOG_PATH.write_text(updated, encoding="utf-8")
+    print(f"Promoted Unreleased to {version} ({release_date.isoformat()})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Keep a Changelog file, CONTRIBUTING note, and a helper script to finalize release notes
- update the container workflow to publish `main`, `sha-<short>`, and semantic version tags without redundant prefixes, with normalized GHCR names, seeded registry environment variables, and consistent SemVer parsing
- add documentation and an optional release workflow that creates GitHub Releases from the changelog when the version changes, now guarded by concurrency and tag existence checks
- allow the changelog script to run on Python versions prior to 3.11 by falling back to `tomli`
- document CHANGELOG update expectations directly in the agent playbook so future changes keep release notes current

## Testing
- python -m compileall scripts/finalize_changelog.py

------
https://chatgpt.com/codex/tasks/task_e_68e80f4a154c832e87ba003c37c26f11