### PR TITLE
Streamline documents grid utilities

### DIFF
--- a/frontend/src/app/routes/DocumentsRoute.tsx
+++ b/frontend/src/app/routes/DocumentsRoute.tsx
@@ -1,2501 +1,374 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import type { ChangeEvent, ReactNode, RefObject } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { ChangeEvent, DragEvent } from "react";
 import clsx from "clsx";
 
-import { useWorkspaceContext } from "../../features/workspaces/context/WorkspaceContext";
+import { useSession } from "../../features/auth/context/SessionContext";
 import { useWorkspaceDocumentsQuery } from "../../features/documents/hooks/useWorkspaceDocumentsQuery";
 import { useUploadDocumentsMutation } from "../../features/documents/hooks/useUploadDocumentsMutation";
 import { useDeleteDocumentsMutation } from "../../features/documents/hooks/useDeleteDocumentsMutation";
 import { downloadWorkspaceDocument } from "../../features/documents/api";
-import type { WorkspaceDocumentSummary } from "../../shared/types/documents";
-import { PageState } from "../components/PageState";
-import { Alert, Button, Input } from "../../ui";
+import { useWorkspaceContext } from "../../features/workspaces/context/WorkspaceContext";
 import { useWorkspaceChrome } from "../workspaces/WorkspaceChromeContext";
-import { trackEvent } from "../../shared/telemetry/events";
-import { ApiError } from "../../shared/api/client";
+import { PageState } from "../components/PageState";
+import { Alert, Button } from "../../ui";
+import {
+  DEFAULT_SORT_STATE,
+  SUPPORTED_FILE_EXTENSIONS,
+  SUPPORTED_FILE_TYPES_LABEL,
+  applyDocumentFilters,
+  resolveApiErrorMessage,
+  sortDocumentRows,
+  splitSupportedFiles,
+  toDocumentRows,
+  toggleSort,
+  trackDocumentsEvent,
+  triggerBrowserDownload,
+} from "./documents/utils";
+import type { DocumentRow, OwnerFilterValue, SortColumn, SortState, StatusFilterValue } from "./documents/utils";
+import { DocumentsToolbar } from "./documents/components/DocumentsToolbar";
+import { DocumentsTable } from "./documents/components/DocumentsTable";
+import { DocumentsEmptyState } from "./documents/components/DocumentsEmptyState";
+import { DocumentDetails } from "./documents/components/DocumentDetails";
 
-const PAGE_SIZE = 50;
-
-const SUPPORTED_FILE_EXTENSIONS = new Set([
-  ".pdf",
-  ".csv",
-  ".tsv",
-  ".xls",
-  ".xlsx",
-  ".xlsm",
-  ".xlsb",
-]);
-
-const SUPPORTED_FILE_TYPES_LABEL = "PDF, CSV, TSV, XLS, XLSX, XLSM, XLSB";
-
-const STATUS_OPTIONS = [
-  { value: "all", label: "All" },
-  { value: "inbox", label: "Inbox" },
-  { value: "processing", label: "Processing" },
-  { value: "completed", label: "Completed" },
-  { value: "failed", label: "Failed" },
-  { value: "archived", label: "Archived" },
-] as const;
-
-type DocumentStatus = (typeof STATUS_OPTIONS)[number]["value"];
-
-const STATUS_RANK: Record<Exclude<DocumentStatus, "all">, number> = {
-  inbox: 0,
-  processing: 1,
-  completed: 2,
-  failed: 3,
-  archived: 4,
-};
-
-type DocumentAction = "retry" | "archive" | "delete" | "download";
-
-interface ActionFeedback {
-  readonly tone: "info" | "success" | "warning" | "danger";
+type FeedbackTone = "info" | "success" | "warning" | "danger";
+interface FeedbackState {
+  readonly tone: FeedbackTone;
   readonly message: string;
 }
 
-type DocumentSortField = "uploaded" | "name" | "status";
-type DocumentSortDirection = "asc" | "desc";
-
-interface DocumentSort {
-  readonly field: DocumentSortField;
-  readonly direction: DocumentSortDirection;
-}
-
-interface DocumentLastRun {
-  readonly result: string;
-  readonly timestamp: string | null;
-}
-
-interface DocumentViewModel extends WorkspaceDocumentSummary {
-  readonly status: DocumentStatus;
-  readonly source: string;
-  readonly uploader: string;
-  readonly tags: readonly string[];
-  readonly fileType: string;
-  readonly uploadedAtDate: Date;
-  readonly lastRun: DocumentLastRun;
-}
-
-interface PendingUploadItem {
-  readonly id: string;
-  readonly name: string;
-  readonly size: number;
-}
-
-const STATUS_BADGES: Record<DocumentStatus, string> = {
-  all: "bg-slate-100 text-slate-700",
-  inbox: "bg-indigo-100 text-indigo-700",
-  processing: "bg-amber-100 text-amber-800",
-  completed: "bg-emerald-100 text-emerald-700",
-  failed: "bg-danger-100 text-danger-700",
-  archived: "bg-slate-200 text-slate-700",
-};
-
-const DEFAULT_SORT: DocumentSort = { field: "uploaded", direction: "desc" };
-
 export function DocumentsRoute() {
   const { workspace } = useWorkspaceContext();
+  const { user: currentUser } = useSession();
+  const { openInspector } = useWorkspaceChrome();
+
   const documentsQuery = useWorkspaceDocumentsQuery(workspace.id);
-  const uploadDocumentsMutation = useUploadDocumentsMutation(workspace.id);
-  const deleteDocumentsMutation = useDeleteDocumentsMutation(workspace.id);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const { openInspector, closeInspector } = useWorkspaceChrome();
+  const uploadDocuments = useUploadDocumentsMutation(workspace.id);
+  const deleteDocuments = useDeleteDocumentsMutation(workspace.id);
 
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  const filterAnchorRef = useRef<HTMLButtonElement>(null);
-  const uploadInputRef = useRef<HTMLInputElement>(null);
-  const dragCounterRef = useRef(0);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [ownerFilter, setOwnerFilter] = useState<OwnerFilterValue>("mine");
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("all");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sortState, setSortState] = useState<SortState>(DEFAULT_SORT_STATE);
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [dragDepth, setDragDepth] = useState(0);
 
-  const [filtersOpen, setFiltersOpen] = useState(false);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [activeDocumentId, setActiveDocumentId] = useState<string | null>(null);
-  const [actionFeedback, setActionFeedback] = useState<ActionFeedback | null>(null);
-  const [downloadingDocumentId, setDownloadingDocumentId] = useState<string | null>(null);
-  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
-  const [pendingUploads, setPendingUploads] = useState<PendingUploadItem[]>([]);
-
-  const rawStatus = (searchParams.get("status") ?? "all").toLowerCase();
-  const status: DocumentStatus = STATUS_OPTIONS.some((option) => option.value === rawStatus)
-    ? (rawStatus as DocumentStatus)
-    : "all";
-  const viewMode = searchParams.get("view") === "list" ? "list" : "grid";
-  const searchQuery = searchParams.get("q") ?? "";
-  const sortParam = searchParams.get("sort");
-  const sort = useMemo(() => parseSort(sortParam), [sortParam]);
-  const page = parsePage(searchParams.get("page"));
-  const selectedDocumentId = searchParams.get("document");
-
-  const filters = {
-    source: sanitize(searchParams.get("source")),
-    uploader: sanitize(searchParams.get("uploader")),
-    tag: sanitize(searchParams.get("tag")),
-    fileType: sanitize(searchParams.get("type")),
-    from: sanitize(searchParams.get("from")),
-    to: sanitize(searchParams.get("to")),
-  };
-
-  useEffect(() => {
-    if (!actionFeedback || typeof window === "undefined") {
-      return;
+  const containsFiles = useCallback((event: DragEvent<HTMLDivElement>) => {
+    const { dataTransfer } = event;
+    if (!dataTransfer) {
+      return false;
     }
-    const timeout = window.setTimeout(() => setActionFeedback(null), 6000);
-    return () => window.clearTimeout(timeout);
-  }, [actionFeedback]);
-
-  const documents = useMemo(() => {
-    return (documentsQuery.data ?? []).map((document) => buildDocumentViewModel(document));
-  }, [documentsQuery.data]);
-
-  useEffect(() => {
-    setSelectedIds((current) => {
-      if (current.size === 0) {
-        return current;
-      }
-      const next = new Set(Array.from(current).filter((id) => documents.some((document) => document.id === id)));
-      if (next.size === current.size) {
-        return current;
-      }
-      return next;
-    });
-  }, [documents]);
-
-  const activeDocument = useMemo(
-    () => documents.find((document) => document.id === selectedDocumentId) ?? null,
-    [documents, selectedDocumentId],
-  );
-
-  const filteredDocuments = useMemo(() => {
-    const fromDate = parseDateFilter(filters.from, "start");
-    const toDate = parseDateFilter(filters.to, "end");
-    const query = searchQuery.trim().toLowerCase();
-    return documents.filter((document) => {
-      if (status !== "all" && document.status !== status) {
-        return false;
-      }
-      if (filters.source && document.source !== filters.source) {
-        return false;
-      }
-      if (filters.uploader && document.uploader !== filters.uploader) {
-        return false;
-      }
-      if (filters.fileType && document.fileType !== filters.fileType) {
-        return false;
-      }
-      if (filters.tag && !document.tags.includes(filters.tag)) {
-        return false;
-      }
-      if (fromDate && document.uploadedAtDate < fromDate) {
-        return false;
-      }
-      if (toDate && document.uploadedAtDate > toDate) {
-        return false;
-      }
-      if (query.length > 0) {
-        const target = [document.name, document.source, document.uploader, ...document.tags]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase();
-        if (!target.includes(query)) {
-          return false;
-        }
-      }
+    if (dataTransfer.files && dataTransfer.files.length > 0) {
       return true;
-    });
-  }, [documents, filters, searchQuery, status]);
-
-  const sortedDocuments = useMemo(
-    () => sortDocuments(filteredDocuments, sort),
-    [filteredDocuments, sort],
-  );
-
-  const totalPages = Math.max(1, Math.ceil(sortedDocuments.length / PAGE_SIZE));
-  const safePage = Math.min(Math.max(page, 1), totalPages);
-
-  useEffect(() => {
-    if (safePage !== page) {
-      setSearchParams((params) => {
-        if (safePage === 1) {
-          params.delete("page");
-        } else {
-          params.set("page", safePage.toString());
-        }
-        return params;
-      });
     }
-  }, [page, safePage, setSearchParams]);
+    const types = dataTransfer.types;
+    return !!types && Array.from(types).includes("Files");
+  }, []);
 
-  const pagedDocuments = useMemo(
+  const documents = useMemo(() => toDocumentRows(documentsQuery.data), [documentsQuery.data]);
+  const filteredDocuments = useMemo(
     () =>
-      sortedDocuments.slice(
-        (safePage - 1) * PAGE_SIZE,
-        (safePage - 1) * PAGE_SIZE + PAGE_SIZE,
-      ),
-    [safePage, sortedDocuments],
+      applyDocumentFilters(documents, {
+        owner: ownerFilter,
+        status: statusFilter,
+        search: searchTerm,
+        currentUser,
+      }),
+    [documents, ownerFilter, statusFilter, searchTerm, currentUser],
+  );
+  const visibleDocuments = useMemo(
+    () => sortDocumentRows(filteredDocuments, sortState),
+    [filteredDocuments, sortState],
   );
 
-  useEffect(() => {
-    setSelectedIds(new Set());
-  }, [safePage]);
+  const totalCount = documents.length;
+  const resultCount = visibleDocuments.length;
+  const hasDocuments = totalCount > 0;
+  const hasVisibleDocuments = resultCount > 0;
+  const isDragging = dragDepth > 0;
 
-  const statusCounts = useMemo(() => {
-    const counts = new Map<DocumentStatus, number>();
-    STATUS_OPTIONS.forEach((option) => counts.set(option.value, 0));
-    counts.set("all", documents.length);
-    for (const document of documents) {
-      counts.set(document.status, (counts.get(document.status) ?? 0) + 1);
-    }
-    return counts;
-  }, [documents]);
+  const clearFeedback = useCallback(() => setFeedback(null), []);
+  const showFeedback = useCallback((value: FeedbackState) => setFeedback(value), []);
 
-  const sourceOptions = useMemo(
-    () => uniqueValues(documents.map((document) => document.source)),
-    [documents],
-  );
-  const uploaderOptions = useMemo(
-    () => uniqueValues(documents.map((document) => document.uploader)),
-    [documents],
-  );
-  const tagOptions = useMemo(
-    () => uniqueValues(documents.flatMap((document) => document.tags)),
-    [documents],
-  );
-  const fileTypeOptions = useMemo(
-    () => uniqueValues(documents.map((document) => document.fileType)),
-    [documents],
-  );
-
-  const hasDocuments = documents.length > 0;
-  const hasFilteredDocuments = filteredDocuments.length > 0;
-  const filterCount = [filters.source, filters.uploader, filters.tag, filters.fileType, filters.from, filters.to]
-    .filter((value) => Boolean(value && value.length > 0)).length;
-
-  const isUploading = uploadDocumentsMutation.isPending;
-  const isDeleting = deleteDocumentsMutation.isPending;
-
-  const dropOverlay = (
-    <DocumentDropOverlay isVisible={isDraggingFiles} isUploading={isUploading} />
-  );
-
-  const uploadProgressPanel = (
-    <UploadProgressPanel files={pendingUploads} isUploading={isUploading} />
-  );
-
-  const allSelected = pagedDocuments.length > 0 && pagedDocuments.every((document) => selectedIds.has(document.id));
-  const someSelected = pagedDocuments.some((document) => selectedIds.has(document.id));
-  const selectedCount = selectedIds.size;
-
-  const openDocument = useCallback(
-    (documentId: string) => {
-      trackDocumentAction("open", workspace.id, documentId);
-      setSearchParams((params) => {
-        params.set("document", documentId);
-        return params;
+  const handleSortChange = useCallback(
+    (column: SortColumn) => {
+      setSortState((current) => {
+        const next = toggleSort(column, current);
+        trackDocumentsEvent("sort", workspace.id, { column: next.column, direction: next.direction });
+        return next;
       });
-    },
-    [setSearchParams, workspace.id],
-  );
-
-  const notifyComingSoon = useCallback(
-    (action: string, message: string, documentId?: string) => {
-      trackDocumentAction(action, workspace.id, documentId);
-      setActionFeedback({ tone: "info", message });
     },
     [workspace.id],
   );
 
-  const handleFilesSelected = useCallback(
-    async (incomingFiles: readonly File[]) => {
-      if (!incomingFiles || incomingFiles.length === 0) {
-        return;
-      }
+  const handleOwnerChange = useCallback(
+    (value: OwnerFilterValue) => {
+      setOwnerFilter(value);
+      trackDocumentsEvent("filter_owner", workspace.id, { owner: value });
+    },
+    [workspace.id],
+  );
 
-      if (uploadDocumentsMutation.isPending) {
-        setActionFeedback({
-          tone: "info",
-          message: "Upload in progress. Wait for it to finish before adding more files.",
+  const handleStatusChange = useCallback(
+    (value: StatusFilterValue) => {
+      setStatusFilter(value);
+      trackDocumentsEvent("filter_status", workspace.id, { status: value });
+    },
+    [workspace.id],
+  );
+
+  const handleInspect = useCallback(
+    (document: DocumentRow) => {
+      openInspector({ title: document.name, content: <DocumentDetails document={document} /> });
+      trackDocumentsEvent("view_details", workspace.id, { documentId: document.id });
+    },
+    [openInspector, workspace.id],
+  );
+
+  const handleDownload = useCallback(
+    async (document: DocumentRow) => {
+      setDownloadingId(document.id);
+      try {
+        trackDocumentsEvent("download", workspace.id, { documentId: document.id });
+        const { blob, filename } = await downloadWorkspaceDocument(workspace.id, document.id);
+        triggerBrowserDownload(blob, filename ?? document.name);
+      } catch (error) {
+        showFeedback({
+          tone: "danger",
+          message: resolveApiErrorMessage(error, "Unable to download document."),
         });
+      } finally {
+        setDownloadingId(null);
+      }
+    },
+    [showFeedback, workspace.id],
+  );
+
+  const handleDelete = useCallback(
+    async (document: DocumentRow) => {
+      setDeletingId(document.id);
+      try {
+        trackDocumentsEvent("delete", workspace.id, { documentId: document.id });
+        await deleteDocuments.mutateAsync([document.id]);
+        showFeedback({ tone: "success", message: "Document deleted." });
+      } catch (error) {
+        showFeedback({
+          tone: "danger",
+          message: resolveApiErrorMessage(error, "Unable to delete document. Try again."),
+        });
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [deleteDocuments, showFeedback, workspace.id],
+  );
+
+  const handleFilesSelected = useCallback(
+    async (files: readonly File[]) => {
+      if (!files.length) {
         return;
       }
 
-      const { supported, rejected } = partitionSupportedFiles(incomingFiles);
-      if (supported.length === 0) {
-        setActionFeedback({
+      const { accepted, rejected } = splitSupportedFiles(files);
+      if (accepted.length === 0) {
+        showFeedback({
           tone: "warning",
           message: `No supported files detected. Supported types: ${SUPPORTED_FILE_TYPES_LABEL}.`,
         });
         return;
       }
 
-      setActionFeedback(null);
-
-      const uploads = supported.map((file, index) => ({
-        id: makeUploadTrackerId(file, index),
-        name: file.name,
-        size: file.size,
-      }));
-      const uploadIdsByIndex = new Map<number, string>(
-        uploads.map((upload, index) => [index, upload.id]),
-      );
-
-      setPendingUploads(uploads);
+      clearFeedback();
 
       try {
-        const uploaded = await uploadDocumentsMutation.mutateAsync({
-          files: supported,
-          onProgress: ({ index }) => {
-            const completedId = uploadIdsByIndex.get(index);
-            if (!completedId) {
-              return;
-            }
-            setPendingUploads((current) =>
-              current.filter((item) => item.id !== completedId),
-            );
-          },
-        });
-        setSelectedIds(new Set());
-        setActiveDocumentId(null);
-
-        if (uploaded.length === 1) {
-          trackDocumentAction("upload", workspace.id, uploaded[0]?.id);
+        await uploadDocuments.mutateAsync({ files: accepted });
+        if (rejected.length > 0) {
+          showFeedback({
+            tone: "warning",
+            message: `${rejected.length} file${rejected.length === 1 ? " was" : "s were"} skipped because the format is not supported.`,
+          });
         } else {
-          trackDocumentAction("bulk_upload", workspace.id);
+          showFeedback({ tone: "success", message: "Upload started." });
         }
-
-        let message =
-          uploaded.length <= 1
-            ? `${supported[0]?.name ?? "Document"} uploaded.`
-            : `${uploaded.length} documents uploaded.`;
-
-        if (rejected > 0) {
-          message = `${message} ${rejected} file${rejected === 1 ? "" : "s"} skipped (unsupported type).`;
-        }
-
-        setActionFeedback({ tone: "success", message });
+        trackDocumentsEvent("upload", workspace.id, {
+          accepted: accepted.length,
+          rejected: rejected.length,
+        });
       } catch (error) {
-        setActionFeedback({
+        showFeedback({
           tone: "danger",
           message: resolveApiErrorMessage(error, "Unable to upload documents. Try again."),
         });
-      } finally {
-        setPendingUploads([]);
       }
     },
-    [uploadDocumentsMutation, workspace.id],
+    [clearFeedback, showFeedback, uploadDocuments, workspace.id],
   );
 
-  const handleUploadButton = useCallback(() => {
-    setActionFeedback(null);
-    trackDocumentAction("upload", workspace.id);
-    uploadInputRef.current?.click();
-  }, [workspace.id, uploadInputRef]);
-
-  const handleUploadInputChange = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const fileList = event.target.files;
-      const files = fileList ? Array.from(fileList) : [];
+  const handleFileInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const files = event.target.files ? Array.from(event.target.files) : [];
+      void handleFilesSelected(files);
       event.target.value = "";
-      if (files.length === 0) {
-        return;
-      }
-      await handleFilesSelected(files);
     },
     [handleFilesSelected],
   );
 
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    function hasFiles(event: DragEvent) {
-      return Array.from(event.dataTransfer?.types ?? []).includes("Files");
-    }
-
-    const handleDragEnter = (event: DragEvent) => {
-      if (!hasFiles(event)) {
+  const handleDragEnter = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!containsFiles(event)) {
         return;
       }
       event.preventDefault();
-      dragCounterRef.current += 1;
-      setIsDraggingFiles(true);
-    };
+      event.stopPropagation();
+      setDragDepth((value) => value + 1);
+    },
+    [containsFiles],
+  );
 
-    const handleDragOver = (event: DragEvent) => {
-      if (!hasFiles(event)) {
+  const handleDragLeave = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!containsFiles(event) && dragDepth === 0) {
         return;
       }
       event.preventDefault();
+      event.stopPropagation();
+      const nextTarget = event.relatedTarget as Node | null;
+      if (nextTarget && event.currentTarget.contains(nextTarget)) {
+        return;
+      }
+      setDragDepth((value) => Math.max(0, value - 1));
+    },
+    [containsFiles, dragDepth],
+  );
+
+  const handleDragOver = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!containsFiles(event) && dragDepth === 0) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
       if (event.dataTransfer) {
         event.dataTransfer.dropEffect = "copy";
       }
-    };
+    },
+    [containsFiles, dragDepth],
+  );
 
-    const handleDragLeave = (event: DragEvent) => {
-      if (!hasFiles(event)) {
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!containsFiles(event)) {
         return;
       }
       event.preventDefault();
-      dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
-      if (dragCounterRef.current === 0) {
-        setIsDraggingFiles(false);
-      }
-    };
-
-    const handleDrop = (event: DragEvent) => {
-      if (!hasFiles(event)) {
-        return;
-      }
-      event.preventDefault();
-      dragCounterRef.current = 0;
-      setIsDraggingFiles(false);
-      const files = event.dataTransfer?.files;
-      if (files && files.length > 0) {
-        void handleFilesSelected(Array.from(files));
-      }
-    };
-
-    const handleWindowBlur = () => {
-      dragCounterRef.current = 0;
-      setIsDraggingFiles(false);
-    };
-
-    window.addEventListener("dragenter", handleDragEnter);
-    window.addEventListener("dragover", handleDragOver);
-    window.addEventListener("dragleave", handleDragLeave);
-    window.addEventListener("drop", handleDrop);
-    window.addEventListener("blur", handleWindowBlur);
-
-    return () => {
-      window.removeEventListener("dragenter", handleDragEnter);
-      window.removeEventListener("dragover", handleDragOver);
-      window.removeEventListener("dragleave", handleDragLeave);
-      window.removeEventListener("drop", handleDrop);
-      window.removeEventListener("blur", handleWindowBlur);
-    };
-  }, [handleFilesSelected]);
-
-  const handleDeleteDocuments = useCallback(
-    async (documentIds: readonly string[]) => {
-      if (documentIds.length === 0) {
-        return;
-      }
-      setActionFeedback(null);
-      try {
-        await deleteDocumentsMutation.mutateAsync(documentIds);
-        setSelectedIds((current) => {
-          const next = new Set(current);
-          documentIds.forEach((id) => next.delete(id));
-          return next;
-        });
-        setActiveDocumentId((current) => (current && documentIds.includes(current) ? null : current));
-        if (selectedDocumentId && documentIds.includes(selectedDocumentId)) {
-          clearDocumentSelection(setSearchParams);
-        }
-        const action = documentIds.length === 1 ? "delete" : "bulk_delete";
-        trackDocumentAction(action, workspace.id, documentIds.length === 1 ? documentIds[0] : undefined);
-        const message =
-          documentIds.length === 1 ? "Document deleted." : `${documentIds.length} documents deleted.`;
-        setActionFeedback({ tone: "success", message });
-      } catch (error) {
-        setActionFeedback({
-          tone: "danger",
-          message: resolveApiErrorMessage(error, "Unable to delete documents. Try again."),
-        });
-      }
+      event.stopPropagation();
+      setDragDepth(0);
+      const files = event.dataTransfer?.files ? Array.from(event.dataTransfer.files) : [];
+      void handleFilesSelected(files);
     },
-    [deleteDocumentsMutation, selectedDocumentId, setSearchParams, workspace.id],
+    [containsFiles, handleFilesSelected],
   );
 
-  const handleDownloadDocument = useCallback(
-    async (documentId: string) => {
-      setActionFeedback(null);
-      setDownloadingDocumentId(documentId);
-      try {
-        const { blob, filename } = await downloadWorkspaceDocument(workspace.id, documentId);
-        triggerBrowserDownload(blob, filename);
-        trackDocumentAction("download", workspace.id, documentId);
-      } catch (error) {
-        setActionFeedback({
-          tone: "danger",
-          message: resolveApiErrorMessage(error, "Unable to download document. Try again."),
-        });
-      } finally {
-        setDownloadingDocumentId((current) => (current === documentId ? null : current));
-      }
-    },
-    [workspace.id],
-  );
-
-  const handleDocumentAction = useCallback(
-    (document: DocumentViewModel, action: DocumentAction) => {
-      switch (action) {
-        case "retry":
-          notifyComingSoon("retry", "Document reprocessing will be available soon.", document.id);
-          break;
-        case "archive":
-          notifyComingSoon("archive", "Archiving is coming soon.", document.id);
-          break;
-        case "delete":
-          void handleDeleteDocuments([document.id]);
-          break;
-        case "download":
-          void handleDownloadDocument(document.id);
-          break;
-      }
-    },
-    [handleDeleteDocuments, handleDownloadDocument, notifyComingSoon],
-  );
-
-  const handleBulkRetry = useCallback(() => {
-    if (selectedCount === 0) {
-      return;
-    }
-    notifyComingSoon("bulk_retry", "Bulk retry is coming soon.");
-  }, [notifyComingSoon, selectedCount]);
-
-  const handleBulkArchive = useCallback(() => {
-    if (selectedCount === 0) {
-      return;
-    }
-    notifyComingSoon("bulk_archive", "Bulk archive is coming soon.");
-  }, [notifyComingSoon, selectedCount]);
-
-  const handleBulkDelete = useCallback(() => {
-    if (selectedCount === 0) {
-      return;
-    }
-    void handleDeleteDocuments(Array.from(selectedIds));
-  }, [handleDeleteDocuments, selectedCount, selectedIds]);
-
-  useEffect(() => {
-    if (!selectedDocumentId) {
-      closeInspector();
-      return;
-    }
-    if (!activeDocument) {
-      if (!documentsQuery.isLoading && !documentsQuery.isFetching) {
-        clearDocumentSelection(setSearchParams);
-      }
-      return;
-    }
-    setActiveDocumentId(selectedDocumentId);
-    const cleanup = () => clearDocumentSelection(setSearchParams);
-    openInspector({
-      title: activeDocument.name,
-      content: (
-        <DocumentInspector
-          document={activeDocument}
-          onRetry={() => notifyComingSoon("retry", "Document reprocessing will be available soon.", activeDocument.id)}
-          onOpenRuns={() => notifyComingSoon("open_runs", "Run history will land in a future update.", activeDocument.id)}
-          onDownload={() => handleDownloadDocument(activeDocument.id)}
-          isDownloading={downloadingDocumentId === activeDocument.id}
-        />
-      ),
-      onClose: cleanup,
-    });
-  }, [
-    activeDocument,
-    closeInspector,
-    downloadingDocumentId,
-    handleDownloadDocument,
-    documentsQuery.isFetching,
-    documentsQuery.isLoading,
-    notifyComingSoon,
-    openInspector,
-    selectedDocumentId,
-    setSearchParams,
-    workspace.id,
-  ]);
-
-  useEffect(() => {
-    function handleKeydown(event: KeyboardEvent) {
-      if (event.key === "/" && !event.defaultPrevented) {
-        const target = event.target as HTMLElement | null;
-        if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
-          return;
-        }
-        event.preventDefault();
-        searchInputRef.current?.focus();
-      }
-      if (event.key === "Enter" && !event.defaultPrevented && activeDocumentId) {
-        if (!selectedDocumentId) {
-          const exists = documents.some((document) => document.id === activeDocumentId);
-          if (exists) {
-            event.preventDefault();
-            openDocument(activeDocumentId);
-          }
-        }
-      }
-    }
-    window.addEventListener("keydown", handleKeydown);
-    return () => window.removeEventListener("keydown", handleKeydown);
-  }, [activeDocumentId, documents, openDocument, selectedDocumentId]);
-
-  const handleStatusChange = useCallback(
-    (nextStatus: DocumentStatus) => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        params.set("status", nextStatus);
-        params.delete("page");
-        params.delete("document");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleViewChange = useCallback(
-    (nextView: "grid" | "list") => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        params.set("view", nextView);
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleSortChange = useCallback(
-    (field: DocumentSortField) => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        const current = parseSort(params.get("sort"));
-        const direction: DocumentSortDirection =
-          current.field === field && current.direction === "desc" ? "asc" : "desc";
-        const next = encodeSort({ field, direction });
-        if (next === encodeSort(DEFAULT_SORT)) {
-          params.delete("sort");
-        } else {
-          params.set("sort", next);
-        }
-        params.delete("page");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleFilterChange = useCallback(
-    (key: keyof typeof filters, value: string) => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        const paramKey = key === "fileType" ? "type" : key;
-        if (value) {
-          params.set(paramKey, value);
-        } else {
-          params.delete(paramKey);
-        }
-        params.delete("page");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleDateFilterChange = useCallback(
-    (key: "from" | "to", value: string) => {
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        if (value) {
-          params.set(key, value);
-        } else {
-          params.delete(key);
-        }
-        params.delete("page");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleClearFilters = useCallback(() => {
-    setActionFeedback(null);
-    setSearchParams((params) => {
-      params.delete("source");
-      params.delete("uploader");
-      params.delete("tag");
-      params.delete("type");
-      params.delete("from");
-      params.delete("to");
-      params.delete("q");
-      params.set("status", "all");
-      params.delete("page");
-      params.delete("document");
-      params.delete("sort");
-      return params;
-    });
-  }, [setSearchParams]);
-
-  const handleSearchChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
-      setActionFeedback(null);
-      setSearchParams((params) => {
-        if (value.trim().length > 0) {
-          params.set("q", value);
-        } else {
-          params.delete("q");
-        }
-        params.delete("page");
-        return params;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const handleSearchClear = useCallback(() => {
-    setActionFeedback(null);
-    setSearchParams((params) => {
-      params.delete("q");
-      params.delete("page");
-      return params;
-    });
-  }, [setSearchParams]);
-
-  const handleToggleSelection = useCallback((documentId: string, selected: boolean) => {
-    setSelectedIds((current) => {
-      const next = new Set(current);
-      if (selected) {
-        next.add(documentId);
-      } else {
-        next.delete(documentId);
-      }
-      return next;
-    });
+  const openFileDialog = useCallback(() => {
+    fileInputRef.current?.click();
   }, []);
 
-  const handleSelectAll = useCallback(
-    (checked: boolean) => {
-      setSelectedIds((current) => {
-        const next = new Set(current);
-        for (const document of pagedDocuments) {
-          if (checked) {
-            next.add(document.id);
-          } else {
-            next.delete(document.id);
-          }
-        }
-        return next;
-      });
-    },
-    [pagedDocuments],
-  );
+  const handleUploadClick = useCallback(() => {
+    trackDocumentsEvent("upload_click", workspace.id);
+    openFileDialog();
+  }, [openFileDialog, workspace.id]);
 
   if (documentsQuery.isLoading) {
-    return (
-      <>
-        {dropOverlay}
-        {uploadProgressPanel}
-        <PageState title="Loading documents" variant="loading" />
-      </>
-    );
+    return <PageState title="Loading documents" description="Fetching workspace documents." variant="loading" />;
   }
 
   if (documentsQuery.isError) {
     return (
-      <>
-        {dropOverlay}
-        {uploadProgressPanel}
-        <PageState
-          title="Unable to load documents"
-          description="Refresh the page or try again later."
-          variant="error"
-          action={
-            <Button variant="secondary" onClick={() => documentsQuery.refetch()}>
-              Retry
-            </Button>
-          }
-        />
-      </>
-    );
-  }
-
-  const uploadInput = (
-    <input
-      ref={uploadInputRef}
-      type="file"
-      multiple
-      accept=".pdf,.csv,.tsv,.xls,.xlsx,.xlsm,.xlsb"
-      className="hidden"
-      onChange={handleUploadInputChange}
-    />
-  );
-
-  const feedbackBanner = actionFeedback ? (
-    <ActionFeedbackBanner feedback={actionFeedback} onDismiss={() => setActionFeedback(null)} />
-  ) : null;
-
-  if (!hasDocuments) {
-    return (
-      <>
-        {dropOverlay}
-        {uploadProgressPanel}
-        <div className="space-y-6">
-          {uploadInput}
-          {feedbackBanner}
-          <EmptyAllState onUpload={handleUploadButton} isUploadPending={isUploading} />
-        </div>
-      </>
-    );
-  }
-
-  if (!hasFilteredDocuments) {
-    return (
-      <>
-        {dropOverlay}
-        {uploadProgressPanel}
-        <div className="space-y-6">
-          {uploadInput}
-          {feedbackBanner}
-          <EmptyFilteredState onClearFilters={handleClearFilters} />
-        </div>
-      </>
-    );
-  }
-
-  return (
-    <>
-      {dropOverlay}
-      {uploadProgressPanel}
-      <section className="space-y-6">
-        {uploadInput}
-        {feedbackBanner}
-        <header className="space-y-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="space-y-1">
-              <h1 className="text-2xl font-semibold text-slate-900">Documents</h1>
-              <p className="text-sm text-slate-500">
-                Upload spreadsheets and PDFs, review extraction progress, and keep runs on track in one place.
-              </p>
-            </div>
-            <Button type="button" onClick={handleUploadButton} isLoading={isUploading}>
-              Upload documents
-            </Button>
-          </div>
-
-          <StatusChips
-            status={status}
-            counts={statusCounts}
-            onChange={(nextStatus) => {
-              handleStatusChange(nextStatus);
-              setActiveDocumentId(null);
-            }}
-          />
-
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="min-w-0 flex-1">
-              <SearchInput
-                inputRef={searchInputRef}
-                value={searchQuery}
-                onChange={handleSearchChange}
-                onClear={handleSearchClear}
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="relative">
-                <Button
-                  ref={filterAnchorRef}
-                  type="button"
-                  variant="secondary"
-                  onClick={() => setFiltersOpen((open) => !open)}
-                  aria-haspopup="dialog"
-                  aria-expanded={filtersOpen}
-                >
-                  Filters
-                  {filterCount > 0 ? <FilterCountBadge count={filterCount} /> : null}
-                </Button>
-                <FiltersDropdown
-                  open={filtersOpen}
-                  anchorRef={filterAnchorRef}
-                  filters={filters}
-                  sourceOptions={sourceOptions}
-                  uploaderOptions={uploaderOptions}
-                  tagOptions={tagOptions}
-                  fileTypeOptions={fileTypeOptions}
-                  onChange={handleFilterChange}
-                  onChangeDate={handleDateFilterChange}
-                  onClear={handleClearFilters}
-                  onClose={() => setFiltersOpen(false)}
-                />
-              </div>
-              <ViewToggle view={viewMode} onChange={handleViewChange} />
-            </div>
-          </div>
-        </header>
-
-        {viewMode === "grid" ? (
-          <Fragment>
-            <DocumentsGrid
-              documents={pagedDocuments}
-              sort={sort}
-              onSortChange={handleSortChange}
-              selectedIds={selectedIds}
-              onToggleSelection={handleToggleSelection}
-              onSelectAll={handleSelectAll}
-              allSelected={allSelected}
-              someSelected={someSelected}
-              onOpenDocument={openDocument}
-              onFocusDocument={setActiveDocumentId}
-              activeDocumentId={activeDocumentId}
-              selectedDocumentId={selectedDocumentId}
-              onAction={handleDocumentAction}
-              actionsDisabled={isDeleting}
-              deletePending={isDeleting}
-              downloadingId={downloadingDocumentId}
-            />
-            <DocumentsMobileList
-              documents={pagedDocuments}
-              selectedIds={selectedIds}
-              onToggleSelection={handleToggleSelection}
-              onOpenDocument={openDocument}
-              onFocusDocument={setActiveDocumentId}
-              selectedDocumentId={selectedDocumentId}
-              onAction={handleDocumentAction}
-              actionsDisabled={isDeleting}
-              deletePending={isDeleting}
-              downloadingId={downloadingDocumentId}
-            />
-          </Fragment>
-        ) : (
-          <Fragment>
-            <DocumentsList
-              documents={pagedDocuments}
-              selectedIds={selectedIds}
-              onToggleSelection={handleToggleSelection}
-              onOpenDocument={openDocument}
-              onFocusDocument={setActiveDocumentId}
-              selectedDocumentId={selectedDocumentId}
-              onAction={handleDocumentAction}
-              actionsDisabled={isDeleting}
-              deletePending={isDeleting}
-              downloadingId={downloadingDocumentId}
-            />
-            <DocumentsMobileList
-              documents={pagedDocuments}
-              selectedIds={selectedIds}
-              onToggleSelection={handleToggleSelection}
-              onOpenDocument={openDocument}
-              onFocusDocument={setActiveDocumentId}
-              selectedDocumentId={selectedDocumentId}
-              onAction={handleDocumentAction}
-              actionsDisabled={isDeleting}
-              deletePending={isDeleting}
-              downloadingId={downloadingDocumentId}
-            />
-          </Fragment>
-        )}
-
-      <Pagination
-        page={safePage}
-        totalPages={totalPages}
-        onChange={(nextPage) => {
-          setSearchParams((params) => {
-            if (nextPage <= 1) {
-              params.delete("page");
-            } else {
-              params.set("page", nextPage.toString());
-            }
-            return params;
-          });
-        }}
-      />
-
-      {selectedCount > 0 ? (
-        <BulkActionBar
-          count={selectedCount}
-          onRetry={handleBulkRetry}
-          onArchive={handleBulkArchive}
-          onDelete={handleBulkDelete}
-          isProcessing={isDeleting}
-        />
-      ) : null}
-      </section>
-    </>
-  );
-}
-
-function buildDocumentViewModel(document: WorkspaceDocumentSummary): DocumentViewModel {
-  const metadata = document.metadata ?? {};
-  const status = extractStatus(metadata);
-  const source = extractString(metadata, ["source", "ingestSource"], "Manual upload");
-  const uploader = extractString(metadata, ["uploader", "uploadedBy", "createdBy"], "Unknown");
-  const tags = extractTags(metadata);
-  const fileType = extractFileType(document, metadata);
-  const uploadedAtDate = safeDate(document.createdAt ?? document.updatedAt ?? new Date().toISOString());
-  const lastRun = extractLastRun(metadata);
-
-  return {
-    ...document,
-    status,
-    source,
-    uploader,
-    tags,
-    fileType,
-    uploadedAtDate,
-    lastRun,
-  };
-}
-
-function extractStatus(metadata: Record<string, unknown>): DocumentStatus {
-  if (metadata.archived === true) {
-    return "archived";
-  }
-  const rawStatus = extractString(metadata, ["status", "state"], "");
-  switch (rawStatus.toLowerCase()) {
-    case "inbox":
-      return "inbox";
-    case "processing":
-    case "running":
-      return "processing";
-    case "failed":
-    case "error":
-      return "failed";
-    case "archived":
-      return "archived";
-    case "completed":
-    case "succeeded":
-    case "success":
-      return "completed";
-    default:
-      break;
-  }
-  if (metadata.processing === true) {
-    return "processing";
-  }
-  if (metadata.failed === true) {
-    return "failed";
-  }
-  return "completed";
-}
-
-function extractString(
-  metadata: Record<string, unknown>,
-  keys: readonly string[],
-  fallback: string,
-): string {
-  for (const key of keys) {
-    const value = metadata[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value.trim();
-    }
-  }
-  return fallback;
-}
-
-function extractTags(metadata: Record<string, unknown>): readonly string[] {
-  const raw = metadata.tags ?? metadata.labels;
-  if (Array.isArray(raw)) {
-    return raw
-      .map((value) => (typeof value === "string" ? value.trim() : String(value)))
-      .filter((value) => value.length > 0);
-  }
-  if (typeof raw === "string" && raw.trim().length > 0) {
-    return raw
-      .split(",")
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0);
-  }
-  return [];
-}
-
-function extractFileType(
-  document: WorkspaceDocumentSummary,
-  metadata: Record<string, unknown>,
-): string {
-  const fromMetadata = extractString(metadata, ["fileType", "file_type", "format"], "");
-  if (fromMetadata) {
-    return normaliseFileType(fromMetadata);
-  }
-  if (document.contentType) {
-    const parts = document.contentType.split("/");
-    const last = parts[parts.length - 1] ?? document.contentType;
-    return normaliseFileType(last);
-  }
-  const extension = document.name.includes(".") ? document.name.split(".").pop() ?? "" : "";
-  if (extension) {
-    return normaliseFileType(extension);
-  }
-  return "Unknown";
-}
-
-function normaliseFileType(value: string) {
-  return value.toUpperCase();
-}
-
-function extractLastRun(metadata: Record<string, unknown>): DocumentLastRun {
-  const raw = (metadata.lastRun ?? metadata.last_run) as Record<string, unknown> | undefined;
-  if (raw && typeof raw === "object") {
-    const result = extractString(raw, ["result", "status", "outcome"], "Unknown");
-    const timestampValue = raw.timestamp ?? raw.completedAt ?? raw.completed_at;
-    const timestamp = typeof timestampValue === "string" ? timestampValue : null;
-    return {
-      result: capitalise(result),
-      timestamp,
-    };
-  }
-  return { result: "Not started", timestamp: null };
-}
-
-function capitalise(value: string) {
-  if (value.length === 0) {
-    return value;
-  }
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
-
-function safeDate(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return new Date();
-  }
-  return date;
-}
-
-function parseSort(raw: string | null): DocumentSort {
-  if (!raw) {
-    return DEFAULT_SORT;
-  }
-  const [field, direction] = raw.split(":");
-  const fieldValue: DocumentSortField = field === "name" || field === "status" ? (field as DocumentSortField) : "uploaded";
-  const directionValue: DocumentSortDirection = direction === "asc" ? "asc" : "desc";
-  return { field: fieldValue, direction: directionValue };
-}
-
-function encodeSort(sort: DocumentSort) {
-  return `${sort.field}:${sort.direction}`;
-}
-
-function sortDocuments(documents: readonly DocumentViewModel[], sort: DocumentSort) {
-  const multiplier = sort.direction === "asc" ? 1 : -1;
-  const copy = [...documents];
-  copy.sort((a, b) => {
-    switch (sort.field) {
-      case "name": {
-        return multiplier * a.name.localeCompare(b.name);
-      }
-      case "status": {
-        const rankA = STATUS_RANK[a.status as Exclude<DocumentStatus, "all">] ?? Number.MAX_SAFE_INTEGER;
-        const rankB = STATUS_RANK[b.status as Exclude<DocumentStatus, "all">] ?? Number.MAX_SAFE_INTEGER;
-        if (rankA !== rankB) {
-          return multiplier * (rankA - rankB);
-        }
-        return multiplier * a.name.localeCompare(b.name);
-      }
-      case "uploaded":
-      default: {
-        return multiplier * (a.uploadedAtDate.getTime() - b.uploadedAtDate.getTime());
-      }
-    }
-  });
-  return copy;
-}
-
-function uniqueValues(values: readonly string[]) {
-  return Array.from(new Set(values.filter((value) => value && value.length > 0))).sort((a, b) => a.localeCompare(b));
-}
-
-function sanitize(value: string | null) {
-  if (!value) {
-    return "";
-  }
-  return value.trim();
-}
-
-function partitionSupportedFiles(files: readonly File[]) {
-  const supported: File[] = [];
-  let rejected = 0;
-
-  for (const file of files) {
-    const extension = getFileExtension(file.name);
-    if (extension && SUPPORTED_FILE_EXTENSIONS.has(extension)) {
-      supported.push(file);
-    } else {
-      rejected += 1;
-    }
-  }
-
-  return { supported, rejected };
-}
-
-function getFileExtension(filename: string) {
-  const lastDot = filename.lastIndexOf(".");
-  if (lastDot === -1) {
-    return null;
-  }
-  return filename.slice(lastDot).toLowerCase();
-}
-
-function makeUploadTrackerId(file: File, index: number) {
-  return `${file.name}-${file.size}-${file.lastModified}-${index}`;
-}
-
-function resolveApiErrorMessage(error: unknown, fallback: string) {
-  if (error instanceof ApiError) {
-    return error.problem?.detail ?? error.message;
-  }
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return fallback;
-}
-
-function parseDateFilter(value: string, boundary: "start" | "end") {
-  if (!value) {
-    return null;
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  if (boundary === "start") {
-    date.setHours(0, 0, 0, 0);
-  } else {
-    date.setHours(23, 59, 59, 999);
-  }
-  return date;
-}
-
-function parsePage(value: string | null) {
-  if (!value) {
-    return 1;
-  }
-  const parsed = Number.parseInt(value, 10);
-  if (Number.isNaN(parsed) || parsed < 1) {
-    return 1;
-  }
-  return parsed;
-}
-
-function clearDocumentSelection(setSearchParams: ReturnType<typeof useSearchParams>[1]) {
-  setSearchParams((params) => {
-    params.delete("document");
-    return params;
-  });
-}
-
-function formatDateTime(value: string | null) {
-  if (!value) {
-    return "Not run";
-  }
-  try {
-    return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
-
-function formatUploaded(date: Date) {
-  try {
-    return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date);
-  } catch {
-    return date.toISOString();
-  }
-}
-
-function formatFileSize(bytes: number) {
-  if (!Number.isFinite(bytes) || bytes < 0) {
-    return "-";
-  }
-  if (bytes === 0) {
-    return "0 B";
-  }
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const size = bytes / Math.pow(1024, index);
-  return `${size.toFixed(1)} ${units[index]}`;
-}
-
-function triggerBrowserDownload(blob: Blob, filename: string) {
-  if (typeof window === "undefined" || typeof document === "undefined") {
-    return;
-  }
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  link.rel = "noopener";
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
-}
-
-function trackDocumentAction(action: string, workspaceId: string, documentId?: string) {
-  trackEvent({
-    name: `documents.${action}`,
-    payload: { workspaceId, documentId },
-  });
-}
-
-function UploadSpinner() {
-  return (
-    <svg
-      className="h-4 w-4 animate-spin text-brand-600"
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.6}
-    >
-      <path d="M10 3a7 7 0 1 1-7 7" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
-interface StatusChipsProps {
-  readonly status: DocumentStatus;
-  readonly counts: Map<DocumentStatus, number>;
-  readonly onChange: (status: DocumentStatus) => void;
-}
-
-function StatusChips({ status, counts, onChange }: StatusChipsProps) {
-  return (
-    <div className="flex flex-wrap gap-2" role="tablist" aria-label="Document status filters">
-      {STATUS_OPTIONS.map((option) => {
-        const isActive = status === option.value;
-        const count = counts.get(option.value) ?? 0;
-        return (
-          <button
-            key={option.value}
-            type="button"
-            role="tab"
-            aria-selected={isActive}
-            onClick={() => onChange(option.value)}
-            className={clsx(
-              "inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
-              isActive
-                ? "border-brand-500 bg-brand-50 text-brand-700"
-                : "border-slate-200 bg-white text-slate-600 hover:border-brand-300 hover:text-brand-700",
-            )}
-          >
-            <span>{option.label}</span>
-            <span className="text-xs text-slate-400" aria-hidden="true">
-              {count}
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function FilterCountBadge({ count }: { readonly count: number }) {
-  return (
-    <span className="ml-2 inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-brand-100 px-2 py-0.5 text-xs font-semibold text-brand-700">
-      {count}
-    </span>
-  );
-}
-
-interface SearchInputProps {
-  readonly value: string;
-  readonly onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  readonly onClear: () => void;
-  readonly inputRef?: RefObject<HTMLInputElement | null>;
-}
-
-function SearchInput({ value, onChange, onClear, inputRef }: SearchInputProps) {
-  return (
-    <div className="relative">
-      <Input
-        ref={inputRef}
-        type="search"
-        value={value}
-        onChange={onChange}
-        placeholder="Search documents"
-        className="pr-10"
-      />
-      {value.length > 0 ? (
-        <button
-          type="button"
-          onClick={onClear}
-          className="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400 transition hover:text-brand-600 focus:outline-none"
-          aria-label="Clear search"
-        >
-          <CloseIcon />
-        </button>
-      ) : null}
-    </div>
-  );
-}
-
-interface ViewToggleProps {
-  readonly view: "grid" | "list";
-  readonly onChange: (view: "grid" | "list") => void;
-}
-
-function ViewToggle({ view, onChange }: ViewToggleProps) {
-  return (
-    <div className="inline-flex items-center rounded-lg border border-slate-200 bg-white p-1 text-xs font-semibold text-slate-600">
-      <button
-        type="button"
-        onClick={() => onChange("grid")}
-        className={clsx(
-          "rounded-md px-3 py-1 transition",
-          view === "grid" ? "bg-brand-600 text-white shadow-sm" : "hover:bg-slate-100",
-        )}
-        aria-pressed={view === "grid"}
-      >
-        Grid
-      </button>
-      <button
-        type="button"
-        onClick={() => onChange("list")}
-        className={clsx(
-          "rounded-md px-3 py-1 transition",
-          view === "list" ? "bg-brand-600 text-white shadow-sm" : "hover:bg-slate-100",
-        )}
-        aria-pressed={view === "list"}
-      >
-        List
-      </button>
-    </div>
-  );
-}
-
-interface FiltersDropdownProps {
-  readonly open: boolean;
-  readonly anchorRef: RefObject<HTMLButtonElement | null>;
-  readonly filters: {
-    readonly source: string;
-    readonly uploader: string;
-    readonly tag: string;
-    readonly fileType: string;
-    readonly from: string;
-    readonly to: string;
-  };
-  readonly sourceOptions: readonly string[];
-  readonly uploaderOptions: readonly string[];
-  readonly tagOptions: readonly string[];
-  readonly fileTypeOptions: readonly string[];
-  readonly onChange: (key: "source" | "uploader" | "tag" | "fileType", value: string) => void;
-  readonly onChangeDate: (key: "from" | "to", value: string) => void;
-  readonly onClear: () => void;
-  readonly onClose: () => void;
-}
-
-function FiltersDropdown({
-  open,
-  anchorRef,
-  filters,
-  sourceOptions,
-  uploaderOptions,
-  tagOptions,
-  fileTypeOptions,
-  onChange,
-  onChangeDate,
-  onClear,
-  onClose,
-}: FiltersDropdownProps) {
-  const desktopPanelRef = useRef<HTMLDivElement>(null);
-  const mobilePanelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    function handleClick(event: MouseEvent) {
-      const target = event.target as Node;
-      if (
-        desktopPanelRef.current?.contains(target) ||
-        mobilePanelRef.current?.contains(target) ||
-        anchorRef.current?.contains(target as Node)
-      ) {
-        return;
-      }
-      onClose();
-    }
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [anchorRef, onClose, open]);
-
-  if (!open) {
-    return null;
-  }
-
-  const content = (
-    <div className="space-y-4">
-      <FilterSelect
-        id="filter-source"
-        label="Source"
-        value={filters.source}
-        onChange={(value) => onChange("source", value)}
-        options={sourceOptions}
-        placeholder="All sources"
-      />
-      <FilterSelect
-        id="filter-uploader"
-        label="Uploader"
-        value={filters.uploader}
-        onChange={(value) => onChange("uploader", value)}
-        options={uploaderOptions}
-        placeholder="All uploaders"
-      />
-      <FilterSelect
-        id="filter-tag"
-        label="Tag"
-        value={filters.tag}
-        onChange={(value) => onChange("tag", value)}
-        options={tagOptions}
-        placeholder="All tags"
-      />
-      <FilterSelect
-        id="filter-type"
-        label="File type"
-        value={filters.fileType}
-        onChange={(value) => onChange("fileType", value)}
-        options={fileTypeOptions}
-        placeholder="All file types"
-      />
-      <FilterDateField
-        id="filter-from"
-        label="From"
-        value={filters.from}
-        onChange={(value) => onChangeDate("from", value)}
-      />
-      <FilterDateField
-        id="filter-to"
-        label="To"
-        value={filters.to}
-        onChange={(value) => onChangeDate("to", value)}
-      />
-      <div className="flex justify-between gap-3">
-        <Button type="button" variant="ghost" onClick={onClear}>
-          Clear filters
-        </Button>
-        <Button type="button" variant="primary" onClick={onClose}>
-          Done
-        </Button>
-      </div>
-    </div>
-  );
-
-  return (
-    <>
-      <div
-        className="fixed inset-0 z-40 bg-slate-900/20 backdrop-blur-sm md:hidden"
-        aria-hidden
-        onClick={onClose}
-      />
-      <div
-        ref={mobilePanelRef}
-        className="fixed inset-x-0 bottom-0 z-50 max-h-[80vh] overflow-y-auto rounded-t-2xl border border-slate-200 bg-white p-5 shadow-2xl md:hidden"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Filter documents"
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-base font-semibold text-slate-900">Filters</h2>
-          <button
-            type="button"
-            className="focus-ring inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500"
-            aria-label="Close filters"
-            onClick={onClose}
-          >
-            <CloseIcon />
-          </button>
-        </div>
-        {content}
-      </div>
-      <div
-        ref={desktopPanelRef}
-        className="absolute right-0 z-50 mt-2 hidden w-80 rounded-2xl border border-slate-200 bg-white p-5 shadow-xl md:block"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Filter documents"
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-slate-900">Filters</h2>
-          <button
-            type="button"
-            className="focus-ring inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500"
-            aria-label="Close filters"
-            onClick={onClose}
-          >
-            <CloseIcon />
-          </button>
-        </div>
-        {content}
-      </div>
-    </>
-  );
-}
-
-interface FilterSelectProps {
-  readonly id: string;
-  readonly label: string;
-  readonly value: string;
-  readonly onChange: (value: string) => void;
-  readonly options: readonly string[];
-  readonly placeholder: string;
-}
-
-function FilterSelect({ id, label, value, onChange, options, placeholder }: FilterSelectProps) {
-  return (
-    <label htmlFor={id} className="block space-y-1 text-sm">
-      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</span>
-      <select
-        id={id}
-        className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-      >
-        <option value="">{placeholder}</option>
-        {options.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
-function FilterDateField({
-  id,
-  label,
-  value,
-  onChange,
-}: {
-  readonly id: string;
-  readonly label: string;
-  readonly value: string;
-  readonly onChange: (value: string) => void;
-}) {
-  return (
-    <label htmlFor={id} className="block space-y-1 text-sm">
-      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</span>
-      <input
-        id={id}
-        type="date"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
-      />
-    </label>
-  );
-}
-
-interface DocumentsGridProps {
-  readonly documents: readonly DocumentViewModel[];
-  readonly sort: DocumentSort;
-  readonly onSortChange: (field: DocumentSortField) => void;
-  readonly selectedIds: Set<string>;
-  readonly onToggleSelection: (documentId: string, selected: boolean) => void;
-  readonly onSelectAll: (checked: boolean) => void;
-  readonly allSelected: boolean;
-  readonly someSelected: boolean;
-  readonly onOpenDocument: (documentId: string) => void;
-  readonly onFocusDocument: (documentId: string) => void;
-  readonly activeDocumentId: string | null;
-  readonly selectedDocumentId: string | null;
-  readonly onAction: (document: DocumentViewModel, action: DocumentAction) => void;
-  readonly actionsDisabled: boolean;
-  readonly deletePending: boolean;
-  readonly downloadingId: string | null;
-}
-
-function DocumentsGrid({
-  documents,
-  sort,
-  onSortChange,
-  selectedIds,
-  onToggleSelection,
-  onSelectAll,
-  allSelected,
-  someSelected,
-  onOpenDocument,
-  onFocusDocument,
-  activeDocumentId,
-  selectedDocumentId,
-  onAction,
-  actionsDisabled,
-  deletePending,
-  downloadingId,
-}: DocumentsGridProps) {
-  const selectAllRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (selectAllRef.current) {
-      selectAllRef.current.indeterminate = someSelected && !allSelected;
-    }
-  }, [allSelected, someSelected]);
-
-  return (
-    <div className="hidden overflow-hidden rounded-xl border border-slate-200 md:block">
-      <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
-        <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
-          <tr>
-            <th scope="col" className="w-12 px-3 py-3">
-              <input
-                ref={selectAllRef}
-                type="checkbox"
-                className="h-4 w-4 rounded border-slate-300 text-brand-600 focus-visible:ring-brand-500"
-                checked={allSelected}
-                onChange={(event) => onSelectAll(event.target.checked)}
-                aria-label="Select all documents on this page"
-                disabled={actionsDisabled}
-              />
-            </th>
-            <SortableHeader label="Name" active={sort.field === "name"} direction={sort.direction} onClick={() => onSortChange("name")} />
-            <SortableHeader label="Status" active={sort.field === "status"} direction={sort.direction} onClick={() => onSortChange("status")} />
-            <th scope="col" className="px-4 py-3">Source</th>
-            <SortableHeader label="Uploaded" active={sort.field === "uploaded"} direction={sort.direction} onClick={() => onSortChange("uploaded")} />
-            <th scope="col" className="px-4 py-3">Last run</th>
-            <th scope="col" className="px-4 py-3 text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-slate-100 bg-white">
-          {documents.map((document) => {
-            const isSelected = selectedIds.has(document.id);
-            const isActive = activeDocumentId === document.id || selectedDocumentId === document.id;
-            return (
-              <tr
-                key={document.id}
-                className={clsx(
-                  "group focus-within:bg-brand-50/40",
-                  isActive ? "bg-brand-50/40" : "hover:bg-slate-50",
-                )}
-              >
-                <td className="px-3 py-3">
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border-slate-300 text-brand-600 focus-visible:ring-brand-500"
-                    checked={isSelected}
-                    onChange={(event) => onToggleSelection(document.id, event.target.checked)}
-                    aria-label={`Select ${document.name}`}
-                    onFocus={() => onFocusDocument(document.id)}
-                    disabled={actionsDisabled}
-                  />
-                </td>
-                <td className="max-w-xs px-4 py-3">
-                  <button
-                    type="button"
-                    className="text-sm font-semibold text-slate-800 hover:text-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-                    onClick={() => onOpenDocument(document.id)}
-                    onFocus={() => onFocusDocument(document.id)}
-                  >
-                    {document.name}
-                  </button>
-                  <div className="text-xs text-slate-500">{document.fileType}</div>
-                </td>
-                <td className="px-4 py-3">
-                  <span className={clsx("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold", STATUS_BADGES[document.status])}>
-                    {capitalise(document.status)}
-                  </span>
-                </td>
-                <td className="px-4 py-3 text-slate-600">{document.source}</td>
-                <td className="px-4 py-3 text-slate-600">{formatUploaded(document.uploadedAtDate)}</td>
-                <td className="px-4 py-3 text-slate-600">
-                  <div className="flex flex-col">
-                    <span className="font-medium text-slate-700">{document.lastRun.result}</span>
-                    <span className="text-xs text-slate-500">{formatDateTime(document.lastRun.timestamp)}</span>
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <DocumentActionsMenu
-                    documentId={document.id}
-                    onOpenDetails={() => onOpenDocument(document.id)}
-                    onAction={(action) => onAction(document, action)}
-                    disabled={actionsDisabled}
-                    isDeleting={deletePending}
-                    isDownloading={downloadingId === document.id}
-                  />
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-interface DocumentsListProps {
-  readonly documents: readonly DocumentViewModel[];
-  readonly selectedIds: Set<string>;
-  readonly onToggleSelection: (documentId: string, selected: boolean) => void;
-  readonly onOpenDocument: (documentId: string) => void;
-  readonly onFocusDocument: (documentId: string) => void;
-  readonly selectedDocumentId: string | null;
-  readonly onAction: (document: DocumentViewModel, action: DocumentAction) => void;
-  readonly actionsDisabled: boolean;
-  readonly deletePending: boolean;
-  readonly downloadingId: string | null;
-}
-
-function DocumentsList({
-  documents,
-  selectedIds,
-  onToggleSelection,
-  onOpenDocument,
-  onFocusDocument,
-  selectedDocumentId,
-  onAction,
-  actionsDisabled,
-  deletePending,
-  downloadingId,
-}: DocumentsListProps) {
-  return (
-    <div className="hidden space-y-3 md:block">
-      {documents.map((document) => {
-        const isSelected = selectedIds.has(document.id);
-        const isActive = selectedDocumentId === document.id;
-        return (
-          <div
-            key={document.id}
-            className={clsx(
-              "rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-brand-200 hover:shadow-md",
-              isActive && "border-brand-300 ring-1 ring-brand-200",
-            )}
-          >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="flex items-start gap-3">
-                <input
-                  type="checkbox"
-                  className="mt-1 h-4 w-4 rounded border-slate-300 text-brand-600 focus-visible:ring-brand-500"
-                  checked={isSelected}
-                  onChange={(event) => onToggleSelection(document.id, event.target.checked)}
-                  aria-label={`Select ${document.name}`}
-                  disabled={actionsDisabled}
-                />
-                <div>
-                  <button
-                    type="button"
-                    className="text-lg font-semibold text-slate-900 hover:text-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-                    onClick={() => onOpenDocument(document.id)}
-                    onFocus={() => onFocusDocument(document.id)}
-                  >
-                    {document.name}
-                  </button>
-                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                    <span>{document.fileType}</span>
-                    <span aria-hidden className="text-slate-300">
-                      •
-                    </span>
-                    <span>{document.source}</span>
-                    {document.tags.length > 0 ? (
-                      <>
-                        <span aria-hidden className="text-slate-300">
-                          •
-                        </span>
-                        <span>{document.tags.join(", ")}</span>
-                      </>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-              <DocumentActionsMenu
-                documentId={document.id}
-                onOpenDetails={() => onOpenDocument(document.id)}
-                onAction={(action) => onAction(document, action)}
-                disabled={actionsDisabled}
-                isDeleting={deletePending}
-                isDownloading={downloadingId === document.id}
-              />
-            </div>
-            <dl className="mt-4 grid gap-4 text-sm text-slate-600 md:grid-cols-4">
-              <div>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Status</dt>
-                <dd>
-                  <span className={clsx("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold", STATUS_BADGES[document.status])}>
-                    {capitalise(document.status)}
-                  </span>
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Uploaded</dt>
-                <dd>{formatUploaded(document.uploadedAtDate)}</dd>
-              </div>
-              <div>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Last run</dt>
-                <dd>
-                  <div className="font-medium text-slate-700">{document.lastRun.result}</div>
-                  <div className="text-xs text-slate-500">{formatDateTime(document.lastRun.timestamp)}</div>
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Size</dt>
-                <dd>{formatFileSize(document.byteSize)}</dd>
-              </div>
-            </dl>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-interface DocumentsMobileListProps {
-  readonly documents: readonly DocumentViewModel[];
-  readonly selectedIds: Set<string>;
-  readonly onToggleSelection: (documentId: string, selected: boolean) => void;
-  readonly onOpenDocument: (documentId: string) => void;
-  readonly onFocusDocument: (documentId: string) => void;
-  readonly selectedDocumentId: string | null;
-  readonly onAction: (document: DocumentViewModel, action: DocumentAction) => void;
-  readonly actionsDisabled: boolean;
-  readonly deletePending: boolean;
-  readonly downloadingId: string | null;
-}
-
-function DocumentsMobileList({
-  documents,
-  selectedIds,
-  onToggleSelection,
-  onOpenDocument,
-  onFocusDocument,
-  selectedDocumentId,
-  onAction,
-  actionsDisabled,
-  deletePending,
-  downloadingId,
-}: DocumentsMobileListProps) {
-  return (
-    <div className="space-y-3 md:hidden">
-      {documents.map((document) => {
-        const isSelected = selectedIds.has(document.id);
-        const isActive = selectedDocumentId === document.id;
-        return (
-          <div
-            key={document.id}
-            className={clsx(
-              "rounded-xl border border-slate-200 bg-white p-4 shadow-sm",
-              isActive && "border-brand-300",
-            )}
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex items-start gap-3">
-                <input
-                  type="checkbox"
-                  className="mt-1 h-4 w-4 rounded border-slate-300 text-brand-600 focus-visible:ring-brand-500"
-                  checked={isSelected}
-                  onChange={(event) => onToggleSelection(document.id, event.target.checked)}
-                  aria-label={`Select ${document.name}`}
-                  disabled={actionsDisabled}
-                />
-                <div>
-                  <button
-                    type="button"
-                    className="text-base font-semibold text-slate-900 hover:text-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-                    onClick={() => onOpenDocument(document.id)}
-                    onFocus={() => onFocusDocument(document.id)}
-                  >
-                    {document.name}
-                  </button>
-                  <div className="mt-1 text-xs text-slate-500">
-                    {document.fileType} • {document.source}
-                  </div>
-                </div>
-              </div>
-              <DocumentActionsMenu
-                documentId={document.id}
-                onOpenDetails={() => onOpenDocument(document.id)}
-                onAction={(action) => onAction(document, action)}
-                disabled={actionsDisabled}
-                isDeleting={deletePending}
-                isDownloading={downloadingId === document.id}
-              />
-            </div>
-            <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-600">
-              <span className={clsx("inline-flex items-center rounded-full px-2 py-0.5 font-semibold", STATUS_BADGES[document.status])}>
-                {capitalise(document.status)}
-              </span>
-              <span>Uploaded {formatUploaded(document.uploadedAtDate)}</span>
-              <span>•</span>
-              <span>{document.lastRun.result}</span>
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-interface SortableHeaderProps {
-  readonly label: string;
-  readonly active: boolean;
-  readonly direction: DocumentSortDirection;
-  readonly onClick: () => void;
-}
-
-function SortableHeader({ label, active, direction, onClick }: SortableHeaderProps) {
-  return (
-    <th scope="col" className="px-4 py-3">
-      <button
-        type="button"
-        onClick={onClick}
-        className={clsx(
-          "inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide",
-          active ? "text-brand-700" : "text-slate-500 hover:text-brand-600",
-        )}
-      >
-        {label}
-        <span aria-hidden className="text-slate-400">
-          {active ? (direction === "asc" ? "↑" : "↓") : "↕"}
-        </span>
-      </button>
-    </th>
-  );
-}
-
-interface DocumentActionsMenuProps {
-  readonly documentId: string;
-  readonly onOpenDetails: () => void;
-  readonly onAction: (action: DocumentAction) => void;
-  readonly disabled?: boolean;
-  readonly isDeleting?: boolean;
-  readonly isDownloading?: boolean;
-}
-
-function DocumentActionsMenu({
-  documentId,
-  onOpenDetails,
-  onAction,
-  disabled = false,
-  isDeleting = false,
-  isDownloading = false,
-}: DocumentActionsMenuProps) {
-  const [open, setOpen] = useState(false);
-  const anchorRef = useRef<HTMLButtonElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    function handleClick(event: MouseEvent) {
-      const target = event.target as Node;
-      if (panelRef.current?.contains(target) || anchorRef.current?.contains(target)) {
-        return;
-      }
-      setOpen(false);
-    }
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [open]);
-
-  return (
-    <div className="relative inline-flex">
-      <button
-        ref={anchorRef}
-        type="button"
-        className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition hover:border-brand-200 hover:text-brand-600 disabled:cursor-not-allowed disabled:opacity-60"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => {
-          if (disabled) {
-            return;
-          }
-          setOpen((current) => !current);
-        }}
-        disabled={disabled}
-        aria-label={`Open actions for document ${documentId}`}
-      >
-        <DotsIcon />
-      </button>
-      {open ? (
-        <div
-          ref={panelRef}
-          className="absolute right-0 z-50 mt-2 w-48 rounded-xl border border-slate-200 bg-white p-2 text-sm text-slate-600 shadow-xl"
-          role="menu"
-        >
-          <MenuButton
-            label="Open details"
-            onClick={() => {
-              onOpenDetails();
-              setOpen(false);
-            }}
-          />
-          <MenuButton
-            label="Start / retry extraction"
-            onClick={() => {
-              onAction("retry");
-              setOpen(false);
-            }}
-            disabled={disabled}
-          />
-          <MenuButton
-            label="Archive"
-            onClick={() => {
-              onAction("archive");
-              setOpen(false);
-            }}
-            disabled={disabled}
-          />
-          <MenuButton
-            label="Download"
-            onClick={() => {
-              onAction("download");
-              setOpen(false);
-            }}
-            disabled={disabled}
-            loading={isDownloading}
-          />
-          <MenuButton
-            label="Delete"
-            tone="danger"
-            onClick={() => {
-              onAction("delete");
-              setOpen(false);
-            }}
-            disabled={disabled}
-            loading={isDeleting}
-          />
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function MenuButton({
-  label,
-  onClick,
-  tone = "default",
-  disabled = false,
-  loading = false,
-}: {
-  readonly label: string;
-  readonly onClick: () => void;
-  readonly tone?: "default" | "danger";
-  readonly disabled?: boolean;
-  readonly loading?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled || loading}
-      className={clsx(
-        "flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-60",
-        tone === "danger"
-          ? "text-danger-600 hover:bg-danger-50"
-          : "text-slate-600 hover:bg-slate-100",
-      )}
-      role="menuitem"
-    >
-      <span>{label}</span>
-      {loading ? (
-        <span
-          aria-hidden
-          className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-        />
-      ) : null}
-    </button>
-  );
-}
-
-interface PaginationProps {
-  readonly page: number;
-  readonly totalPages: number;
-  readonly onChange: (page: number) => void;
-}
-
-function Pagination({ page, totalPages, onChange }: PaginationProps) {
-  if (totalPages <= 1) {
-    return null;
-  }
-  const previousDisabled = page <= 1;
-  const nextDisabled = page >= totalPages;
-  return (
-    <div className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm">
-      <div>
-        Page {page} of {totalPages}
-      </div>
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          disabled={previousDisabled}
-          onClick={() => onChange(page - 1)}
-        >
-          Previous
-        </Button>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          disabled={nextDisabled}
-          onClick={() => onChange(page + 1)}
-        >
-          Next
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-interface BulkActionBarProps {
-  readonly count: number;
-  readonly onRetry: () => void;
-  readonly onArchive: () => void;
-  readonly onDelete: () => void;
-  readonly isProcessing?: boolean;
-}
-
-function BulkActionBar({ count, onRetry, onArchive, onDelete, isProcessing = false }: BulkActionBarProps) {
-  return (
-    <div className="sticky bottom-4 flex items-center justify-between gap-3 rounded-full border border-slate-200 bg-white px-5 py-3 text-sm text-slate-700 shadow-lg">
-      <div className="font-semibold">{count} selected</div>
-      <div className="flex items-center gap-2">
-        <Button type="button" variant="secondary" size="sm" onClick={onRetry} disabled={isProcessing}>
-          Retry
-        </Button>
-        <Button type="button" variant="secondary" size="sm" onClick={onArchive} disabled={isProcessing}>
-          Archive
-        </Button>
-        <Button type="button" variant="danger" size="sm" onClick={onDelete} isLoading={isProcessing}>
-          Delete
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function ActionFeedbackBanner({
-  feedback,
-  onDismiss,
-}: {
-  readonly feedback: ActionFeedback;
-  readonly onDismiss: () => void;
-}) {
-  return (
-    <div className="relative">
-      <Alert tone={feedback.tone} className="pr-12">
-        {feedback.message}
-      </Alert>
-      <button
-        type="button"
-        className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 text-slate-500 transition hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-        aria-label="Dismiss message"
-        onClick={onDismiss}
-      >
-        <CloseIcon />
-      </button>
-    </div>
-  );
-}
-
-function DocumentDropOverlay({
-  isVisible,
-  isUploading,
-}: {
-  readonly isVisible: boolean;
-  readonly isUploading: boolean;
-}) {
-  if (!isVisible) {
-    return null;
-  }
-
-  return (
-    <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center bg-slate-900/30 backdrop-blur-sm">
-      <div className="pointer-events-auto flex w-full max-w-lg flex-col items-center gap-3 rounded-3xl border-2 border-dashed border-brand-400 bg-white/95 px-10 py-12 text-center shadow-2xl">
-        <div className="text-xl font-semibold text-slate-900">Drop files to upload</div>
-        <p className="text-sm text-slate-600">Files are added to this workspace and queued for extraction.</p>
-        <p className="text-xs font-medium uppercase tracking-wide text-brand-600">
-          {isUploading ? "Uploading…" : "Release to start upload"}
-        </p>
-        <p className="text-xs text-slate-400">Supported: {SUPPORTED_FILE_TYPES_LABEL}</p>
-      </div>
-    </div>
-  );
-}
-
-function UploadProgressPanel({
-  files,
-  isUploading,
-}: {
-  readonly files: readonly PendingUploadItem[];
-  readonly isUploading: boolean;
-}) {
-  if (!isUploading || files.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="fixed bottom-6 right-6 z-30 w-full max-w-xs overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur">
-      <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-3">
-        <UploadSpinner />
-        <div className="min-w-0 text-sm font-medium text-slate-900">
-          {files.length === 1 ? "Uploading 1 document" : `Uploading ${files.length} documents`}
-        </div>
-      </div>
-      <ul className="max-h-48 space-y-1 overflow-y-auto px-4 py-3 text-sm text-slate-600">
-        {files.map((file) => (
-          <li key={file.id} className="flex items-center justify-between gap-3">
-            <span className="truncate" title={file.name}>
-              {file.name}
-            </span>
-            <span className="shrink-0 text-xs text-slate-400">{formatFileSize(file.size)}</span>
-          </li>
-        ))}
-      </ul>
-      <div className="border-t border-slate-100 px-4 py-2 text-xs text-slate-400">
-        Keep this tab open until uploads finish.
-      </div>
-    </div>
-  );
-}
-
-function EmptyAllState({
-  onUpload,
-  isUploadPending,
-}: {
-  readonly onUpload: () => void;
-  readonly isUploadPending: boolean;
-}) {
-  return (
-    <section className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center">
-      <div className="space-y-3">
-        <h1 className="text-2xl font-semibold text-slate-900">Upload your first spreadsheet or PDF</h1>
-        <p className="text-sm text-slate-500">
-          Drag and drop files or click upload to start extracting data for this workspace.
-        </p>
-      </div>
-      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
-        <Button type="button" onClick={onUpload} isLoading={isUploadPending}>
-          Upload documents
-        </Button>
-      </div>
-      <div className="mt-6 w-full max-w-xl rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-6 py-5 text-sm text-slate-500">
-        Supported types: {SUPPORTED_FILE_TYPES_LABEL}. Files stay private to this workspace.
-      </div>
-    </section>
-  );
-}
-
-function EmptyFilteredState({ onClearFilters }: { readonly onClearFilters: () => void }) {
-  return (
-    <section className="flex flex-col items-center justify-center rounded-3xl border border-slate-200 bg-white px-6 py-16 text-center">
-      <div className="space-y-3">
-        <h1 className="text-2xl font-semibold text-slate-900">No documents match these filters</h1>
-        <p className="text-sm text-slate-500">Try adjusting your filters or widening the date range.</p>
-      </div>
-      <Button type="button" variant="secondary" className="mt-6" onClick={onClearFilters}>
-        Clear filters
-      </Button>
-    </section>
-  );
-}
-
-function DocumentInspector({
-  document,
-  onRetry,
-  onOpenRuns,
-  onDownload,
-  isDownloading,
-}: {
-  readonly document: DocumentViewModel;
-  readonly onRetry: () => void;
-  readonly onOpenRuns: () => void;
-  readonly onDownload: () => void;
-  readonly isDownloading: boolean;
-}) {
-  return (
-    <div className="space-y-6">
-      <header className="space-y-1">
-        <h3 className="text-lg font-semibold text-slate-900">{document.name}</h3>
-        <p className="text-sm text-slate-500">{document.fileType}</p>
-      </header>
-      <section className="space-y-3">
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Preview</h4>
-        <div className="flex h-40 items-center justify-center rounded-xl border border-slate-200 bg-slate-50 text-sm text-slate-400">
-          Preview coming soon
-        </div>
-      </section>
-      <section className="space-y-3">
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Metadata</h4>
-        <dl className="divide-y divide-slate-200 rounded-xl border border-slate-200">
-          <InspectorRow label="Status">
-            <span className={clsx("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold", STATUS_BADGES[document.status])}>
-              {capitalise(document.status)}
-            </span>
-          </InspectorRow>
-          <InspectorRow label="Source">{document.source}</InspectorRow>
-          <InspectorRow label="Uploader">{document.uploader}</InspectorRow>
-          <InspectorRow label="Uploaded">{formatUploaded(document.uploadedAtDate)}</InspectorRow>
-          <InspectorRow label="Size">{formatFileSize(document.byteSize)}</InspectorRow>
-        </dl>
-      </section>
-      <section className="space-y-3">
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Last run</h4>
-        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-          <div className="font-semibold text-slate-800">{document.lastRun.result}</div>
-          <div className="text-xs text-slate-500">{formatDateTime(document.lastRun.timestamp)}</div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button type="button" variant="secondary" onClick={onRetry}>
+      <PageState
+        title="Unable to load documents"
+        description="Refresh the page or try again later."
+        variant="error"
+        action={
+          <Button variant="secondary" onClick={() => documentsQuery.refetch()}>
             Retry
           </Button>
-          <Button type="button" variant="ghost" onClick={onDownload} isLoading={isDownloading}>
-            Download
-          </Button>
-          <Button type="button" variant="primary" onClick={onOpenRuns}>
-            Open in Runs
-          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <section className="flex h-full flex-col gap-3">
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={SUPPORTED_FILE_EXTENSIONS.join(",")}
+        className="hidden"
+        onChange={handleFileInputChange}
+      />
+
+      {feedback ? <Alert tone={feedback.tone}>{feedback.message}</Alert> : null}
+
+      <div
+        role="region"
+        aria-label="Workspace documents"
+        aria-busy={documentsQuery.isFetching}
+        className={clsx(
+          "relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-soft transition",
+          isDragging ? "border-dashed border-brand-400 ring-4 ring-brand-100" : "hover:border-slate-300",
+        )}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
+        <DocumentsToolbar
+          owner={ownerFilter}
+          onOwnerChange={handleOwnerChange}
+          status={statusFilter}
+          onStatusChange={handleStatusChange}
+          search={searchTerm}
+          onSearchChange={setSearchTerm}
+          onUploadClick={handleUploadClick}
+          isUploading={uploadDocuments.isPending}
+          resultCount={resultCount}
+          totalCount={totalCount}
+        />
+
+        <div className="relative flex-1">
+          {hasVisibleDocuments ? (
+            <DocumentsTable
+              rows={visibleDocuments}
+              sortState={sortState}
+              onSortChange={handleSortChange}
+              onInspect={handleInspect}
+              onDownload={handleDownload}
+              onDelete={handleDelete}
+              downloadingId={downloadingId}
+              deletingId={deletingId}
+            />
+          ) : (
+            <DocumentsEmptyState
+              owner={ownerFilter}
+              status={statusFilter}
+              hasDocuments={hasDocuments}
+              onViewAll={() => handleOwnerChange("all")}
+              onClearStatus={() => handleStatusChange("all")}
+              onUpload={handleUploadClick}
+              isUploading={uploadDocuments.isPending}
+            />
+          )}
+
+          {isDragging ? (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl border-4 border-dashed border-brand-300 bg-brand-50/80 text-sm font-semibold text-brand-700">
+              Drop files to upload
+            </div>
+          ) : null}
         </div>
-      </section>
-      <section className="space-y-3">
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Raw metadata</h4>
-        <pre className="max-h-48 overflow-auto rounded-xl border border-slate-200 bg-slate-900/90 p-3 text-xs text-slate-100">
-          {JSON.stringify(document.metadata, null, 2)}
-        </pre>
-      </section>
-    </div>
+      </div>
+    </section>
   );
 }
-
-function InspectorRow({ label, children }: { readonly label: string; readonly children: ReactNode }) {
-  return (
-    <div className="flex items-center justify-between gap-3 px-4 py-3 text-sm text-slate-600">
-      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</dt>
-      <dd className="text-right">{children}</dd>
-    </div>
-  );
-}
-
-function CloseIcon() {
-  return (
-    <svg className="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
-      <path d="M5 5l10 10M15 5l-10 10" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
-function DotsIcon() {
-  return (
-    <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
-      <circle cx="4" cy="10" r="1.5" />
-      <circle cx="10" cy="10" r="1.5" />
-      <circle cx="16" cy="10" r="1.5" />
-    </svg>
-  );
-}
-

--- a/frontend/src/app/routes/documents/components/DocumentDetails.tsx
+++ b/frontend/src/app/routes/documents/components/DocumentDetails.tsx
@@ -1,0 +1,50 @@
+import type { DocumentRow } from "../utils";
+import { formatDateTime, formatFileSize, formatStatusLabel } from "../utils";
+
+interface DocumentDetailsProps {
+  readonly document: DocumentRow;
+}
+
+export function DocumentDetails({ document }: DocumentDetailsProps) {
+  return (
+    <div className="flex flex-col gap-6 text-sm text-slate-600">
+      <section className="flex flex-col gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Document</h3>
+        <dl className="space-y-2">
+          <Detail term="Name" value={document.name} />
+          <Detail term="Status" value={formatStatusLabel(document.status)} />
+          <Detail term="Source" value={document.source} />
+          <Detail term="Uploaded" value={formatDateTime(document.uploadedAt)} />
+          <Detail term="Last run" value={document.lastRunAt ? `${document.lastRunLabel} (${formatDateTime(document.lastRunAt)})` : document.lastRunLabel} />
+          <Detail term="Size" value={formatFileSize(document.byteSize)} />
+        </dl>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Uploader</h3>
+        <dl className="space-y-2">
+          <Detail term="Name" value={document.uploaderName} />
+          {document.uploaderEmail ? <Detail term="Email" value={document.uploaderEmail} /> : null}
+        </dl>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Metadata</h3>
+        <pre className="max-h-64 overflow-auto rounded-md bg-slate-100 p-3 text-xs text-slate-700">
+          {JSON.stringify(document.metadata, null, 2)}
+        </pre>
+      </section>
+    </div>
+  );
+}
+
+function Detail({ term, value }: { readonly term: string; readonly value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{term}</dt>
+      <dd className="max-w-[65%] truncate text-sm text-slate-700" title={value}>
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/frontend/src/app/routes/documents/components/DocumentsEmptyState.tsx
+++ b/frontend/src/app/routes/documents/components/DocumentsEmptyState.tsx
@@ -1,0 +1,66 @@
+import { Button } from "../../../../ui";
+import type { OwnerFilterValue, StatusFilterValue } from "../utils";
+
+interface DocumentsEmptyStateProps {
+  readonly owner: OwnerFilterValue;
+  readonly status: StatusFilterValue;
+  readonly hasDocuments: boolean;
+  readonly onViewAll: () => void;
+  readonly onClearStatus: () => void;
+  readonly onUpload: () => void;
+  readonly isUploading: boolean;
+}
+
+export function DocumentsEmptyState({
+  owner,
+  status,
+  hasDocuments,
+  onViewAll,
+  onClearStatus,
+  onUpload,
+  isUploading,
+}: DocumentsEmptyStateProps) {
+  if (!hasDocuments) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+        <h2 className="text-lg font-semibold text-slate-800">Upload your first document</h2>
+        <p className="max-w-md text-sm text-slate-500">
+          Drag and drop a file anywhere in this panel or use the upload button to get started.
+        </p>
+        <Button onClick={onUpload} isLoading={isUploading}>
+          Upload documents
+        </Button>
+      </div>
+    );
+  }
+
+  const ownerDescription = owner === "mine" ? "your uploads" : "workspace uploads";
+  const statusDescription = status === "all" ? "" : ` (${status})`;
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+      <div>
+        <h2 className="text-lg font-semibold text-slate-800">No documents match the current filters</h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500">
+          Showing {ownerDescription}
+          {statusDescription}. Adjust the filters or upload a new document.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        {owner === "mine" ? (
+          <Button variant="secondary" onClick={onViewAll}>
+            View all documents
+          </Button>
+        ) : null}
+        {status !== "all" ? (
+          <Button variant="secondary" onClick={onClearStatus}>
+            Clear status filter
+          </Button>
+        ) : null}
+        <Button onClick={onUpload} isLoading={isUploading}>
+          Upload documents
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/routes/documents/components/DocumentsTable.tsx
+++ b/frontend/src/app/routes/documents/components/DocumentsTable.tsx
@@ -1,0 +1,247 @@
+import clsx from "clsx";
+
+import { Button } from "../../../../ui";
+import type { DocumentRow, SortColumn, SortState } from "../utils";
+import { formatDateTime, formatFileSize, formatRelativeTime, formatStatusLabel } from "../utils";
+
+interface DocumentsTableProps {
+  readonly rows: readonly DocumentRow[];
+  readonly sortState: SortState;
+  readonly onSortChange: (column: SortColumn) => void;
+  readonly onInspect: (row: DocumentRow) => void;
+  readonly onDownload: (row: DocumentRow) => void;
+  readonly onDelete: (row: DocumentRow) => void;
+  readonly downloadingId: string | null;
+  readonly deletingId: string | null;
+}
+
+const columns: { id: SortColumn | "tags" | "actions"; label: string; widthClass?: string; align?: "start" | "center" | "end"; sortable?: boolean }[] = [
+  { id: "name", label: "Document", widthClass: "w-[26%]", sortable: true },
+  { id: "status", label: "Status", widthClass: "w-[11%]", sortable: true },
+  { id: "source", label: "Source", widthClass: "w-[13%]", sortable: true },
+  { id: "uploadedAt", label: "Uploaded", widthClass: "w-[14%]", sortable: true },
+  { id: "lastRunAt", label: "Last run", widthClass: "w-[14%]", sortable: true },
+  { id: "byteSize", label: "Size", widthClass: "w-[8%]", sortable: true, align: "end" },
+  { id: "tags", label: "Tags", widthClass: "w-[14%]" },
+  { id: "actions", label: "Actions", widthClass: "w-[10%]", align: "end" },
+];
+
+const STATUS_BADGES = {
+  inbox: "bg-indigo-100 text-indigo-700",
+  processing: "bg-amber-100 text-amber-800",
+  completed: "bg-emerald-100 text-emerald-700",
+  failed: "bg-danger-100 text-danger-700",
+  archived: "bg-slate-200 text-slate-700",
+} as const satisfies Record<DocumentRow["status"], string>;
+
+export function DocumentsTable({
+  rows,
+  sortState,
+  onSortChange,
+  onInspect,
+  onDownload,
+  onDelete,
+  downloadingId,
+  deletingId,
+}: DocumentsTableProps) {
+  return (
+    <div role="grid" className="absolute inset-0 overflow-auto">
+      <table className="min-w-full border-separate border-spacing-0 text-sm">
+        <caption className="sr-only">Workspace documents</caption>
+        <colgroup>
+          {columns.map((column) => (
+            <col key={column.id} className={column.widthClass} />
+          ))}
+        </colgroup>
+        <thead className="sticky top-0 z-10 bg-white shadow-[0_1px_0_rgba(15,23,42,0.08)]">
+          <tr>
+            {columns.map((column) => (
+              <TableHeaderCell
+                key={column.id}
+                column={column}
+                sortState={sortState}
+                onSortChange={onSortChange}
+              />
+            ))}
+          </tr>
+        </thead>
+        <tbody className="bg-white">
+          {rows.map((row) => (
+            <DocumentsRow
+              key={row.id}
+              row={row}
+              onInspect={onInspect}
+              onDownload={onDownload}
+              onDelete={onDelete}
+              isDownloading={downloadingId === row.id}
+              isDeleting={deletingId === row.id}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface HeaderColumn {
+  readonly id: (typeof columns)[number]["id"];
+  readonly label: string;
+  readonly widthClass?: string;
+  readonly align?: "start" | "center" | "end";
+  readonly sortable?: boolean;
+}
+
+interface TableHeaderCellProps {
+  readonly column: HeaderColumn;
+  readonly sortState: SortState;
+  readonly onSortChange: (column: SortColumn) => void;
+}
+
+function TableHeaderCell({ column, sortState, onSortChange }: TableHeaderCellProps) {
+  const alignment =
+    column.align === "end"
+      ? "justify-end text-right"
+      : column.align === "center"
+        ? "justify-center text-center"
+        : "justify-start text-left";
+
+  const baseClass = "px-4 py-3 text-xs font-semibold uppercase tracking-wide";
+
+  if (!column.sortable) {
+    return (
+      <th scope="col" className={clsx(baseClass, "text-slate-500", alignment)}>
+        {column.label}
+      </th>
+    );
+  }
+
+  const isActive = sortState.column === column.id;
+  const nextDirection = isActive && sortState.direction === "asc" ? "desc" : "asc";
+  const ariaSort = isActive ? (sortState.direction === "asc" ? "ascending" : "descending") : "none";
+
+  return (
+    <th scope="col" className="px-4 py-3" aria-sort={ariaSort}>
+      <button
+        type="button"
+        onClick={() => onSortChange(column.id as SortColumn)}
+        className={clsx(
+          "flex w-full items-center gap-2 text-xs font-semibold uppercase tracking-wide transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+          alignment,
+          isActive ? "text-brand-600" : "text-slate-500 hover:text-slate-700",
+        )}
+      >
+        <span className="truncate">{column.label}</span>
+        <span aria-hidden="true" className={clsx("text-[10px]", isActive ? "opacity-100" : "opacity-0")}> 
+          {isActive ? (sortState.direction === "asc" ? "▲" : "▼") : "▲"}
+        </span>
+        <span className="sr-only">Sort by {column.label} ({nextDirection})</span>
+      </button>
+    </th>
+  );
+}
+
+interface DocumentsRowProps {
+  readonly row: DocumentRow;
+  readonly onInspect: (row: DocumentRow) => void;
+  readonly onDownload: (row: DocumentRow) => void;
+  readonly onDelete: (row: DocumentRow) => void;
+  readonly isDownloading: boolean;
+  readonly isDeleting: boolean;
+}
+
+function DocumentsRow({ row, onInspect, onDownload, onDelete, isDownloading, isDeleting }: DocumentsRowProps) {
+  const isBusy = isDownloading || isDeleting;
+
+  return (
+    <tr
+      className={clsx("border-b border-slate-100 last:border-b-0", isBusy ? "opacity-60" : "", "hover:bg-slate-50")}
+      aria-busy={isBusy || undefined}
+    >
+      <th scope="row" className="px-4 py-4 align-top">
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={() => onInspect(row)}
+            className="max-w-full truncate text-left text-sm font-semibold text-slate-900 transition hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+          >
+            {row.name}
+          </button>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+            <span>{row.uploaderName}</span>
+            {row.contentType ? <span className="text-slate-400">• {row.contentType}</span> : null}
+          </div>
+        </div>
+      </th>
+      <td className="px-4 py-4 align-top">
+        <StatusBadge status={row.status} />
+      </td>
+      <td className="px-4 py-4 align-top text-slate-700">
+        <span className="block truncate" title={row.source}>
+          {row.source}
+        </span>
+      </td>
+      <td className="px-4 py-4 align-top text-slate-700">
+        <Timestamp value={row.uploadedAt} />
+      </td>
+      <td className="px-4 py-4 align-top text-slate-700">
+        {row.lastRunAt ? <Timestamp value={row.lastRunAt} description={row.lastRunLabel} /> : <span className="text-sm text-slate-500">{row.lastRunLabel}</span>}
+      </td>
+      <td className="px-4 py-4 align-top text-right text-sm font-semibold text-slate-700">{formatFileSize(row.byteSize)}</td>
+      <td className="px-4 py-4 align-top">
+        <TagList tags={row.tags} />
+      </td>
+      <td className="px-4 py-4 align-top">
+        <div className="flex flex-wrap justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={() => onInspect(row)}>
+            Details
+          </Button>
+          <Button variant="secondary" size="sm" onClick={() => onDownload(row)} isLoading={isDownloading}>
+            Download
+          </Button>
+          <Button variant="danger" size="sm" onClick={() => onDelete(row)} isLoading={isDeleting}>
+            Delete
+          </Button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function Timestamp({ value, description }: { readonly value: Date; readonly description?: string }) {
+  return (
+    <div className="flex flex-col">
+      <time dateTime={value.toISOString()}>{formatDateTime(value)}</time>
+      <span className="text-xs text-slate-400">
+        {description ? `${description} • ` : ""}
+        {formatRelativeTime(value)}
+      </span>
+    </div>
+  );
+}
+
+function TagList({ tags }: { readonly tags: readonly string[] }) {
+  if (!tags.length) {
+    return <span className="text-slate-400">—</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {tags.map((tag) => (
+        <span key={tag} className="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { readonly status: DocumentRow["status"] }) {
+  return (
+    <span
+      className={clsx("inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold", STATUS_BADGES[status])}
+      aria-label={`Status: ${formatStatusLabel(status)}`}
+    >
+      {formatStatusLabel(status)}
+    </span>
+  );
+}

--- a/frontend/src/app/routes/documents/components/DocumentsToolbar.tsx
+++ b/frontend/src/app/routes/documents/components/DocumentsToolbar.tsx
@@ -1,0 +1,133 @@
+import { useId } from "react";
+
+import { Button, Input, Select } from "../../../../ui";
+import { OWNER_FILTER_OPTIONS, STATUS_FILTER_OPTIONS } from "../utils";
+import type { OwnerFilterValue, StatusFilterValue } from "../utils";
+
+interface DocumentsToolbarProps {
+  readonly owner: OwnerFilterValue;
+  readonly onOwnerChange: (value: OwnerFilterValue) => void;
+  readonly status: StatusFilterValue;
+  readonly onStatusChange: (value: StatusFilterValue) => void;
+  readonly search: string;
+  readonly onSearchChange: (value: string) => void;
+  readonly onUploadClick: () => void;
+  readonly isUploading: boolean;
+  readonly resultCount: number;
+  readonly totalCount: number;
+}
+
+export function DocumentsToolbar({
+  owner,
+  onOwnerChange,
+  status,
+  onStatusChange,
+  search,
+  onSearchChange,
+  onUploadClick,
+  isUploading,
+  resultCount,
+  totalCount,
+}: DocumentsToolbarProps) {
+  const showTotal = totalCount > 0 && totalCount !== resultCount;
+  const formattedCurrent = resultCount.toLocaleString();
+  const formattedTotal = totalCount.toLocaleString();
+  const label = showTotal ? `${formattedCurrent} of ${formattedTotal}` : formattedCurrent;
+  const noun = resultCount === 1 ? "result" : "results";
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-5 py-3">
+      <div className="flex flex-1 flex-wrap items-center gap-3">
+        <FilterSelect
+          label="Showing"
+          value={owner}
+          onChange={onOwnerChange}
+          options={OWNER_FILTER_OPTIONS}
+          widthClass="w-44"
+        />
+        <FilterSelect
+          label="Status"
+          value={status}
+          onChange={onStatusChange}
+          options={STATUS_FILTER_OPTIONS}
+          widthClass="w-48"
+        />
+        <SearchField value={search} onChange={onSearchChange} />
+      </div>
+      <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <span aria-live="polite">
+          {label} {noun}
+        </span>
+        <Button onClick={onUploadClick} isLoading={isUploading} size="sm">
+          Upload
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type Option<T extends string> = { value: T; label: string };
+
+interface FilterSelectProps<T extends string> {
+  readonly label: string;
+  readonly value: T;
+  readonly onChange: (value: T) => void;
+  readonly options: readonly Option<T>[];
+  readonly widthClass: string;
+}
+
+function FilterSelect<T extends string>({ label, value, onChange, options, widthClass }: FilterSelectProps<T>) {
+  const id = useId();
+
+  return (
+    <label htmlFor={id} className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+      <span>{label}</span>
+      <Select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value as T)}
+        className={widthClass}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </Select>
+    </label>
+  );
+}
+
+interface SearchFieldProps {
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+}
+
+function SearchField({ value, onChange }: SearchFieldProps) {
+  const id = useId();
+
+  return (
+    <label htmlFor={id} className="relative flex w-full max-w-xs items-center">
+      <span className="sr-only">Search documents</span>
+      <svg
+        className="pointer-events-none absolute left-3 h-4 w-4 text-slate-400"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth="1.5"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-4.35-4.35m0 0A7.5 7.5 0 1 0 5.25 5.25a7.5 7.5 0 0 0 11.4 11.4Z" />
+      </svg>
+      <Input
+        id={id}
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Search"
+        className="h-9 pl-9"
+      />
+    </label>
+  );
+}

--- a/frontend/src/app/routes/documents/utils.ts
+++ b/frontend/src/app/routes/documents/utils.ts
@@ -1,0 +1,422 @@
+import { ApiError } from "../../../shared/api/client";
+import type { SessionUser } from "../../../shared/types/auth";
+import type { WorkspaceDocumentSummary } from "../../../shared/types/documents";
+import { trackEvent } from "../../../shared/telemetry/events";
+
+export type OwnerFilterValue = "mine" | "all";
+
+export type DocumentStatus = "inbox" | "processing" | "completed" | "failed" | "archived";
+
+export type StatusFilterValue = "all" | DocumentStatus;
+
+export type SortColumn = "name" | "status" | "source" | "uploadedAt" | "lastRunAt" | "byteSize";
+
+export type SortDirection = "asc" | "desc";
+
+export interface SortState {
+  readonly column: SortColumn;
+  readonly direction: SortDirection;
+}
+
+export interface DocumentRow {
+  readonly id: string;
+  readonly name: string;
+  readonly status: DocumentStatus;
+  readonly source: string;
+  readonly tags: readonly string[];
+  readonly uploadedAt: Date;
+  readonly byteSize: number;
+  readonly contentType: string | null;
+  readonly uploaderName: string;
+  readonly uploaderId: string | null;
+  readonly uploaderEmail: string | null;
+  readonly lastRunLabel: string;
+  readonly lastRunAt: Date | null;
+  readonly metadata: Record<string, unknown>;
+}
+
+export const OWNER_FILTER_OPTIONS = [
+  { value: "mine", label: "My Documents" },
+  { value: "all", label: "All Documents" },
+] as const;
+
+export const STATUS_FILTER_OPTIONS = [
+  { value: "all", label: "All statuses" },
+  { value: "inbox", label: "Inbox" },
+  { value: "processing", label: "Processing" },
+  { value: "completed", label: "Completed" },
+  { value: "failed", label: "Failed" },
+  { value: "archived", label: "Archived" },
+] as const;
+
+export const SUPPORTED_FILE_EXTENSIONS = [
+  ".pdf",
+  ".csv",
+  ".tsv",
+  ".xls",
+  ".xlsx",
+  ".xlsm",
+  ".xlsb",
+] as const;
+
+export const SUPPORTED_FILE_TYPES_LABEL = "PDF, CSV, TSV, XLS, XLSX, XLSM, XLSB";
+
+export const DEFAULT_SORT_STATE: SortState = { column: "uploadedAt", direction: "desc" };
+
+const STATUS_SORT_ORDER: Record<DocumentStatus, number> = {
+  processing: 0,
+  inbox: 1,
+  failed: 2,
+  completed: 3,
+  archived: 4,
+};
+
+const ALLOWED_EXTENSIONS = new Set(SUPPORTED_FILE_EXTENSIONS.map((value) => value.toLowerCase()));
+
+interface DocumentFilters {
+  readonly owner: OwnerFilterValue;
+  readonly status: StatusFilterValue;
+  readonly search: string;
+  readonly currentUser: SessionUser | null;
+}
+
+export function toDocumentRows(documents: readonly WorkspaceDocumentSummary[] | undefined): DocumentRow[] {
+  if (!documents) {
+    return [];
+  }
+
+  return documents.map((document) => {
+    const metadata = document.metadata ?? {};
+    const uploader = resolveUploader(metadata);
+    const lastRun = resolveLastRun(metadata);
+
+    return {
+      id: document.id,
+      name: document.name,
+      status: resolveStatus(metadata),
+      source: resolveSource(metadata),
+      tags: resolveTags(metadata),
+      uploadedAt: resolveUploadedAt(document),
+      byteSize: document.byteSize,
+      contentType: document.contentType,
+      uploaderName: uploader.name,
+      uploaderId: uploader.id,
+      uploaderEmail: uploader.email,
+      lastRunLabel: lastRun.label,
+      lastRunAt: lastRun.completedAt,
+      metadata,
+    } satisfies DocumentRow;
+  });
+}
+
+export function applyDocumentFilters(rows: readonly DocumentRow[], filters: DocumentFilters) {
+  const term = filters.search.trim().toLowerCase();
+
+  return rows.filter((row) => {
+    if (filters.owner === "mine" && !isOwnedByUser(row, filters.currentUser)) {
+      return false;
+    }
+
+    if (filters.status !== "all" && row.status !== filters.status) {
+      return false;
+    }
+
+    if (!term) {
+      return true;
+    }
+
+    return [row.name, row.source, row.uploaderName, row.lastRunLabel, ...row.tags]
+      .filter(Boolean)
+      .some((value) => value.toLowerCase().includes(term));
+  });
+}
+
+export function sortDocumentRows(rows: readonly DocumentRow[], sortState: SortState) {
+  const { column, direction } = sortState;
+  const directionMultiplier = direction === "asc" ? 1 : -1;
+
+  const compare = (a: DocumentRow, b: DocumentRow) => {
+    switch (column) {
+      case "name":
+        return a.name.localeCompare(b.name);
+      case "status":
+        return STATUS_SORT_ORDER[a.status] - STATUS_SORT_ORDER[b.status] || a.name.localeCompare(b.name);
+      case "source":
+        return a.source.localeCompare(b.source);
+      case "uploadedAt":
+        return a.uploadedAt.getTime() - b.uploadedAt.getTime();
+      case "lastRunAt": {
+        const timeA = a.lastRunAt?.getTime() ?? 0;
+        const timeB = b.lastRunAt?.getTime() ?? 0;
+        if (timeA === timeB) {
+          return a.name.localeCompare(b.name);
+        }
+        return timeA - timeB;
+      }
+      case "byteSize":
+        return a.byteSize - b.byteSize;
+      default:
+        return 0;
+    }
+  };
+
+  return [...rows].sort((a, b) => compare(a, b) * directionMultiplier);
+}
+
+export function toggleSort(column: SortColumn, current: SortState): SortState {
+  if (current.column !== column) {
+    return {
+      column,
+      direction: column === "uploadedAt" || column === "lastRunAt" || column === "byteSize" ? "desc" : "asc",
+    };
+  }
+
+  return { column, direction: current.direction === "asc" ? "desc" : "asc" };
+}
+
+export function splitSupportedFiles(files: readonly File[]) {
+  const accepted: File[] = [];
+  const rejected: File[] = [];
+
+  for (const file of files) {
+    const extension = getFileExtension(file.name);
+    if (extension && ALLOWED_EXTENSIONS.has(extension)) {
+      accepted.push(file);
+    } else {
+      rejected.push(file);
+    }
+  }
+
+  return { accepted, rejected };
+}
+
+export function triggerBrowserDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function formatDateTime(value: Date) {
+  return dateTimeFormatter.format(value);
+}
+
+export function formatRelativeTime(value: Date) {
+  const diffMs = value.getTime() - Date.now();
+  const diffMinutes = Math.round(diffMs / 60_000);
+  const absMinutes = Math.abs(diffMinutes);
+
+  if (absMinutes < 60) {
+    return relativeTimeFormatter.format(diffMinutes, "minute");
+  }
+
+  const diffHours = Math.round(diffMinutes / 60);
+  const absHours = Math.abs(diffHours);
+  if (absHours < 24) {
+    return relativeTimeFormatter.format(diffHours, "hour");
+  }
+
+  const diffDays = Math.round(diffHours / 24);
+  return relativeTimeFormatter.format(diffDays, "day");
+}
+
+export function formatFileSize(bytes: number) {
+  if (bytes < 1024) {
+    return `${integerFormatter.format(bytes)} B`;
+  }
+
+  const units = ["KB", "MB", "GB", "TB"] as const;
+  let value = bytes / 1024;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  const formatter = value >= 10 || unitIndex === 0 ? integerFormatter : decimalFormatter;
+  return `${formatter.format(value)} ${units[unitIndex]}`;
+}
+
+export function formatStatusLabel(status: DocumentStatus) {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+export function resolveApiErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof ApiError) {
+    return error.problem?.detail ?? error.message ?? fallback;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+export function trackDocumentsEvent(action: string, workspaceId: string, payload: Record<string, unknown> = {}) {
+  trackEvent({
+    name: `documents.${action}`,
+    payload: { workspaceId, ...payload },
+  });
+}
+
+function isOwnedByUser(row: DocumentRow, user: SessionUser | null) {
+  if (!user) {
+    return false;
+  }
+
+  if (row.uploaderId && user.user_id && row.uploaderId === user.user_id) {
+    return true;
+  }
+
+  const normalizedName = (user.display_name ?? "").trim().toLowerCase();
+  if (normalizedName && row.uploaderName.trim().toLowerCase() === normalizedName) {
+    return true;
+  }
+
+  const normalizedEmail = user.email.trim().toLowerCase();
+  if (row.uploaderEmail && row.uploaderEmail.trim().toLowerCase() === normalizedEmail) {
+    return true;
+  }
+
+  return false;
+}
+
+function resolveStatus(metadata: Record<string, unknown>): DocumentStatus {
+  if (metadata.archived === true) {
+    return "archived";
+  }
+
+  const rawStatus = readString(metadata, ["status", "state"]).toLowerCase();
+  switch (rawStatus) {
+    case "processing":
+    case "running":
+      return "processing";
+    case "failed":
+    case "error":
+      return "failed";
+    case "completed":
+    case "done":
+      return "completed";
+    case "archived":
+      return "archived";
+    case "inbox":
+      return "inbox";
+    default:
+      return metadata.completed === true ? "completed" : "inbox";
+  }
+}
+
+function resolveSource(metadata: Record<string, unknown>) {
+  return readString(metadata, ["source", "ingestSource"], "Manual upload");
+}
+
+function resolveTags(metadata: Record<string, unknown>) {
+  const raw = metadata.tags;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .map((value) => value.trim());
+}
+
+function resolveUploadedAt(document: WorkspaceDocumentSummary) {
+  const timestamp = document.updatedAt ?? document.createdAt;
+  return parseDateOrNow(timestamp);
+}
+
+function resolveUploader(metadata: Record<string, unknown>) {
+  const uploader = metadata.uploader;
+  if (uploader && typeof uploader === "object" && !Array.isArray(uploader)) {
+    const record = uploader as Record<string, unknown>;
+    return {
+      id: typeof record.id === "string" && record.id.trim() ? record.id : null,
+      name: readString(record, ["name"], "Unknown"),
+      email: readString(record, ["email"], "") || null,
+    };
+  }
+
+  return {
+    id: null,
+    name: readString(metadata, ["uploadedBy", "createdBy"], "Unknown"),
+    email: readString(metadata, ["uploadedByEmail", "createdByEmail"], "") || null,
+  };
+}
+
+function resolveLastRun(metadata: Record<string, unknown>) {
+  const job = metadata.lastRun;
+  if (job && typeof job === "object" && !Array.isArray(job)) {
+    const record = job as Record<string, unknown>;
+    const status = readString(record, ["status"], "Never run");
+    const finishedAt = readString(record, ["finishedAt"], "");
+    return {
+      label: status || "Never run",
+      completedAt: finishedAt ? parseDateOrNow(finishedAt) : null,
+    };
+  }
+
+  const label = readString(metadata, ["lastRunStatus"], "Never run");
+  const timestamp = readString(metadata, ["lastRunAt", "lastRunTimestamp"], "");
+
+  return {
+    label: label || "Never run",
+    completedAt: timestamp ? parseDateOrNow(timestamp) : null,
+  };
+}
+
+function readString(metadata: Record<string, unknown>, keys: readonly string[], fallback = "") {
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return fallback;
+}
+
+function parseDateOrNow(value: string | undefined | null) {
+  if (!value) {
+    return new Date();
+  }
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return new Date();
+  }
+
+  return new Date(timestamp);
+}
+
+function getFileExtension(filename: string) {
+  const lastDotIndex = filename.lastIndexOf(".");
+  if (lastDotIndex === -1 || lastDotIndex === filename.length - 1) {
+    return "";
+  }
+
+  return filename.slice(lastDotIndex).toLowerCase();
+}
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+const integerFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+const decimalFormatter = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});

--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -2,3 +2,4 @@ export * from "./alert";
 export * from "./button";
 export * from "./form-field";
 export * from "./input";
+export * from "./select";

--- a/frontend/src/ui/select.tsx
+++ b/frontend/src/ui/select.tsx
@@ -1,0 +1,16 @@
+import clsx from "clsx";
+import { forwardRef } from "react";
+import type { SelectHTMLAttributes } from "react";
+
+const BASE_CLASS =
+  "block w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500";
+
+export type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, ...props }, ref) => (
+    <select ref={ref} className={clsx(BASE_CLASS, className)} {...props} />
+  ),
+);
+
+Select.displayName = "Select";


### PR DESCRIPTION
## Summary
- collapse the documents helper modules into a single utils surface that exposes the shared types, filtering, sorting, formatting, and upload helpers for the route
- rename the documents toolbar component and update the route/components to consume the streamlined utilities and naming

## Testing
- npm test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f06ba2ac28832e909c85ab5f88b919