### PR TITLE
Streamline documents route layout with drag-and-drop uploads

### DIFF
--- a/frontend/src/app/routes/DocumentsRoute.tsx
+++ b/frontend/src/app/routes/DocumentsRoute.tsx
@@ -1,408 +1,205 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import type { ChangeEvent, ReactNode, RefObject } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ChangeEvent, DragEvent, ReactNode } from "react";
 import clsx from "clsx";
 
+import { useSession } from "../../features/auth/context/SessionContext";
 import { useWorkspaceContext } from "../../features/workspaces/context/WorkspaceContext";
 import { useWorkspaceDocumentsQuery } from "../../features/documents/hooks/useWorkspaceDocumentsQuery";
 import { useUploadDocumentsMutation } from "../../features/documents/hooks/useUploadDocumentsMutation";
 import { useDeleteDocumentsMutation } from "../../features/documents/hooks/useDeleteDocumentsMutation";
 import { downloadWorkspaceDocument } from "../../features/documents/api";
-import type { WorkspaceDocumentSummary } from "../../shared/types/documents";
-import { PageState } from "../components/PageState";
-import { Alert, Button, Input } from "../../ui";
 import { useWorkspaceChrome } from "../workspaces/WorkspaceChromeContext";
+import type { WorkspaceDocumentSummary } from "../../shared/types/documents";
+import type { SessionUser } from "../../shared/types/auth";
+import { PageState } from "../components/PageState";
+import { Alert, Button } from "../../ui";
 import { trackEvent } from "../../shared/telemetry/events";
 import { ApiError } from "../../shared/api/client";
 
-const PAGE_SIZE = 50;
-
-const SUPPORTED_FILE_EXTENSIONS = new Set([
-  ".pdf",
-  ".csv",
-  ".tsv",
-  ".xls",
-  ".xlsx",
-  ".xlsm",
-  ".xlsb",
-]);
-
-const SUPPORTED_FILE_TYPES_LABEL = "PDF, CSV, TSV, XLS, XLSX, XLSM, XLSB";
-
-const STATUS_OPTIONS = [
-  { value: "all", label: "All" },
-  { value: "inbox", label: "Inbox" },
-  { value: "processing", label: "Processing" },
-  { value: "completed", label: "Completed" },
-  { value: "failed", label: "Failed" },
-  { value: "archived", label: "Archived" },
+const OWNER_FILTER_OPTIONS = [
+  { value: "mine", label: "My Documents" },
+  { value: "all", label: "All Documents" },
 ] as const;
 
-type DocumentStatus = (typeof STATUS_OPTIONS)[number]["value"];
+const SUPPORTED_FILE_EXTENSIONS = [".pdf", ".csv", ".tsv", ".xls", ".xlsx", ".xlsm", ".xlsb"] as const;
+const SUPPORTED_FILE_EXTENSION_SET = new Set(
+  SUPPORTED_FILE_EXTENSIONS.map((value) => value.toLowerCase()),
+);
+const SUPPORTED_FILE_TYPES_LABEL = "PDF, CSV, TSV, XLS, XLSX, XLSM, XLSB";
 
-const STATUS_RANK: Record<Exclude<DocumentStatus, "all">, number> = {
-  inbox: 0,
-  processing: 1,
-  completed: 2,
-  failed: 3,
-  archived: 4,
-};
-
-type DocumentAction = "retry" | "archive" | "delete" | "download";
-
-interface ActionFeedback {
+interface FeedbackState {
   readonly tone: "info" | "success" | "warning" | "danger";
   readonly message: string;
 }
 
-type DocumentSortField = "uploaded" | "name" | "status";
-type DocumentSortDirection = "asc" | "desc";
+type OwnerFilter = (typeof OWNER_FILTER_OPTIONS)[number]["value"];
 
-interface DocumentSort {
-  readonly field: DocumentSortField;
-  readonly direction: DocumentSortDirection;
-}
+type DocumentStatus = "inbox" | "processing" | "completed" | "failed" | "archived";
 
-interface DocumentLastRun {
-  readonly result: string;
-  readonly timestamp: string | null;
-}
-
-interface DocumentViewModel extends WorkspaceDocumentSummary {
-  readonly status: DocumentStatus;
-  readonly source: string;
-  readonly uploader: string;
-  readonly tags: readonly string[];
-  readonly fileType: string;
-  readonly uploadedAtDate: Date;
-  readonly lastRun: DocumentLastRun;
-}
-
-interface PendingUploadItem {
+interface DocumentItem {
   readonly id: string;
   readonly name: string;
-  readonly size: number;
+  readonly status: DocumentStatus;
+  readonly source: string;
+  readonly tags: readonly string[];
+  readonly uploadedAt: Date;
+  readonly byteSize: number;
+  readonly contentType: string | null;
+  readonly uploaderName: string;
+  readonly uploaderId: string | null;
+  readonly uploaderEmail: string | null;
+  readonly lastRunLabel: string;
+  readonly lastRunAt: Date | null;
+  readonly metadata: Record<string, unknown>;
+  readonly summary: WorkspaceDocumentSummary;
 }
-
-const STATUS_BADGES: Record<DocumentStatus, string> = {
-  all: "bg-slate-100 text-slate-700",
-  inbox: "bg-indigo-100 text-indigo-700",
-  processing: "bg-amber-100 text-amber-800",
-  completed: "bg-emerald-100 text-emerald-700",
-  failed: "bg-danger-100 text-danger-700",
-  archived: "bg-slate-200 text-slate-700",
-};
-
-const DEFAULT_SORT: DocumentSort = { field: "uploaded", direction: "desc" };
 
 export function DocumentsRoute() {
   const { workspace } = useWorkspaceContext();
+  const { user: currentUser } = useSession();
+
   const documentsQuery = useWorkspaceDocumentsQuery(workspace.id);
-  const uploadDocumentsMutation = useUploadDocumentsMutation(workspace.id);
-  const deleteDocumentsMutation = useDeleteDocumentsMutation(workspace.id);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const { openInspector, closeInspector } = useWorkspaceChrome();
+  const uploadDocuments = useUploadDocumentsMutation(workspace.id);
+  const deleteDocuments = useDeleteDocumentsMutation(workspace.id);
+  const { openInspector } = useWorkspaceChrome();
 
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  const filterAnchorRef = useRef<HTMLButtonElement>(null);
-  const uploadInputRef = useRef<HTMLInputElement>(null);
-  const dragCounterRef = useRef(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragDepthRef = useRef(0);
 
-  const [filtersOpen, setFiltersOpen] = useState(false);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [activeDocumentId, setActiveDocumentId] = useState<string | null>(null);
-  const [actionFeedback, setActionFeedback] = useState<ActionFeedback | null>(null);
-  const [downloadingDocumentId, setDownloadingDocumentId] = useState<string | null>(null);
-  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
-  const [pendingUploads, setPendingUploads] = useState<PendingUploadItem[]>([]);
-
-  const rawStatus = (searchParams.get("status") ?? "all").toLowerCase();
-  const status: DocumentStatus = STATUS_OPTIONS.some((option) => option.value === rawStatus)
-    ? (rawStatus as DocumentStatus)
-    : "all";
-  const viewMode = searchParams.get("view") === "list" ? "list" : "grid";
-  const searchQuery = searchParams.get("q") ?? "";
-  const sortParam = searchParams.get("sort");
-  const sort = useMemo(() => parseSort(sortParam), [sortParam]);
-  const page = parsePage(searchParams.get("page"));
-  const selectedDocumentId = searchParams.get("document");
-
-  const filters = {
-    source: sanitize(searchParams.get("source")),
-    uploader: sanitize(searchParams.get("uploader")),
-    tag: sanitize(searchParams.get("tag")),
-    fileType: sanitize(searchParams.get("type")),
-    from: sanitize(searchParams.get("from")),
-    to: sanitize(searchParams.get("to")),
-  };
+  const [ownerFilter, setOwnerFilter] = useState<OwnerFilter>("mine");
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
 
   useEffect(() => {
-    if (!actionFeedback || typeof window === "undefined") {
+    if (!currentUser?.user_id && ownerFilter === "mine") {
+      setOwnerFilter("all");
+    }
+  }, [currentUser?.user_id, ownerFilter]);
+
+  useEffect(() => {
+    if (!feedback || typeof window === "undefined") {
       return;
     }
-    const timeout = window.setTimeout(() => setActionFeedback(null), 6000);
-    return () => window.clearTimeout(timeout);
-  }, [actionFeedback]);
+    const timer = window.setTimeout(() => setFeedback(null), 6000);
+    return () => window.clearTimeout(timer);
+  }, [feedback]);
 
-  const documents = useMemo(() => {
-    return (documentsQuery.data ?? []).map((document) => buildDocumentViewModel(document));
-  }, [documentsQuery.data]);
-
-  useEffect(() => {
-    setSelectedIds((current) => {
-      if (current.size === 0) {
-        return current;
-      }
-      const next = new Set(Array.from(current).filter((id) => documents.some((document) => document.id === id)));
-      if (next.size === current.size) {
-        return current;
-      }
-      return next;
-    });
-  }, [documents]);
-
-  const activeDocument = useMemo(
-    () => documents.find((document) => document.id === selectedDocumentId) ?? null,
-    [documents, selectedDocumentId],
+  const documents = useMemo<readonly DocumentItem[]>(
+    () => (documentsQuery.data ?? []).map((document) => buildDocumentItem(document)),
+    [documentsQuery.data],
   );
 
-  const filteredDocuments = useMemo(() => {
-    const fromDate = parseDateFilter(filters.from, "start");
-    const toDate = parseDateFilter(filters.to, "end");
-    const query = searchQuery.trim().toLowerCase();
-    return documents.filter((document) => {
-      if (status !== "all" && document.status !== status) {
-        return false;
-      }
-      if (filters.source && document.source !== filters.source) {
-        return false;
-      }
-      if (filters.uploader && document.uploader !== filters.uploader) {
-        return false;
-      }
-      if (filters.fileType && document.fileType !== filters.fileType) {
-        return false;
-      }
-      if (filters.tag && !document.tags.includes(filters.tag)) {
-        return false;
-      }
-      if (fromDate && document.uploadedAtDate < fromDate) {
-        return false;
-      }
-      if (toDate && document.uploadedAtDate > toDate) {
-        return false;
-      }
-      if (query.length > 0) {
-        const target = [document.name, document.source, document.uploader, ...document.tags]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase();
-        if (!target.includes(query)) {
-          return false;
-        }
-      }
-      return true;
-    });
-  }, [documents, filters, searchQuery, status]);
+  const visibleDocuments = useMemo(() => {
+    const list = ownerFilter === "mine"
+      ? documents.filter((document) => belongsToCurrentUser(document, currentUser))
+      : documents;
 
-  const sortedDocuments = useMemo(
-    () => sortDocuments(filteredDocuments, sort),
-    [filteredDocuments, sort],
-  );
-
-  const totalPages = Math.max(1, Math.ceil(sortedDocuments.length / PAGE_SIZE));
-  const safePage = Math.min(Math.max(page, 1), totalPages);
-
-  useEffect(() => {
-    if (safePage !== page) {
-      setSearchParams((params) => {
-        if (safePage === 1) {
-          params.delete("page");
-        } else {
-          params.set("page", safePage.toString());
-        }
-        return params;
-      });
-    }
-  }, [page, safePage, setSearchParams]);
-
-  const pagedDocuments = useMemo(
-    () =>
-      sortedDocuments.slice(
-        (safePage - 1) * PAGE_SIZE,
-        (safePage - 1) * PAGE_SIZE + PAGE_SIZE,
-      ),
-    [safePage, sortedDocuments],
-  );
-
-  useEffect(() => {
-    setSelectedIds(new Set());
-  }, [safePage]);
-
-  const statusCounts = useMemo(() => {
-    const counts = new Map<DocumentStatus, number>();
-    STATUS_OPTIONS.forEach((option) => counts.set(option.value, 0));
-    counts.set("all", documents.length);
-    for (const document of documents) {
-      counts.set(document.status, (counts.get(document.status) ?? 0) + 1);
-    }
-    return counts;
-  }, [documents]);
-
-  const sourceOptions = useMemo(
-    () => uniqueValues(documents.map((document) => document.source)),
-    [documents],
-  );
-  const uploaderOptions = useMemo(
-    () => uniqueValues(documents.map((document) => document.uploader)),
-    [documents],
-  );
-  const tagOptions = useMemo(
-    () => uniqueValues(documents.flatMap((document) => document.tags)),
-    [documents],
-  );
-  const fileTypeOptions = useMemo(
-    () => uniqueValues(documents.map((document) => document.fileType)),
-    [documents],
-  );
+    return [...list].sort(sortDocumentsByUploadedAt);
+  }, [documents, ownerFilter, currentUser]);
 
   const hasDocuments = documents.length > 0;
-  const hasFilteredDocuments = filteredDocuments.length > 0;
-  const filterCount = [filters.source, filters.uploader, filters.tag, filters.fileType, filters.from, filters.to]
-    .filter((value) => Boolean(value && value.length > 0)).length;
+  const hasVisibleDocuments = visibleDocuments.length > 0;
 
-  const isUploading = uploadDocumentsMutation.isPending;
-  const isDeleting = deleteDocumentsMutation.isPending;
-
-  const dropOverlay = (
-    <DocumentDropOverlay isVisible={isDraggingFiles} isUploading={isUploading} />
-  );
-
-  const uploadProgressPanel = (
-    <UploadProgressPanel files={pendingUploads} isUploading={isUploading} />
-  );
-
-  const allSelected = pagedDocuments.length > 0 && pagedDocuments.every((document) => selectedIds.has(document.id));
-  const someSelected = pagedDocuments.some((document) => selectedIds.has(document.id));
-  const selectedCount = selectedIds.size;
-
-  const openDocument = useCallback(
-    (documentId: string) => {
-      trackDocumentAction("open", workspace.id, documentId);
-      setSearchParams((params) => {
-        params.set("document", documentId);
-        return params;
-      });
-    },
-    [setSearchParams, workspace.id],
-  );
-
-  const notifyComingSoon = useCallback(
-    (action: string, message: string, documentId?: string) => {
-      trackDocumentAction(action, workspace.id, documentId);
-      setActionFeedback({ tone: "info", message });
+  const handleOwnerFilterChange = useCallback(
+    (value: OwnerFilter) => {
+      setOwnerFilter(value);
+      trackDocumentsEvent("filter_owner", workspace.id, { owner: value });
     },
     [workspace.id],
   );
 
+  const handleUploadButtonClick = useCallback(() => {
+    setFeedback(null);
+    fileInputRef.current?.click();
+    trackDocumentsEvent("start_upload", workspace.id);
+  }, [workspace.id]);
+
   const handleFilesSelected = useCallback(
-    async (incomingFiles: readonly File[]) => {
-      if (!incomingFiles || incomingFiles.length === 0) {
+    async (files: readonly File[]) => {
+      if (!files.length) {
         return;
       }
 
-      if (uploadDocumentsMutation.isPending) {
-        setActionFeedback({
-          tone: "info",
-          message: "Upload in progress. Wait for it to finish before adding more files.",
-        });
-        return;
-      }
-
-      const { supported, rejected } = partitionSupportedFiles(incomingFiles);
-      if (supported.length === 0) {
-        setActionFeedback({
+      const { accepted, rejected } = partitionSupportedFiles(files);
+      if (accepted.length === 0) {
+        setFeedback({
           tone: "warning",
           message: `No supported files detected. Supported types: ${SUPPORTED_FILE_TYPES_LABEL}.`,
         });
         return;
       }
 
-      setActionFeedback(null);
-
-      const uploads = supported.map((file, index) => ({
-        id: makeUploadTrackerId(file, index),
-        name: file.name,
-        size: file.size,
-      }));
-      const uploadIdsByIndex = new Map<number, string>(
-        uploads.map((upload, index) => [index, upload.id]),
-      );
-
-      setPendingUploads(uploads);
+      setFeedback(null);
 
       try {
-        const uploaded = await uploadDocumentsMutation.mutateAsync({
-          files: supported,
-          onProgress: ({ index }) => {
-            const completedId = uploadIdsByIndex.get(index);
-            if (!completedId) {
-              return;
-            }
-            setPendingUploads((current) =>
-              current.filter((item) => item.id !== completedId),
-            );
-          },
+        const uploaded = await uploadDocuments.mutateAsync({ files: accepted });
+        const count = uploaded.length;
+        const label = count === 1 ? accepted[0]?.name ?? "Document" : `${count} documents`;
+        const skipped = rejected.length
+          ? ` ${rejected.length} file${rejected.length === 1 ? "" : "s"} skipped (unsupported type).`
+          : "";
+        setFeedback({
+          tone: "success",
+          message: `${label} uploaded.${skipped}`,
         });
-        setSelectedIds(new Set());
-        setActiveDocumentId(null);
-
-        if (uploaded.length === 1) {
-          trackDocumentAction("upload", workspace.id, uploaded[0]?.id);
-        } else {
-          trackDocumentAction("bulk_upload", workspace.id);
-        }
-
-        let message =
-          uploaded.length <= 1
-            ? `${supported[0]?.name ?? "Document"} uploaded.`
-            : `${uploaded.length} documents uploaded.`;
-
-        if (rejected > 0) {
-          message = `${message} ${rejected} file${rejected === 1 ? "" : "s"} skipped (unsupported type).`;
-        }
-
-        setActionFeedback({ tone: "success", message });
+        trackDocumentsEvent(count === 1 ? "upload" : "bulk_upload", workspace.id, {
+          documentId: uploaded[0]?.id,
+          count,
+        });
       } catch (error) {
-        setActionFeedback({
+        setFeedback({
           tone: "danger",
           message: resolveApiErrorMessage(error, "Unable to upload documents. Try again."),
         });
-      } finally {
-        setPendingUploads([]);
       }
     },
-    [uploadDocumentsMutation, workspace.id],
+    [uploadDocuments, workspace.id],
   );
 
-  const handleUploadButton = useCallback(() => {
-    setActionFeedback(null);
-    trackDocumentAction("upload", workspace.id);
-    uploadInputRef.current?.click();
-  }, [workspace.id, uploadInputRef]);
-
-  const handleUploadInputChange = useCallback(
+  const handleFileInputChange = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
-      const fileList = event.target.files;
-      const files = fileList ? Array.from(fileList) : [];
+      const files = event.target.files ? Array.from(event.target.files) : [];
       event.target.value = "";
+      if (!files.length) {
+        return;
+      }
+      await handleFilesSelected(files);
+    },
+    [handleFilesSelected],
+  );
+
+  const handleDragEnter = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    dragDepthRef.current += 1;
+    if (!isDragging) {
+      setIsDragging(true);
+    }
+  }, [isDragging]);
+
+  const handleDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) {
+      setIsDragging(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const handleDrop = useCallback(
+    async (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDragging(false);
+      dragDepthRef.current = 0;
+      const files = extractFilesFromDataTransfer(event.dataTransfer);
       if (files.length === 0) {
         return;
       }
@@ -411,637 +208,419 @@ export function DocumentsRoute() {
     [handleFilesSelected],
   );
 
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    function hasFiles(event: DragEvent) {
-      return Array.from(event.dataTransfer?.types ?? []).includes("Files");
-    }
-
-    const handleDragEnter = (event: DragEvent) => {
-      if (!hasFiles(event)) {
-        return;
-      }
-      event.preventDefault();
-      dragCounterRef.current += 1;
-      setIsDraggingFiles(true);
-    };
-
-    const handleDragOver = (event: DragEvent) => {
-      if (!hasFiles(event)) {
-        return;
-      }
-      event.preventDefault();
-      if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = "copy";
-      }
-    };
-
-    const handleDragLeave = (event: DragEvent) => {
-      if (!hasFiles(event)) {
-        return;
-      }
-      event.preventDefault();
-      dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
-      if (dragCounterRef.current === 0) {
-        setIsDraggingFiles(false);
-      }
-    };
-
-    const handleDrop = (event: DragEvent) => {
-      if (!hasFiles(event)) {
-        return;
-      }
-      event.preventDefault();
-      dragCounterRef.current = 0;
-      setIsDraggingFiles(false);
-      const files = event.dataTransfer?.files;
-      if (files && files.length > 0) {
-        void handleFilesSelected(Array.from(files));
-      }
-    };
-
-    const handleWindowBlur = () => {
-      dragCounterRef.current = 0;
-      setIsDraggingFiles(false);
-    };
-
-    window.addEventListener("dragenter", handleDragEnter);
-    window.addEventListener("dragover", handleDragOver);
-    window.addEventListener("dragleave", handleDragLeave);
-    window.addEventListener("drop", handleDrop);
-    window.addEventListener("blur", handleWindowBlur);
-
-    return () => {
-      window.removeEventListener("dragenter", handleDragEnter);
-      window.removeEventListener("dragover", handleDragOver);
-      window.removeEventListener("dragleave", handleDragLeave);
-      window.removeEventListener("drop", handleDrop);
-      window.removeEventListener("blur", handleWindowBlur);
-    };
-  }, [handleFilesSelected]);
-
-  const handleDeleteDocuments = useCallback(
-    async (documentIds: readonly string[]) => {
-      if (documentIds.length === 0) {
-        return;
-      }
-      setActionFeedback(null);
+  const handleDownload = useCallback(
+    async (document: DocumentItem) => {
       try {
-        await deleteDocumentsMutation.mutateAsync(documentIds);
-        setSelectedIds((current) => {
-          const next = new Set(current);
-          documentIds.forEach((id) => next.delete(id));
-          return next;
-        });
-        setActiveDocumentId((current) => (current && documentIds.includes(current) ? null : current));
-        if (selectedDocumentId && documentIds.includes(selectedDocumentId)) {
-          clearDocumentSelection(setSearchParams);
-        }
-        const action = documentIds.length === 1 ? "delete" : "bulk_delete";
-        trackDocumentAction(action, workspace.id, documentIds.length === 1 ? documentIds[0] : undefined);
-        const message =
-          documentIds.length === 1 ? "Document deleted." : `${documentIds.length} documents deleted.`;
-        setActionFeedback({ tone: "success", message });
-      } catch (error) {
-        setActionFeedback({
-          tone: "danger",
-          message: resolveApiErrorMessage(error, "Unable to delete documents. Try again."),
-        });
-      }
-    },
-    [deleteDocumentsMutation, selectedDocumentId, setSearchParams, workspace.id],
-  );
-
-  const handleDownloadDocument = useCallback(
-    async (documentId: string) => {
-      setActionFeedback(null);
-      setDownloadingDocumentId(documentId);
-      try {
-        const { blob, filename } = await downloadWorkspaceDocument(workspace.id, documentId);
+        setFeedback(null);
+        setDownloadingId(document.id);
+        const { blob, filename } = await downloadWorkspaceDocument(workspace.id, document.id);
         triggerBrowserDownload(blob, filename);
-        trackDocumentAction("download", workspace.id, documentId);
+        trackDocumentsEvent("download", workspace.id, { documentId: document.id });
       } catch (error) {
-        setActionFeedback({
+        setFeedback({
           tone: "danger",
           message: resolveApiErrorMessage(error, "Unable to download document. Try again."),
         });
       } finally {
-        setDownloadingDocumentId((current) => (current === documentId ? null : current));
+        setDownloadingId(null);
       }
     },
     [workspace.id],
   );
 
-  const handleDocumentAction = useCallback(
-    (document: DocumentViewModel, action: DocumentAction) => {
-      switch (action) {
-        case "retry":
-          notifyComingSoon("retry", "Document reprocessing will be available soon.", document.id);
-          break;
-        case "archive":
-          notifyComingSoon("archive", "Archiving is coming soon.", document.id);
-          break;
-        case "delete":
-          void handleDeleteDocuments([document.id]);
-          break;
-        case "download":
-          void handleDownloadDocument(document.id);
-          break;
-      }
-    },
-    [handleDeleteDocuments, handleDownloadDocument, notifyComingSoon],
-  );
-
-  const handleBulkRetry = useCallback(() => {
-    if (selectedCount === 0) {
-      return;
-    }
-    notifyComingSoon("bulk_retry", "Bulk retry is coming soon.");
-  }, [notifyComingSoon, selectedCount]);
-
-  const handleBulkArchive = useCallback(() => {
-    if (selectedCount === 0) {
-      return;
-    }
-    notifyComingSoon("bulk_archive", "Bulk archive is coming soon.");
-  }, [notifyComingSoon, selectedCount]);
-
-  const handleBulkDelete = useCallback(() => {
-    if (selectedCount === 0) {
-      return;
-    }
-    void handleDeleteDocuments(Array.from(selectedIds));
-  }, [handleDeleteDocuments, selectedCount, selectedIds]);
-
-  useEffect(() => {
-    if (!selectedDocumentId) {
-      closeInspector();
-      return;
-    }
-    if (!activeDocument) {
-      if (!documentsQuery.isLoading && !documentsQuery.isFetching) {
-        clearDocumentSelection(setSearchParams);
-      }
-      return;
-    }
-    setActiveDocumentId(selectedDocumentId);
-    const cleanup = () => clearDocumentSelection(setSearchParams);
-    openInspector({
-      title: activeDocument.name,
-      content: (
-        <DocumentInspector
-          document={activeDocument}
-          onRetry={() => notifyComingSoon("retry", "Document reprocessing will be available soon.", activeDocument.id)}
-          onOpenRuns={() => notifyComingSoon("open_runs", "Run history will land in a future update.", activeDocument.id)}
-          onDownload={() => handleDownloadDocument(activeDocument.id)}
-          isDownloading={downloadingDocumentId === activeDocument.id}
-        />
-      ),
-      onClose: cleanup,
-    });
-  }, [
-    activeDocument,
-    closeInspector,
-    downloadingDocumentId,
-    handleDownloadDocument,
-    documentsQuery.isFetching,
-    documentsQuery.isLoading,
-    notifyComingSoon,
-    openInspector,
-    selectedDocumentId,
-    setSearchParams,
-    workspace.id,
-  ]);
-
-  useEffect(() => {
-    function handleKeydown(event: KeyboardEvent) {
-      if (event.key === "/" && !event.defaultPrevented) {
-        const target = event.target as HTMLElement | null;
-        if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+  const handleDelete = useCallback(
+    async (document: DocumentItem) => {
+      if (typeof window !== "undefined") {
+        const confirmed = window.confirm(`Delete ${document.name}? This action cannot be undone.`);
+        if (!confirmed) {
           return;
         }
-        event.preventDefault();
-        searchInputRef.current?.focus();
       }
-      if (event.key === "Enter" && !event.defaultPrevented && activeDocumentId) {
-        if (!selectedDocumentId) {
-          const exists = documents.some((document) => document.id === activeDocumentId);
-          if (exists) {
-            event.preventDefault();
-            openDocument(activeDocumentId);
-          }
-        }
+
+      try {
+        setFeedback(null);
+        setDeletingId(document.id);
+        await deleteDocuments.mutateAsync([document.id]);
+        setFeedback({ tone: "success", message: "Document deleted." });
+        trackDocumentsEvent("delete", workspace.id, { documentId: document.id });
+      } catch (error) {
+        setFeedback({
+          tone: "danger",
+          message: resolveApiErrorMessage(error, "Unable to delete document. Try again."),
+        });
+      } finally {
+        setDeletingId(null);
       }
-    }
-    window.addEventListener("keydown", handleKeydown);
-    return () => window.removeEventListener("keydown", handleKeydown);
-  }, [activeDocumentId, documents, openDocument, selectedDocumentId]);
-
-  const handleStatusChange = useCallback(
-    (nextStatus: DocumentStatus) => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        params.set("status", nextStatus);
-        params.delete("page");
-        params.delete("document");
-        return params;
-      });
     },
-    [setSearchParams],
+    [deleteDocuments, workspace.id],
   );
 
-  const handleViewChange = useCallback(
-    (nextView: "grid" | "list") => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        params.set("view", nextView);
-        return params;
+  const handleInspect = useCallback(
+    (document: DocumentItem) => {
+      openInspector({
+        title: document.name,
+        content: <DocumentDetails document={document} />,
       });
+      trackDocumentsEvent("view_details", workspace.id, { documentId: document.id });
     },
-    [setSearchParams],
-  );
-
-  const handleSortChange = useCallback(
-    (field: DocumentSortField) => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        const current = parseSort(params.get("sort"));
-        const direction: DocumentSortDirection =
-          current.field === field && current.direction === "desc" ? "asc" : "desc";
-        const next = encodeSort({ field, direction });
-        if (next === encodeSort(DEFAULT_SORT)) {
-          params.delete("sort");
-        } else {
-          params.set("sort", next);
-        }
-        params.delete("page");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleFilterChange = useCallback(
-    (key: keyof typeof filters, value: string) => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        const paramKey = key === "fileType" ? "type" : key;
-        if (value) {
-          params.set(paramKey, value);
-        } else {
-          params.delete(paramKey);
-        }
-        params.delete("page");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleDateFilterChange = useCallback(
-    (key: "from" | "to", value: string) => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        if (value) {
-          params.set(key, value);
-        } else {
-          params.delete(key);
-        }
-        params.delete("page");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleClearFilters = useCallback(() => {
-    setActionFeedback(null);
-    setSearchParams((params) => {
-      params.delete("source");
-      params.delete("uploader");
-      params.delete("tag");
-      params.delete("type");
-      params.delete("from");
-      params.delete("to");
-      params.delete("q");
-      params.set("status", "all");
-      params.delete("page");
-      params.delete("document");
-      params.delete("sort");
-      return params;
-    });
-  }, [setSearchParams]);
-
-  const handleSearchChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        if (value.trim().length > 0) {
-          params.set("q", value);
-        } else {
-          params.delete("q");
-        }
-        params.delete("page");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleSearchClear = useCallback(() => {
-    setActionFeedback(null);
-    setSearchParams((params) => {
-      params.delete("q");
-      params.delete("page");
-      return params;
-    });
-  }, [setSearchParams]);
-
-  const handleToggleSelection = useCallback((documentId: string, selected: boolean) => {
-    setSelectedIds((current) => {
-      const next = new Set(current);
-      if (selected) {
-        next.add(documentId);
-      } else {
-        next.delete(documentId);
-      }
-      return next;
-    });
-  }, []);
-
-  const handleSelectAll = useCallback(
-    (checked: boolean) => {
-      setSelectedIds((current) => {
-        const next = new Set(current);
-        for (const document of pagedDocuments) {
-          if (checked) {
-            next.add(document.id);
-          } else {
-            next.delete(document.id);
-          }
-        }
-        return next;
-      });
-    },
-    [pagedDocuments],
+    [openInspector, workspace.id],
   );
 
   if (documentsQuery.isLoading) {
     return (
-      <>
-        {dropOverlay}
-        {uploadProgressPanel}
-        <PageState title="Loading documents" variant="loading" />
-      </>
+      <PageState
+        title="Loading documents"
+        description="Fetching workspace documents."
+        variant="loading"
+      />
     );
   }
 
   if (documentsQuery.isError) {
     return (
-      <>
-        {dropOverlay}
-        {uploadProgressPanel}
-        <PageState
-          title="Unable to load documents"
-          description="Refresh the page or try again later."
-          variant="error"
-          action={
-            <Button variant="secondary" onClick={() => documentsQuery.refetch()}>
-              Retry
-            </Button>
-          }
-        />
-      </>
-    );
-  }
-
-  const uploadInput = (
-    <input
-      ref={uploadInputRef}
-      type="file"
-      multiple
-      accept=".pdf,.csv,.tsv,.xls,.xlsx,.xlsm,.xlsb"
-      className="hidden"
-      onChange={handleUploadInputChange}
-    />
-  );
-
-  const feedbackBanner = actionFeedback ? (
-    <ActionFeedbackBanner feedback={actionFeedback} onDismiss={() => setActionFeedback(null)} />
-  ) : null;
-
-  if (!hasDocuments) {
-    return (
-      <>
-        {dropOverlay}
-        {uploadProgressPanel}
-        <div className="space-y-6">
-          {uploadInput}
-          {feedbackBanner}
-          <EmptyAllState onUpload={handleUploadButton} isUploadPending={isUploading} />
-        </div>
-      </>
-    );
-  }
-
-  if (!hasFilteredDocuments) {
-    return (
-      <>
-        {dropOverlay}
-        {uploadProgressPanel}
-        <div className="space-y-6">
-          {uploadInput}
-          {feedbackBanner}
-          <EmptyFilteredState onClearFilters={handleClearFilters} />
-        </div>
-      </>
+      <PageState
+        title="Unable to load documents"
+        description="Refresh the page or try again later."
+        variant="error"
+        action={
+          <Button variant="secondary" onClick={() => documentsQuery.refetch()}>
+            Retry
+          </Button>
+        }
+      />
     );
   }
 
   return (
-    <>
-      {dropOverlay}
-      {uploadProgressPanel}
-      <section className="space-y-6">
-        {uploadInput}
-        {feedbackBanner}
-        <header className="space-y-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="space-y-1">
-              <h1 className="text-2xl font-semibold text-slate-900">Documents</h1>
-              <p className="text-sm text-slate-500">
-                Upload spreadsheets and PDFs, review extraction progress, and keep runs on track in one place.
-              </p>
-            </div>
-            <Button type="button" onClick={handleUploadButton} isLoading={isUploading}>
+    <section className="flex h-full flex-col gap-4">
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={SUPPORTED_FILE_EXTENSIONS.join(",")}
+        className="hidden"
+        onChange={handleFileInputChange}
+      />
+
+      {feedback ? <Alert tone={feedback.tone}>{feedback.message}</Alert> : null}
+
+      <div
+        role="region"
+        aria-label="Workspace documents"
+        className={clsx(
+          "flex flex-1 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-soft transition",
+          isDragging ? "border-dashed border-brand-400 ring-4 ring-brand-100" : "hover:border-slate-300",
+        )}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
+        <div className="flex flex-col gap-3 border-b border-slate-100 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <OwnerFilterSelect value={ownerFilter} onChange={handleOwnerFilterChange} />
+          <div className="flex flex-wrap items-center justify-end gap-3 text-sm text-slate-500">
+            <span className="hidden sm:inline">Drag and drop files here or</span>
+            <Button onClick={handleUploadButtonClick} isLoading={uploadDocuments.isPending}>
               Upload documents
             </Button>
           </div>
+        </div>
 
-          <StatusChips
-            status={status}
-            counts={statusCounts}
-            onChange={(nextStatus) => {
-              handleStatusChange(nextStatus);
-              setActiveDocumentId(null);
-            }}
-          />
-
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="min-w-0 flex-1">
-              <SearchInput
-                inputRef={searchInputRef}
-                value={searchQuery}
-                onChange={handleSearchChange}
-                onClear={handleSearchClear}
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="relative">
-                <Button
-                  ref={filterAnchorRef}
-                  type="button"
-                  variant="secondary"
-                  onClick={() => setFiltersOpen((open) => !open)}
-                  aria-haspopup="dialog"
-                  aria-expanded={filtersOpen}
-                >
-                  Filters
-                  {filterCount > 0 ? <FilterCountBadge count={filterCount} /> : null}
-                </Button>
-                <FiltersDropdown
-                  open={filtersOpen}
-                  anchorRef={filterAnchorRef}
-                  filters={filters}
-                  sourceOptions={sourceOptions}
-                  uploaderOptions={uploaderOptions}
-                  tagOptions={tagOptions}
-                  fileTypeOptions={fileTypeOptions}
-                  onChange={handleFilterChange}
-                  onChangeDate={handleDateFilterChange}
-                  onClear={handleClearFilters}
-                  onClose={() => setFiltersOpen(false)}
+        <div className="relative flex-1 overflow-auto p-4">
+          {hasVisibleDocuments ? (
+            <div className="grid grid-cols-1 gap-3">
+              {visibleDocuments.map((document) => (
+                <DocumentRow
+                  key={document.id}
+                  document={document}
+                  onInspect={handleInspect}
+                  onDownload={handleDownload}
+                  onDelete={handleDelete}
+                  isDownloading={downloadingId === document.id}
+                  isDeleting={deletingId === document.id}
                 />
-              </div>
-              <ViewToggle view={viewMode} onChange={handleViewChange} />
+              ))}
             </div>
-          </div>
-        </header>
+          ) : (
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-slate-500">
+              <p>
+                {ownerFilter === "mine"
+                  ? "No documents uploaded by you yet."
+                  : hasDocuments
+                    ? "No documents match this filter."
+                    : "No documents uploaded yet."}
+              </p>
+              {ownerFilter === "mine" && hasDocuments ? (
+                <Button variant="secondary" size="sm" onClick={() => setOwnerFilter("all")}>View all documents</Button>
+              ) : (
+                <Button onClick={handleUploadButtonClick} isLoading={uploadDocuments.isPending} size="sm">
+                  Upload documents
+                </Button>
+              )}
+            </div>
+          )}
 
-        {viewMode === "grid" ? (
-          <Fragment>
-            <DocumentsGrid
-              documents={pagedDocuments}
-              sort={sort}
-              onSortChange={handleSortChange}
-              selectedIds={selectedIds}
-              onToggleSelection={handleToggleSelection}
-              onSelectAll={handleSelectAll}
-              allSelected={allSelected}
-              someSelected={someSelected}
-              onOpenDocument={openDocument}
-              onFocusDocument={setActiveDocumentId}
-              activeDocumentId={activeDocumentId}
-              selectedDocumentId={selectedDocumentId}
-              onAction={handleDocumentAction}
-              actionsDisabled={isDeleting}
-              deletePending={isDeleting}
-              downloadingId={downloadingDocumentId}
-            />
-            <DocumentsMobileList
-              documents={pagedDocuments}
-              selectedIds={selectedIds}
-              onToggleSelection={handleToggleSelection}
-              onOpenDocument={openDocument}
-              onFocusDocument={setActiveDocumentId}
-              selectedDocumentId={selectedDocumentId}
-              onAction={handleDocumentAction}
-              actionsDisabled={isDeleting}
-              deletePending={isDeleting}
-              downloadingId={downloadingDocumentId}
-            />
-          </Fragment>
-        ) : (
-          <Fragment>
-            <DocumentsList
-              documents={pagedDocuments}
-              selectedIds={selectedIds}
-              onToggleSelection={handleToggleSelection}
-              onOpenDocument={openDocument}
-              onFocusDocument={setActiveDocumentId}
-              selectedDocumentId={selectedDocumentId}
-              onAction={handleDocumentAction}
-              actionsDisabled={isDeleting}
-              deletePending={isDeleting}
-              downloadingId={downloadingDocumentId}
-            />
-            <DocumentsMobileList
-              documents={pagedDocuments}
-              selectedIds={selectedIds}
-              onToggleSelection={handleToggleSelection}
-              onOpenDocument={openDocument}
-              onFocusDocument={setActiveDocumentId}
-              selectedDocumentId={selectedDocumentId}
-              onAction={handleDocumentAction}
-              actionsDisabled={isDeleting}
-              deletePending={isDeleting}
-              downloadingId={downloadingDocumentId}
-            />
-          </Fragment>
-        )}
-
-      <Pagination
-        page={safePage}
-        totalPages={totalPages}
-        onChange={(nextPage) => {
-          setSearchParams((params) => {
-            if (nextPage <= 1) {
-              params.delete("page");
-            } else {
-              params.set("page", nextPage.toString());
-            }
-            return params;
-          });
-        }}
-      />
-
-      {selectedCount > 0 ? (
-        <BulkActionBar
-          count={selectedCount}
-          onRetry={handleBulkRetry}
-          onArchive={handleBulkArchive}
-          onDelete={handleBulkDelete}
-          isProcessing={isDeleting}
-        />
-      ) : null}
-      </section>
-    </>
+          {isDragging ? (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl border-4 border-dashed border-brand-300 bg-brand-50/80 text-sm font-semibold text-brand-700">
+              Drop files to upload
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
   );
 }
 
-function buildDocumentViewModel(document: WorkspaceDocumentSummary): DocumentViewModel {
+interface OwnerFilterSelectProps {
+  readonly value: OwnerFilter;
+  readonly onChange: (value: OwnerFilter) => void;
+}
+
+function OwnerFilterSelect({ value, onChange }: OwnerFilterSelectProps) {
+  return (
+    <label className="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-500 sm:flex-row sm:items-center">
+      <span>Showing</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value as OwnerFilter)}
+        className="mt-2 w-48 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:ml-3 sm:mt-0"
+      >
+        {OWNER_FILTER_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+interface DocumentRowProps {
+  readonly document: DocumentItem;
+  readonly onInspect: (document: DocumentItem) => void;
+  readonly onDownload: (document: DocumentItem) => void;
+  readonly onDelete: (document: DocumentItem) => void;
+  readonly isDownloading: boolean;
+  readonly isDeleting: boolean;
+}
+
+function DocumentRow({
+  document,
+  onInspect,
+  onDownload,
+  onDelete,
+  isDownloading,
+  isDeleting,
+}: DocumentRowProps) {
+  return (
+    <article className="group flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-soft transition hover:border-brand-300 hover:shadow-md">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => onInspect(document)}
+          className="max-w-full text-left text-base font-semibold text-slate-900 transition hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+        >
+          <span className="line-clamp-2 break-words">{document.name}</span>
+        </button>
+        <StatusBadge status={document.status} />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-600">
+        <span className="flex items-center gap-2">
+          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-600">
+            {document.contentType ?? "Unknown type"}
+          </span>
+          <span>{formatFileSize(document.byteSize)}</span>
+        </span>
+        <span>
+          Uploaded {formatRelativeTime(document.uploadedAt)} by {document.uploaderName}
+        </span>
+        <span>Source: {document.source}</span>
+        <span>Last run: {document.lastRunLabel}</span>
+      </div>
+
+      {document.tags.length ? (
+        <div className="flex flex-wrap gap-2">
+          {document.tags.map((tag) => (
+            <span key={tag} className="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">
+              {tag}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={() => onInspect(document)}>
+          View details
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => onDownload(document)} isLoading={isDownloading}>
+          Download
+        </Button>
+        <Button variant="danger" size="sm" onClick={() => onDelete(document)} isLoading={isDeleting}>
+          Delete
+        </Button>
+      </div>
+    </article>
+  );
+}
+
+interface DocumentDetailsProps {
+  readonly document: DocumentItem;
+}
+
+function DocumentDetails({ document }: DocumentDetailsProps) {
+  return (
+    <div className="space-y-4">
+      <section className="grid grid-cols-1 gap-2 text-sm text-slate-700">
+        <DetailField label="Name">{document.name}</DetailField>
+        <DetailField label="Status">
+          <StatusBadge status={document.status} />
+        </DetailField>
+        <DetailField label="Content type">{document.contentType ?? "Unknown"}</DetailField>
+        <DetailField label="File size">{formatFileSize(document.byteSize)}</DetailField>
+        <DetailField label="Uploaded">
+          {formatDateTime(document.uploadedAt)}
+        </DetailField>
+        <DetailField label="Uploaded by">{document.uploaderName}</DetailField>
+        {document.lastRunAt ? (
+          <DetailField label="Last run">
+            {document.lastRunLabel} on {formatDateTime(document.lastRunAt)}
+          </DetailField>
+        ) : (
+          <DetailField label="Last run">{document.lastRunLabel}</DetailField>
+        )}
+        <DetailField label="Source">{document.source}</DetailField>
+      </section>
+
+      {document.tags.length ? (
+        <section className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Tags</h3>
+          <div className="flex flex-wrap gap-2">
+            {document.tags.map((tag) => (
+              <span key={tag} className="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">
+                {tag}
+              </span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="space-y-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Metadata</h3>
+        {Object.keys(document.metadata).length === 0 ? (
+          <p className="text-sm text-slate-500">No metadata attached.</p>
+        ) : (
+          <pre className="max-h-64 overflow-auto rounded-lg bg-slate-900/90 p-3 text-xs text-slate-100">
+            {JSON.stringify(document.metadata, null, 2)}
+          </pre>
+        )}
+      </section>
+    </div>
+  );
+}
+
+interface DetailFieldProps {
+  readonly label: string;
+  readonly children: ReactNode;
+}
+
+function DetailField({ label, children }: DetailFieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</span>
+      <span>{children}</span>
+    </div>
+  );
+}
+
+const STATUS_LABELS: Record<DocumentStatus, string> = {
+  inbox: "Inbox",
+  processing: "Processing",
+  completed: "Completed",
+  failed: "Failed",
+  archived: "Archived",
+};
+
+const STATUS_BADGE_STYLE: Record<DocumentStatus, string> = {
+  inbox: "bg-indigo-100 text-indigo-700",
+  processing: "bg-amber-100 text-amber-800",
+  completed: "bg-emerald-100 text-emerald-700",
+  failed: "bg-danger-100 text-danger-700",
+  archived: "bg-slate-200 text-slate-700",
+};
+
+interface StatusBadgeProps {
+  readonly status: DocumentStatus;
+}
+
+function StatusBadge({ status }: StatusBadgeProps) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold",
+        STATUS_BADGE_STYLE[status],
+      )}
+    >
+      {STATUS_LABELS[status]}
+    </span>
+  );
+}
+
+function belongsToCurrentUser(document: DocumentItem, user: SessionUser | null): boolean {
+  if (!user) {
+    return false;
+  }
+
+  if (document.uploaderId && user.user_id && document.uploaderId === user.user_id) {
+    return true;
+  }
+
+  const normalizedName = (user.display_name ?? "").trim().toLowerCase();
+  if (normalizedName && document.uploaderName.trim().toLowerCase() === normalizedName) {
+    return true;
+  }
+
+  const normalizedEmail = user.email.trim().toLowerCase();
+  if (document.uploaderEmail && document.uploaderEmail.trim().toLowerCase() === normalizedEmail) {
+    return true;
+  }
+
+  return false;
+}
+
+function sortDocumentsByUploadedAt(a: DocumentItem, b: DocumentItem) {
+  const delta = b.uploadedAt.getTime() - a.uploadedAt.getTime();
+  if (delta !== 0) {
+    return delta;
+  }
+  return a.name.localeCompare(b.name);
+}
+
+function buildDocumentItem(document: WorkspaceDocumentSummary): DocumentItem {
   const metadata = document.metadata ?? {};
   const status = extractStatus(metadata);
   const source = extractString(metadata, ["source", "ingestSource"], "Manual upload");
-  const uploader = extractString(metadata, ["uploader", "uploadedBy", "createdBy"], "Unknown");
   const tags = extractTags(metadata);
-  const fileType = extractFileType(document, metadata);
-  const uploadedAtDate = safeDate(document.createdAt ?? document.updatedAt ?? new Date().toISOString());
+  const uploadedAt = safeDate(document.createdAt ?? document.updatedAt ?? new Date().toISOString());
+  const { name, id, email } = extractUploader(metadata);
   const lastRun = extractLastRun(metadata);
 
   return {
-    ...document,
+    id: document.id,
+    name: document.name,
     status,
     source,
-    uploader,
     tags,
-    fileType,
-    uploadedAtDate,
-    lastRun,
+    uploadedAt,
+    byteSize: document.byteSize,
+    contentType: document.contentType,
+    uploaderName: name,
+    uploaderId: id,
+    uploaderEmail: email,
+    lastRunLabel: lastRun.result,
+    lastRunAt: lastRun.timestamp,
+    metadata,
+    summary: document,
   };
 }
 
@@ -1049,6 +628,7 @@ function extractStatus(metadata: Record<string, unknown>): DocumentStatus {
   if (metadata.archived === true) {
     return "archived";
   }
+
   const rawStatus = extractString(metadata, ["status", "state"], "");
   switch (rawStatus.toLowerCase()) {
     case "inbox":
@@ -1068,12 +648,14 @@ function extractStatus(metadata: Record<string, unknown>): DocumentStatus {
     default:
       break;
   }
+
   if (metadata.processing === true) {
     return "processing";
   }
   if (metadata.failed === true) {
     return "failed";
   }
+
   return "completed";
 }
 
@@ -1107,45 +689,69 @@ function extractTags(metadata: Record<string, unknown>): readonly string[] {
   return [];
 }
 
-function extractFileType(
-  document: WorkspaceDocumentSummary,
-  metadata: Record<string, unknown>,
-): string {
-  const fromMetadata = extractString(metadata, ["fileType", "file_type", "format"], "");
-  if (fromMetadata) {
-    return normaliseFileType(fromMetadata);
-  }
-  if (document.contentType) {
-    const parts = document.contentType.split("/");
-    const last = parts[parts.length - 1] ?? document.contentType;
-    return normaliseFileType(last);
-  }
-  const extension = document.name.includes(".") ? document.name.split(".").pop() ?? "" : "";
-  if (extension) {
-    return normaliseFileType(extension);
-  }
-  return "Unknown";
+function extractUploader(metadata: Record<string, unknown>) {
+  const name = extractString(
+    metadata,
+    ["uploader", "uploadedBy", "createdBy", "owner", "ownerName"],
+    "Unknown",
+  );
+  const id = extractOptionalString(metadata, [
+    "uploaderId",
+    "uploader_id",
+    "uploadedById",
+    "uploaded_by_id",
+    "createdById",
+    "created_by_id",
+    "ownerId",
+    "owner_id",
+  ]);
+  const email = extractOptionalString(metadata, [
+    "uploaderEmail",
+    "uploadedByEmail",
+    "createdByEmail",
+    "ownerEmail",
+    "email",
+  ]);
+  return { name, id, email };
 }
 
-function normaliseFileType(value: string) {
-  return value.toUpperCase();
+function extractOptionalString(metadata: Record<string, unknown>, keys: readonly string[]) {
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
 }
 
-function extractLastRun(metadata: Record<string, unknown>): DocumentLastRun {
-  const raw = (metadata.lastRun ?? metadata.last_run) as Record<string, unknown> | undefined;
+function extractLastRun(metadata: Record<string, unknown>) {
+  const raw = metadata.lastRun ?? metadata.last_run ?? metadata.jobStatus ?? metadata.latestJob;
   if (raw && typeof raw === "object") {
-    const result = extractString(raw, ["result", "status", "outcome"], "Unknown");
-    const timestampValue = raw.timestamp ?? raw.completedAt ?? raw.completed_at;
-    const timestamp = typeof timestampValue === "string" ? timestampValue : null;
+    const maybeTimestamp = extractOptionalString(raw as Record<string, unknown>, [
+      "completedAt",
+      "completed_at",
+      "timestamp",
+      "updatedAt",
+      "updated_at",
+    ]);
+    const timestamp = maybeTimestamp ? safeDate(maybeTimestamp) : null;
+    const result = extractString(raw as Record<string, unknown>, ["result", "status", "state"], "Not started");
     return {
-      result: capitalise(result),
+      result: capitalize(result),
       timestamp,
     };
   }
+
+  const status = extractOptionalString(metadata, ["lastRunStatus", "jobStatus", "status"]);
+  if (status) {
+    return { result: capitalize(status), timestamp: null };
+  }
+
   return { result: "Not started", timestamp: null };
 }
 
-function capitalise(value: string) {
+function capitalize(value: string) {
   if (value.length === 0) {
     return value;
   }
@@ -1160,87 +766,58 @@ function safeDate(value: string) {
   return date;
 }
 
-function parseSort(raw: string | null): DocumentSort {
-  if (!raw) {
-    return DEFAULT_SORT;
-  }
-  const [field, direction] = raw.split(":");
-  const fieldValue: DocumentSortField = field === "name" || field === "status" ? (field as DocumentSortField) : "uploaded";
-  const directionValue: DocumentSortDirection = direction === "asc" ? "asc" : "desc";
-  return { field: fieldValue, direction: directionValue };
-}
-
-function encodeSort(sort: DocumentSort) {
-  return `${sort.field}:${sort.direction}`;
-}
-
-function sortDocuments(documents: readonly DocumentViewModel[], sort: DocumentSort) {
-  const multiplier = sort.direction === "asc" ? 1 : -1;
-  const copy = [...documents];
-  copy.sort((a, b) => {
-    switch (sort.field) {
-      case "name": {
-        return multiplier * a.name.localeCompare(b.name);
-      }
-      case "status": {
-        const rankA = STATUS_RANK[a.status as Exclude<DocumentStatus, "all">] ?? Number.MAX_SAFE_INTEGER;
-        const rankB = STATUS_RANK[b.status as Exclude<DocumentStatus, "all">] ?? Number.MAX_SAFE_INTEGER;
-        if (rankA !== rankB) {
-          return multiplier * (rankA - rankB);
-        }
-        return multiplier * a.name.localeCompare(b.name);
-      }
-      case "uploaded":
-      default: {
-        return multiplier * (a.uploadedAtDate.getTime() - b.uploadedAtDate.getTime());
-      }
+function partitionSupportedFiles(files: readonly File[]) {
+  const accepted: File[] = [];
+  const rejected: File[] = [];
+  for (const file of files) {
+    const extension = getExtension(file.name);
+    if (extension && SUPPORTED_FILE_EXTENSION_SET.has(extension)) {
+      accepted.push(file);
+    } else {
+      rejected.push(file);
     }
-  });
-  return copy;
+  }
+  return { accepted, rejected };
 }
 
-function uniqueValues(values: readonly string[]) {
-  return Array.from(new Set(values.filter((value) => value && value.length > 0))).sort((a, b) => a.localeCompare(b));
-}
-
-function sanitize(value: string | null) {
-  if (!value) {
+function getExtension(filename: string) {
+  const index = filename.lastIndexOf(".");
+  if (index === -1) {
     return "";
   }
-  return value.trim();
+  return filename.slice(index).toLowerCase();
 }
 
-function partitionSupportedFiles(files: readonly File[]) {
-  const supported: File[] = [];
-  let rejected = 0;
+function extractFilesFromDataTransfer(dataTransfer: DataTransfer | null) {
+  if (!dataTransfer) {
+    return [];
+  }
 
-  for (const file of files) {
-    const extension = getFileExtension(file.name);
-    if (extension && SUPPORTED_FILE_EXTENSIONS.has(extension)) {
-      supported.push(file);
-    } else {
-      rejected += 1;
+  const files: File[] = [];
+  if (dataTransfer.files && dataTransfer.files.length > 0) {
+    for (const file of Array.from(dataTransfer.files)) {
+      files.push(file);
+    }
+    return files;
+  }
+
+  if (dataTransfer.items) {
+    for (const item of Array.from(dataTransfer.items)) {
+      if (item.kind === "file") {
+        const file = item.getAsFile();
+        if (file) {
+          files.push(file);
+        }
+      }
     }
   }
 
-  return { supported, rejected };
-}
-
-function getFileExtension(filename: string) {
-  const lastDot = filename.lastIndexOf(".");
-  if (lastDot === -1) {
-    return null;
-  }
-  return filename.slice(lastDot).toLowerCase();
-}
-
-function makeUploadTrackerId(file: File, index: number) {
-  return `${file.name}-${file.size}-${file.lastModified}-${index}`;
+  return files;
 }
 
 function resolveApiErrorMessage(error: unknown, fallback: string) {
   if (error instanceof ApiError) {
-    return error.problem?.detail ?? error.message;
+    return error.problem?.detail ?? error.message ?? fallback;
   }
   if (error instanceof Error) {
     return error.message;
@@ -1248,76 +825,7 @@ function resolveApiErrorMessage(error: unknown, fallback: string) {
   return fallback;
 }
 
-function parseDateFilter(value: string, boundary: "start" | "end") {
-  if (!value) {
-    return null;
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  if (boundary === "start") {
-    date.setHours(0, 0, 0, 0);
-  } else {
-    date.setHours(23, 59, 59, 999);
-  }
-  return date;
-}
-
-function parsePage(value: string | null) {
-  if (!value) {
-    return 1;
-  }
-  const parsed = Number.parseInt(value, 10);
-  if (Number.isNaN(parsed) || parsed < 1) {
-    return 1;
-  }
-  return parsed;
-}
-
-function clearDocumentSelection(setSearchParams: ReturnType<typeof useSearchParams>[1]) {
-  setSearchParams((params) => {
-    params.delete("document");
-    return params;
-  });
-}
-
-function formatDateTime(value: string | null) {
-  if (!value) {
-    return "Not run";
-  }
-  try {
-    return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
-
-function formatUploaded(date: Date) {
-  try {
-    return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date);
-  } catch {
-    return date.toISOString();
-  }
-}
-
-function formatFileSize(bytes: number) {
-  if (!Number.isFinite(bytes) || bytes < 0) {
-    return "-";
-  }
-  if (bytes === 0) {
-    return "0 B";
-  }
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const size = bytes / Math.pow(1024, index);
-  return `${size.toFixed(1)} ${units[index]}`;
-}
-
 function triggerBrowserDownload(blob: Blob, filename: string) {
-  if (typeof window === "undefined" || typeof document === "undefined") {
-    return;
-  }
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
@@ -1329,1173 +837,61 @@ function triggerBrowserDownload(blob: Blob, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-function trackDocumentAction(action: string, workspaceId: string, documentId?: string) {
+function formatFileSize(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+function formatDateTime(date: Date) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function formatRelativeTime(date: Date) {
+  const now = Date.now();
+  const value = date.getTime();
+  const deltaSeconds = Math.round((value - now) / 1000);
+
+  const divisions: readonly [number, Intl.RelativeTimeFormatUnit][] = [
+    [60, "second"],
+    [60, "minute"],
+    [24, "hour"],
+    [7, "day"],
+    [4.34524, "week"],
+    [12, "month"],
+    [Number.POSITIVE_INFINITY, "year"],
+  ];
+
+  let remainder = deltaSeconds;
+  let unit: Intl.RelativeTimeFormatUnit = "second";
+
+  for (const [amount, nextUnit] of divisions) {
+    if (Math.abs(remainder) < amount) {
+      unit = nextUnit;
+      break;
+    }
+    remainder /= amount;
+    unit = nextUnit;
+  }
+
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  return formatter.format(Math.round(remainder), unit);
+}
+
+function trackDocumentsEvent(
+  action: string,
+  workspaceId: string,
+  payload: Record<string, unknown> = {},
+) {
   trackEvent({
     name: `documents.${action}`,
-    payload: { workspaceId, documentId },
+    payload: { workspaceId, ...payload },
   });
 }
-
-function UploadSpinner() {
-  return (
-    <svg
-      className="h-4 w-4 animate-spin text-brand-600"
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.6}
-    >
-      <path d="M10 3a7 7 0 1 1-7 7" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
-interface StatusChipsProps {
-  readonly status: DocumentStatus;
-  readonly counts: Map<DocumentStatus, number>;
-  readonly onChange: (status: DocumentStatus) => void;
-}
-
-function StatusChips({ status, counts, onChange }: StatusChipsProps) {
-  return (
-    <div className="flex flex-wrap gap-2" role="tablist" aria-label="Document status filters">
-      {STATUS_OPTIONS.map((option) => {
-        const isActive = status === option.value;
-        const count = counts.get(option.value) ?? 0;
-        return (
-          <button
-            key={option.value}
-            type="button"
-            role="tab"
-            aria-selected={isActive}
-            onClick={() => onChange(option.value)}
-            className={clsx(
-              "inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
-              isActive
-                ? "border-brand-500 bg-brand-50 text-brand-700"
-                : "border-slate-200 bg-white text-slate-600 hover:border-brand-300 hover:text-brand-700",
-            )}
-          >
-            <span>{option.label}</span>
-            <span className="text-xs text-slate-400" aria-hidden="true">
-              {count}
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function FilterCountBadge({ count }: { readonly count: number }) {
-  return (
-    <span className="ml-2 inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-brand-100 px-2 py-0.5 text-xs font-semibold text-brand-700">
-      {count}
-    </span>
-  );
-}
-
-interface SearchInputProps {
-  readonly value: string;
-  readonly onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  readonly onClear: () => void;
-  readonly inputRef?: RefObject<HTMLInputElement | null>;
-}
-
-function SearchInput({ value, onChange, onClear, inputRef }: SearchInputProps) {
-  return (
-    <div className="relative">
-      <Input
-        ref={inputRef}
-        type="search"
-        value={value}
-        onChange={onChange}
-        placeholder="Search documents"
-        className="pr-10"
-      />
-      {value.length > 0 ? (
-        <button
-          type="button"
-          onClick={onClear}
-          className="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400 transition hover:text-brand-600 focus:outline-none"
-          aria-label="Clear search"
-        >
-          <CloseIcon />
-        </button>
-      ) : null}
-    </div>
-  );
-}
-
-interface ViewToggleProps {
-  readonly view: "grid" | "list";
-  readonly onChange: (view: "grid" | "list") => void;
-}
-
-function ViewToggle({ view, onChange }: ViewToggleProps) {
-  return (
-    <div className="inline-flex items-center rounded-lg border border-slate-200 bg-white p-1 text-xs font-semibold text-slate-600">
-      <button
-        type="button"
-        onClick={() => onChange("grid")}
-        className={clsx(
-          "rounded-md px-3 py-1 transition",
-          view === "grid" ? "bg-brand-600 text-white shadow-sm" : "hover:bg-slate-100",
-        )}
-        aria-pressed={view === "grid"}
-      >
-        Grid
-      </button>
-      <button
-        type="button"
-        onClick={() => onChange("list")}
-        className={clsx(
-          "rounded-md px-3 py-1 transition",
-          view === "list" ? "bg-brand-600 text-white shadow-sm" : "hover:bg-slate-100",
-        )}
-        aria-pressed={view === "list"}
-      >
-        List
-      </button>
-    </div>
-  );
-}
-
-interface FiltersDropdownProps {
-  readonly open: boolean;
-  readonly anchorRef: RefObject<HTMLButtonElement | null>;
-  readonly filters: {
-    readonly source: string;
-    readonly uploader: string;
-    readonly tag: string;
-    readonly fileType: string;
-    readonly from: string;
-    readonly to: string;
-  };
-  readonly sourceOptions: readonly string[];
-  readonly uploaderOptions: readonly string[];
-  readonly tagOptions: readonly string[];
-  readonly fileTypeOptions: readonly string[];
-  readonly onChange: (key: "source" | "uploader" | "tag" | "fileType", value: string) => void;
-  readonly onChangeDate: (key: "from" | "to", value: string) => void;
-  readonly onClear: () => void;
-  readonly onClose: () => void;
-}
-
-function FiltersDropdown({
-  open,
-  anchorRef,
-  filters,
-  sourceOptions,
-  uploaderOptions,
-  tagOptions,
-  fileTypeOptions,
-  onChange,
-  onChangeDate,
-  onClear,
-  onClose,
-}: FiltersDropdownProps) {
-  const desktopPanelRef = useRef<HTMLDivElement>(null);
-  const mobilePanelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    function handleClick(event: MouseEvent) {
-      const target = event.target as Node;
-      if (
-        desktopPanelRef.current?.contains(target) ||
-        mobilePanelRef.current?.contains(target) ||
-        anchorRef.current?.contains(target as Node)
-      ) {
-        return;
-      }
-      onClose();
-    }
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [anchorRef, onClose, open]);
-
-  if (!open) {
-    return null;
-  }
-
-  const content = (
-    <div className="space-y-4">
-      <FilterSelect
-        id="filter-source"
-        label="Source"
-        value={filters.source}
-        onChange={(value) => onChange("source", value)}
-        options={sourceOptions}
-        placeholder="All sources"
-      />
-      <FilterSelect
-        id="filter-uploader"
-        label="Uploader"
-        value={filters.uploader}
-        onChange={(value) => onChange("uploader", value)}
-        options={uploaderOptions}
-        placeholder="All uploaders"
-      />
-      <FilterSelect
-        id="filter-tag"
-        label="Tag"
-        value={filters.tag}
-        onChange={(value) => onChange("tag", value)}
-        options={tagOptions}
-        placeholder="All tags"
-      />
-      <FilterSelect
-        id="filter-type"
-        label="File type"
-        value={filters.fileType}
-        onChange={(value) => onChange("fileType", value)}
-        options={fileTypeOptions}
-        placeholder="All file types"
-      />
-      <FilterDateField
-        id="filter-from"
-        label="From"
-        value={filters.from}
-        onChange={(value) => onChangeDate("from", value)}
-      />
-      <FilterDateField
-        id="filter-to"
-        label="To"
-        value={filters.to}
-        onChange={(value) => onChangeDate("to", value)}
-      />
-      <div className="flex justify-between gap-3">
-        <Button type="button" variant="ghost" onClick={onClear}>
-          Clear filters
-        </Button>
-        <Button type="button" variant="primary" onClick={onClose}>
-          Done
-        </Button>
-      </div>
-    </div>
-  );
-
-  return (
-    <>
-      <div
-        className="fixed inset-0 z-40 bg-slate-900/20 backdrop-blur-sm md:hidden"
-        aria-hidden
-        onClick={onClose}
-      />
-      <div
-        ref={mobilePanelRef}
-        className="fixed inset-x-0 bottom-0 z-50 max-h-[80vh] overflow-y-auto rounded-t-2xl border border-slate-200 bg-white p-5 shadow-2xl md:hidden"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Filter documents"
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-base font-semibold text-slate-900">Filters</h2>
-          <button
-            type="button"
-            className="focus-ring inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500"
-            aria-label="Close filters"
-            onClick={onClose}
-          >
-            <CloseIcon />
-          </button>
-        </div>
-        {content}
-      </div>
-      <div
-        ref={desktopPanelRef}
-        className="absolute right-0 z-50 mt-2 hidden w-80 rounded-2xl border border-slate-200 bg-white p-5 shadow-xl md:block"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Filter documents"
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-slate-900">Filters</h2>
-          <button
-            type="button"
-            className="focus-ring inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500"
-            aria-label="Close filters"
-            onClick={onClose}
-          >
-            <CloseIcon />
-          </button>
-        </div>
-        {content}
-      </div>
-    </>
-  );
-}
-
-interface FilterSelectProps {
-  readonly id: string;
-  readonly label: string;
-  readonly value: string;
-  readonly onChange: (value: string) => void;
-  readonly options: readonly string[];
-  readonly placeholder: string;
-}
-
-function FilterSelect({ id, label, value, onChange, options, placeholder }: FilterSelectProps) {
-  return (
-    <label htmlFor={id} className="block space-y-1 text-sm">
-      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</span>
-      <select
-        id={id}
-        className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-      >
-        <option value="">{placeholder}</option>
-        {options.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
-function FilterDateField({
-  id,
-  label,
-  value,
-  onChange,
-}: {
-  readonly id: string;
-  readonly label: string;
-  readonly value: string;
-  readonly onChange: (value: string) => void;
-}) {
-  return (
-    <label htmlFor={id} className="block space-y-1 text-sm">
-      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</span>
-      <input
-        id={id}
-        type="date"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
-      />
-    </label>
-  );
-}
-
-interface DocumentsGridProps {
-  readonly documents: readonly DocumentViewModel[];
-  readonly sort: DocumentSort;
-  readonly onSortChange: (field: DocumentSortField) => void;
-  readonly selectedIds: Set<string>;
-  readonly onToggleSelection: (documentId: string, selected: boolean) => void;
-  readonly onSelectAll: (checked: boolean) => void;
-  readonly allSelected: boolean;
-  readonly someSelected: boolean;
-  readonly onOpenDocument: (documentId: string) => void;
-  readonly onFocusDocument: (documentId: string) => void;
-  readonly activeDocumentId: string | null;
-  readonly selectedDocumentId: string | null;
-  readonly onAction: (document: DocumentViewModel, action: DocumentAction) => void;
-  readonly actionsDisabled: boolean;
-  readonly deletePending: boolean;
-  readonly downloadingId: string | null;
-}
-
-function DocumentsGrid({
-  documents,
-  sort,
-  onSortChange,
-  selectedIds,
-  onToggleSelection,
-  onSelectAll,
-  allSelected,
-  someSelected,
-  onOpenDocument,
-  onFocusDocument,
-  activeDocumentId,
-  selectedDocumentId,
-  onAction,
-  actionsDisabled,
-  deletePending,
-  downloadingId,
-}: DocumentsGridProps) {
-  const selectAllRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (selectAllRef.current) {
-      selectAllRef.current.indeterminate = someSelected && !allSelected;
-    }
-  }, [allSelected, someSelected]);
-
-  return (
-    <div className="hidden overflow-hidden rounded-xl border border-slate-200 md:block">
-      <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
-        <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
-          <tr>
-            <th scope="col" className="w-12 px-3 py-3">
-              <input
-                ref={selectAllRef}
-                type="checkbox"
-                className="h-4 w-4 rounded border-slate-300 text-brand-600 focus-visible:ring-brand-500"
-                checked={allSelected}
-                onChange={(event) => onSelectAll(event.target.checked)}
-                aria-label="Select all documents on this page"
-                disabled={actionsDisabled}
-              />
-            </th>
-            <SortableHeader label="Name" active={sort.field === "name"} direction={sort.direction} onClick={() => onSortChange("name")} />
-            <SortableHeader label="Status" active={sort.field === "status"} direction={sort.direction} onClick={() => onSortChange("status")} />
-            <th scope="col" className="px-4 py-3">Source</th>
-            <SortableHeader label="Uploaded" active={sort.field === "uploaded"} direction={sort.direction} onClick={() => onSortChange("uploaded")} />
-            <th scope="col" className="px-4 py-3">Last run</th>
-            <th scope="col" className="px-4 py-3 text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-slate-100 bg-white">
-          {documents.map((document) => {
-            const isSelected = selectedIds.has(document.id);
-            const isActive = activeDocumentId === document.id || selectedDocumentId === document.id;
-            return (
-              <tr
-                key={document.id}
-                className={clsx(
-                  "group focus-within:bg-brand-50/40",
-                  isActive ? "bg-brand-50/40" : "hover:bg-slate-50",
-                )}
-              >
-                <td className="px-3 py-3">
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border-slate-300 text-brand-600 focus-visible:ring-brand-500"
-                    checked={isSelected}
-                    onChange={(event) => onToggleSelection(document.id, event.target.checked)}
-                    aria-label={`Select ${document.name}`}
-                    onFocus={() => onFocusDocument(document.id)}
-                    disabled={actionsDisabled}
-                  />
-                </td>
-                <td className="max-w-xs px-4 py-3">
-                  <button
-                    type="button"
-                    className="text-sm font-semibold text-slate-800 hover:text-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-                    onClick={() => onOpenDocument(document.id)}
-                    onFocus={() => onFocusDocument(document.id)}
-                  >
-                    {document.name}
-                  </button>
-                  <div className="text-xs text-slate-500">{document.fileType}</div>
-                </td>
-                <td className="px-4 py-3">
-                  <span className={clsx("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold", STATUS_BADGES[document.status])}>
-                    {capitalise(document.status)}
-                  </span>
-                </td>
-                <td className="px-4 py-3 text-slate-600">{document.source}</td>
-                <td className="px-4 py-3 text-slate-600">{formatUploaded(document.uploadedAtDate)}</td>
-                <td className="px-4 py-3 text-slate-600">
-                  <div className="flex flex-col">
-                    <span className="font-medium text-slate-700">{document.lastRun.result}</span>
-                    <span className="text-xs text-slate-500">{formatDateTime(document.lastRun.timestamp)}</span>
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <DocumentActionsMenu
-                    documentId={document.id}
-                    onOpenDetails={() => onOpenDocument(document.id)}
-                    onAction={(action) => onAction(document, action)}
-                    disabled={actionsDisabled}
-                    isDeleting={deletePending}
-                    isDownloading={downloadingId === document.id}
-                  />
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-interface DocumentsListProps {
-  readonly documents: readonly DocumentViewModel[];
-  readonly selectedIds: Set<string>;
-  readonly onToggleSelection: (documentId: string, selected: boolean) => void;
-  readonly onOpenDocument: (documentId: string) => void;
-  readonly onFocusDocument: (documentId: string) => void;
-  readonly selectedDocumentId: string | null;
-  readonly onAction: (document: DocumentViewModel, action: DocumentAction) => void;
-  readonly actionsDisabled: boolean;
-  readonly deletePending: boolean;
-  readonly downloadingId: string | null;
-}
-
-function DocumentsList({
-  documents,
-  selectedIds,
-  onToggleSelection,
-  onOpenDocument,
-  onFocusDocument,
-  selectedDocumentId,
-  onAction,
-  actionsDisabled,
-  deletePending,
-  downloadingId,
-}: DocumentsListProps) {
-  return (
-    <div className="hidden space-y-3 md:block">
-      {documents.map((document) => {
-        const isSelected = selectedIds.has(document.id);
-        const isActive = selectedDocumentId === document.id;
-        return (
-          <div
-            key={document.id}
-            className={clsx(
-              "rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-brand-200 hover:shadow-md",
-              isActive && "border-brand-300 ring-1 ring-brand-200",
-            )}
-          >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="flex items-start gap-3">
-                <input
-                  type="checkbox"
-                  className="mt-1 h-4 w-4 rounded border-slate-300 text-brand-600 focus-visible:ring-brand-500"
-                  checked={isSelected}
-                  onChange={(event) => onToggleSelection(document.id, event.target.checked)}
-                  aria-label={`Select ${document.name}`}
-                  disabled={actionsDisabled}
-                />
-                <div>
-                  <button
-                    type="button"
-                    className="text-lg font-semibold text-slate-900 hover:text-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-                    onClick={() => onOpenDocument(document.id)}
-                    onFocus={() => onFocusDocument(document.id)}
-                  >
-                    {document.name}
-                  </button>
-                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                    <span>{document.fileType}</span>
-                    <span aria-hidden className="text-slate-300">
-                      •
-                    </span>
-                    <span>{document.source}</span>
-                    {document.tags.length > 0 ? (
-                      <>
-                        <span aria-hidden className="text-slate-300">
-                          •
-                        </span>
-                        <span>{document.tags.join(", ")}</span>
-                      </>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-              <DocumentActionsMenu
-                documentId={document.id}
-                onOpenDetails={() => onOpenDocument(document.id)}
-                onAction={(action) => onAction(document, action)}
-                disabled={actionsDisabled}
-                isDeleting={deletePending}
-                isDownloading={downloadingId === document.id}
-              />
-            </div>
-            <dl className="mt-4 grid gap-4 text-sm text-slate-600 md:grid-cols-4">
-              <div>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Status</dt>
-                <dd>
-                  <span className={clsx("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold", STATUS_BADGES[document.status])}>
-                    {capitalise(document.status)}
-                  </span>
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Uploaded</dt>
-                <dd>{formatUploaded(document.uploadedAtDate)}</dd>
-              </div>
-              <div>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Last run</dt>
-                <dd>
-                  <div className="font-medium text-slate-700">{document.lastRun.result}</div>
-                  <div className="text-xs text-slate-500">{formatDateTime(document.lastRun.timestamp)}</div>
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Size</dt>
-                <dd>{formatFileSize(document.byteSize)}</dd>
-              </div>
-            </dl>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-interface DocumentsMobileListProps {
-  readonly documents: readonly DocumentViewModel[];
-  readonly selectedIds: Set<string>;
-  readonly onToggleSelection: (documentId: string, selected: boolean) => void;
-  readonly onOpenDocument: (documentId: string) => void;
-  readonly onFocusDocument: (documentId: string) => void;
-  readonly selectedDocumentId: string | null;
-  readonly onAction: (document: DocumentViewModel, action: DocumentAction) => void;
-  readonly actionsDisabled: boolean;
-  readonly deletePending: boolean;
-  readonly downloadingId: string | null;
-}
-
-function DocumentsMobileList({
-  documents,
-  selectedIds,
-  onToggleSelection,
-  onOpenDocument,
-  onFocusDocument,
-  selectedDocumentId,
-  onAction,
-  actionsDisabled,
-  deletePending,
-  downloadingId,
-}: DocumentsMobileListProps) {
-  return (
-    <div className="space-y-3 md:hidden">
-      {documents.map((document) => {
-        const isSelected = selectedIds.has(document.id);
-        const isActive = selectedDocumentId === document.id;
-        return (
-          <div
-            key={document.id}
-            className={clsx(
-              "rounded-xl border border-slate-200 bg-white p-4 shadow-sm",
-              isActive && "border-brand-300",
-            )}
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex items-start gap-3">
-                <input
-                  type="checkbox"
-                  className="mt-1 h-4 w-4 rounded border-slate-300 text-brand-600 focus-visible:ring-brand-500"
-                  checked={isSelected}
-                  onChange={(event) => onToggleSelection(document.id, event.target.checked)}
-                  aria-label={`Select ${document.name}`}
-                  disabled={actionsDisabled}
-                />
-                <div>
-                  <button
-                    type="button"
-                    className="text-base font-semibold text-slate-900 hover:text-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-                    onClick={() => onOpenDocument(document.id)}
-                    onFocus={() => onFocusDocument(document.id)}
-                  >
-                    {document.name}
-                  </button>
-                  <div className="mt-1 text-xs text-slate-500">
-                    {document.fileType} • {document.source}
-                  </div>
-                </div>
-              </div>
-              <DocumentActionsMenu
-                documentId={document.id}
-                onOpenDetails={() => onOpenDocument(document.id)}
-                onAction={(action) => onAction(document, action)}
-                disabled={actionsDisabled}
-                isDeleting={deletePending}
-                isDownloading={downloadingId === document.id}
-              />
-            </div>
-            <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-600">
-              <span className={clsx("inline-flex items-center rounded-full px-2 py-0.5 font-semibold", STATUS_BADGES[document.status])}>
-                {capitalise(document.status)}
-              </span>
-              <span>Uploaded {formatUploaded(document.uploadedAtDate)}</span>
-              <span>•</span>
-              <span>{document.lastRun.result}</span>
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-interface SortableHeaderProps {
-  readonly label: string;
-  readonly active: boolean;
-  readonly direction: DocumentSortDirection;
-  readonly onClick: () => void;
-}
-
-function SortableHeader({ label, active, direction, onClick }: SortableHeaderProps) {
-  return (
-    <th scope="col" className="px-4 py-3">
-      <button
-        type="button"
-        onClick={onClick}
-        className={clsx(
-          "inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide",
-          active ? "text-brand-700" : "text-slate-500 hover:text-brand-600",
-        )}
-      >
-        {label}
-        <span aria-hidden className="text-slate-400">
-          {active ? (direction === "asc" ? "↑" : "↓") : "↕"}
-        </span>
-      </button>
-    </th>
-  );
-}
-
-interface DocumentActionsMenuProps {
-  readonly documentId: string;
-  readonly onOpenDetails: () => void;
-  readonly onAction: (action: DocumentAction) => void;
-  readonly disabled?: boolean;
-  readonly isDeleting?: boolean;
-  readonly isDownloading?: boolean;
-}
-
-function DocumentActionsMenu({
-  documentId,
-  onOpenDetails,
-  onAction,
-  disabled = false,
-  isDeleting = false,
-  isDownloading = false,
-}: DocumentActionsMenuProps) {
-  const [open, setOpen] = useState(false);
-  const anchorRef = useRef<HTMLButtonElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    function handleClick(event: MouseEvent) {
-      const target = event.target as Node;
-      if (panelRef.current?.contains(target) || anchorRef.current?.contains(target)) {
-        return;
-      }
-      setOpen(false);
-    }
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [open]);
-
-  return (
-    <div className="relative inline-flex">
-      <button
-        ref={anchorRef}
-        type="button"
-        className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition hover:border-brand-200 hover:text-brand-600 disabled:cursor-not-allowed disabled:opacity-60"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => {
-          if (disabled) {
-            return;
-          }
-          setOpen((current) => !current);
-        }}
-        disabled={disabled}
-        aria-label={`Open actions for document ${documentId}`}
-      >
-        <DotsIcon />
-      </button>
-      {open ? (
-        <div
-          ref={panelRef}
-          className="absolute right-0 z-50 mt-2 w-48 rounded-xl border border-slate-200 bg-white p-2 text-sm text-slate-600 shadow-xl"
-          role="menu"
-        >
-          <MenuButton
-            label="Open details"
-            onClick={() => {
-              onOpenDetails();
-              setOpen(false);
-            }}
-          />
-          <MenuButton
-            label="Start / retry extraction"
-            onClick={() => {
-              onAction("retry");
-              setOpen(false);
-            }}
-            disabled={disabled}
-          />
-          <MenuButton
-            label="Archive"
-            onClick={() => {
-              onAction("archive");
-              setOpen(false);
-            }}
-            disabled={disabled}
-          />
-          <MenuButton
-            label="Download"
-            onClick={() => {
-              onAction("download");
-              setOpen(false);
-            }}
-            disabled={disabled}
-            loading={isDownloading}
-          />
-          <MenuButton
-            label="Delete"
-            tone="danger"
-            onClick={() => {
-              onAction("delete");
-              setOpen(false);
-            }}
-            disabled={disabled}
-            loading={isDeleting}
-          />
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function MenuButton({
-  label,
-  onClick,
-  tone = "default",
-  disabled = false,
-  loading = false,
-}: {
-  readonly label: string;
-  readonly onClick: () => void;
-  readonly tone?: "default" | "danger";
-  readonly disabled?: boolean;
-  readonly loading?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled || loading}
-      className={clsx(
-        "flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-60",
-        tone === "danger"
-          ? "text-danger-600 hover:bg-danger-50"
-          : "text-slate-600 hover:bg-slate-100",
-      )}
-      role="menuitem"
-    >
-      <span>{label}</span>
-      {loading ? (
-        <span
-          aria-hidden
-          className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-        />
-      ) : null}
-    </button>
-  );
-}
-
-interface PaginationProps {
-  readonly page: number;
-  readonly totalPages: number;
-  readonly onChange: (page: number) => void;
-}
-
-function Pagination({ page, totalPages, onChange }: PaginationProps) {
-  if (totalPages <= 1) {
-    return null;
-  }
-  const previousDisabled = page <= 1;
-  const nextDisabled = page >= totalPages;
-  return (
-    <div className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm">
-      <div>
-        Page {page} of {totalPages}
-      </div>
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          disabled={previousDisabled}
-          onClick={() => onChange(page - 1)}
-        >
-          Previous
-        </Button>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          disabled={nextDisabled}
-          onClick={() => onChange(page + 1)}
-        >
-          Next
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-interface BulkActionBarProps {
-  readonly count: number;
-  readonly onRetry: () => void;
-  readonly onArchive: () => void;
-  readonly onDelete: () => void;
-  readonly isProcessing?: boolean;
-}
-
-function BulkActionBar({ count, onRetry, onArchive, onDelete, isProcessing = false }: BulkActionBarProps) {
-  return (
-    <div className="sticky bottom-4 flex items-center justify-between gap-3 rounded-full border border-slate-200 bg-white px-5 py-3 text-sm text-slate-700 shadow-lg">
-      <div className="font-semibold">{count} selected</div>
-      <div className="flex items-center gap-2">
-        <Button type="button" variant="secondary" size="sm" onClick={onRetry} disabled={isProcessing}>
-          Retry
-        </Button>
-        <Button type="button" variant="secondary" size="sm" onClick={onArchive} disabled={isProcessing}>
-          Archive
-        </Button>
-        <Button type="button" variant="danger" size="sm" onClick={onDelete} isLoading={isProcessing}>
-          Delete
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function ActionFeedbackBanner({
-  feedback,
-  onDismiss,
-}: {
-  readonly feedback: ActionFeedback;
-  readonly onDismiss: () => void;
-}) {
-  return (
-    <div className="relative">
-      <Alert tone={feedback.tone} className="pr-12">
-        {feedback.message}
-      </Alert>
-      <button
-        type="button"
-        className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 text-slate-500 transition hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-        aria-label="Dismiss message"
-        onClick={onDismiss}
-      >
-        <CloseIcon />
-      </button>
-    </div>
-  );
-}
-
-function DocumentDropOverlay({
-  isVisible,
-  isUploading,
-}: {
-  readonly isVisible: boolean;
-  readonly isUploading: boolean;
-}) {
-  if (!isVisible) {
-    return null;
-  }
-
-  return (
-    <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center bg-slate-900/30 backdrop-blur-sm">
-      <div className="pointer-events-auto flex w-full max-w-lg flex-col items-center gap-3 rounded-3xl border-2 border-dashed border-brand-400 bg-white/95 px-10 py-12 text-center shadow-2xl">
-        <div className="text-xl font-semibold text-slate-900">Drop files to upload</div>
-        <p className="text-sm text-slate-600">Files are added to this workspace and queued for extraction.</p>
-        <p className="text-xs font-medium uppercase tracking-wide text-brand-600">
-          {isUploading ? "Uploading…" : "Release to start upload"}
-        </p>
-        <p className="text-xs text-slate-400">Supported: {SUPPORTED_FILE_TYPES_LABEL}</p>
-      </div>
-    </div>
-  );
-}
-
-function UploadProgressPanel({
-  files,
-  isUploading,
-}: {
-  readonly files: readonly PendingUploadItem[];
-  readonly isUploading: boolean;
-}) {
-  if (!isUploading || files.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="fixed bottom-6 right-6 z-30 w-full max-w-xs overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur">
-      <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-3">
-        <UploadSpinner />
-        <div className="min-w-0 text-sm font-medium text-slate-900">
-          {files.length === 1 ? "Uploading 1 document" : `Uploading ${files.length} documents`}
-        </div>
-      </div>
-      <ul className="max-h-48 space-y-1 overflow-y-auto px-4 py-3 text-sm text-slate-600">
-        {files.map((file) => (
-          <li key={file.id} className="flex items-center justify-between gap-3">
-            <span className="truncate" title={file.name}>
-              {file.name}
-            </span>
-            <span className="shrink-0 text-xs text-slate-400">{formatFileSize(file.size)}</span>
-          </li>
-        ))}
-      </ul>
-      <div className="border-t border-slate-100 px-4 py-2 text-xs text-slate-400">
-        Keep this tab open until uploads finish.
-      </div>
-    </div>
-  );
-}
-
-function EmptyAllState({
-  onUpload,
-  isUploadPending,
-}: {
-  readonly onUpload: () => void;
-  readonly isUploadPending: boolean;
-}) {
-  return (
-    <section className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center">
-      <div className="space-y-3">
-        <h1 className="text-2xl font-semibold text-slate-900">Upload your first spreadsheet or PDF</h1>
-        <p className="text-sm text-slate-500">
-          Drag and drop files or click upload to start extracting data for this workspace.
-        </p>
-      </div>
-      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
-        <Button type="button" onClick={onUpload} isLoading={isUploadPending}>
-          Upload documents
-        </Button>
-      </div>
-      <div className="mt-6 w-full max-w-xl rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-6 py-5 text-sm text-slate-500">
-        Supported types: {SUPPORTED_FILE_TYPES_LABEL}. Files stay private to this workspace.
-      </div>
-    </section>
-  );
-}
-
-function EmptyFilteredState({ onClearFilters }: { readonly onClearFilters: () => void }) {
-  return (
-    <section className="flex flex-col items-center justify-center rounded-3xl border border-slate-200 bg-white px-6 py-16 text-center">
-      <div className="space-y-3">
-        <h1 className="text-2xl font-semibold text-slate-900">No documents match these filters</h1>
-        <p className="text-sm text-slate-500">Try adjusting your filters or widening the date range.</p>
-      </div>
-      <Button type="button" variant="secondary" className="mt-6" onClick={onClearFilters}>
-        Clear filters
-      </Button>
-    </section>
-  );
-}
-
-function DocumentInspector({
-  document,
-  onRetry,
-  onOpenRuns,
-  onDownload,
-  isDownloading,
-}: {
-  readonly document: DocumentViewModel;
-  readonly onRetry: () => void;
-  readonly onOpenRuns: () => void;
-  readonly onDownload: () => void;
-  readonly isDownloading: boolean;
-}) {
-  return (
-    <div className="space-y-6">
-      <header className="space-y-1">
-        <h3 className="text-lg font-semibold text-slate-900">{document.name}</h3>
-        <p className="text-sm text-slate-500">{document.fileType}</p>
-      </header>
-      <section className="space-y-3">
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Preview</h4>
-        <div className="flex h-40 items-center justify-center rounded-xl border border-slate-200 bg-slate-50 text-sm text-slate-400">
-          Preview coming soon
-        </div>
-      </section>
-      <section className="space-y-3">
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Metadata</h4>
-        <dl className="divide-y divide-slate-200 rounded-xl border border-slate-200">
-          <InspectorRow label="Status">
-            <span className={clsx("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold", STATUS_BADGES[document.status])}>
-              {capitalise(document.status)}
-            </span>
-          </InspectorRow>
-          <InspectorRow label="Source">{document.source}</InspectorRow>
-          <InspectorRow label="Uploader">{document.uploader}</InspectorRow>
-          <InspectorRow label="Uploaded">{formatUploaded(document.uploadedAtDate)}</InspectorRow>
-          <InspectorRow label="Size">{formatFileSize(document.byteSize)}</InspectorRow>
-        </dl>
-      </section>
-      <section className="space-y-3">
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Last run</h4>
-        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-          <div className="font-semibold text-slate-800">{document.lastRun.result}</div>
-          <div className="text-xs text-slate-500">{formatDateTime(document.lastRun.timestamp)}</div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button type="button" variant="secondary" onClick={onRetry}>
-            Retry
-          </Button>
-          <Button type="button" variant="ghost" onClick={onDownload} isLoading={isDownloading}>
-            Download
-          </Button>
-          <Button type="button" variant="primary" onClick={onOpenRuns}>
-            Open in Runs
-          </Button>
-        </div>
-      </section>
-      <section className="space-y-3">
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Raw metadata</h4>
-        <pre className="max-h-48 overflow-auto rounded-xl border border-slate-200 bg-slate-900/90 p-3 text-xs text-slate-100">
-          {JSON.stringify(document.metadata, null, 2)}
-        </pre>
-      </section>
-    </div>
-  );
-}
-
-function InspectorRow({ label, children }: { readonly label: string; readonly children: ReactNode }) {
-  return (
-    <div className="flex items-center justify-between gap-3 px-4 py-3 text-sm text-slate-600">
-      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</dt>
-      <dd className="text-right">{children}</dd>
-    </div>
-  );
-}
-
-function CloseIcon() {
-  return (
-    <svg className="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
-      <path d="M5 5l10 10M15 5l-10 10" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
-function DotsIcon() {
-  return (
-    <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
-      <circle cx="4" cy="10" r="1.5" />
-      <circle cx="10" cy="10" r="1.5" />
-      <circle cx="16" cy="10" r="1.5" />
-    </svg>
-  );
-}
-


### PR DESCRIPTION
## Summary
- Rebuild the documents route with a full-width single-column grid and owner filter toolbar without the previous status pills
- Add drag-and-drop uploads alongside traditional file selection while preserving upload, download, delete, and inspector flows
- Simplify document rows and inspector details for clearer metadata presentation and responsive spacing

## Testing
- npm test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f06ba2ac28832e909c85ab5f88b919