### PR TITLE
Handle browser session expiry with auto-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 - Ensure document uploads stream to the backend API, clear progress indicators per file, and immediately refresh the workspace list after completion.
 - Fix the upload picker so selected files are processed before the input resets, keeping button and drag-and-drop uploads consistent.
+- Automatically refresh browser sessions before access tokens expire so idle users are not met with unexpected 401 errors.
 
 ## [v0.1.0] - 2025-10-09
 

--- a/frontend/src/features/auth/components/__tests__/RequireSession.test.tsx
+++ b/frontend/src/features/auth/components/__tests__/RequireSession.test.tsx
@@ -94,8 +94,8 @@ describe("RequireSession", () => {
         display_name: "Test User",
         permissions: ["Workspaces.Create"],
       },
-      expires_at: new Date().toISOString(),
-      refresh_expires_at: new Date(Date.now() + 60_000).toISOString(),
+      expires_at: new Date(Date.now() + 120_000).toISOString(),
+      refresh_expires_at: new Date(Date.now() + 300_000).toISOString(),
       return_to: null,
     };
 

--- a/frontend/src/features/auth/context/SessionContext.tsx
+++ b/frontend/src/features/auth/context/SessionContext.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useEffect, type ReactNode } from "react";
 
 import type { SessionEnvelope } from "../../../shared/types/auth";
+import { refreshSession } from "../api";
 
 type RefetchSession = () => Promise<unknown>;
 
@@ -19,6 +20,8 @@ export interface SessionProviderProps {
 }
 
 export function SessionProvider({ session, refetch, children }: SessionProviderProps) {
+  useSessionAutoRefresh(session, refetch);
+
   return (
     <SessionContext.Provider value={{ session, refetch }}>
       {children}
@@ -40,4 +43,58 @@ export function useSession() {
 
 export function useSessionRefetch() {
   return useSessionContext().refetch;
+}
+
+const REFRESH_BUFFER_MS = 60_000;
+
+function useSessionAutoRefresh(session: SessionEnvelope, refetch: RefetchSession) {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const expiresAt = Date.parse(session.expires_at);
+    const refreshExpiresAt = Date.parse(session.refresh_expires_at);
+
+    if (Number.isNaN(expiresAt) || Number.isNaN(refreshExpiresAt)) {
+      return undefined;
+    }
+
+    const now = Date.now();
+    if (refreshExpiresAt <= now) {
+      void refetch().catch((error) => {
+        console.warn("Failed to refetch session after refresh expiry", error);
+      });
+      return undefined;
+    }
+
+    const targetTime = Math.min(expiresAt, refreshExpiresAt) - REFRESH_BUFFER_MS;
+    const delay = Math.max(targetTime - now, 0);
+    let cancelled = false;
+
+    const timeoutId = window.setTimeout(async () => {
+      try {
+        await refreshSession();
+        if (cancelled) {
+          return;
+        }
+        await refetch().catch((refetchError) => {
+          console.warn("Failed to refetch session after refresh", refetchError);
+        });
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        console.warn("Failed to refresh session", error);
+        await refetch().catch((refetchError) => {
+          console.warn("Failed to refetch session after refresh failure", refetchError);
+        });
+      }
+    }, delay);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [refetch, session.expires_at, session.refresh_expires_at]);
 }

--- a/frontend/src/features/auth/context/__tests__/SessionProvider.test.tsx
+++ b/frontend/src/features/auth/context/__tests__/SessionProvider.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, beforeEach, afterEach, vi, expect } from "vitest";
+import { render } from "../../../../test/test-utils";
+import type { SessionEnvelope } from "../../../../shared/types/auth";
+import { SessionProvider } from "../SessionContext";
+import { refreshSession } from "../../api";
+
+vi.mock("../../api", () => ({
+  refreshSession: vi.fn(),
+}));
+
+describe("SessionProvider", () => {
+  const mockedRefreshSession = vi.mocked(refreshSession);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedRefreshSession.mockReset();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("refreshes the session shortly before expiry", async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const session: SessionEnvelope = {
+      user: {
+        user_id: "user-1",
+        email: "user@example.com",
+        is_active: true,
+        is_service_account: false,
+      },
+      expires_at: new Date(Date.now() + 70_000).toISOString(),
+      refresh_expires_at: new Date(Date.now() + 600_000).toISOString(),
+      return_to: null,
+    };
+
+    mockedRefreshSession.mockResolvedValueOnce({
+      ...session,
+      expires_at: new Date(Date.now() + 170_000).toISOString(),
+    });
+
+    render(
+      <SessionProvider session={session} refetch={refetch}>
+        <div>Child</div>
+      </SessionProvider>,
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(mockedRefreshSession).toHaveBeenCalledTimes(1);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to refetch when the refresh request fails", async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const session: SessionEnvelope = {
+      user: {
+        user_id: "user-2",
+        email: "other@example.com",
+        is_active: true,
+        is_service_account: false,
+      },
+      expires_at: new Date(Date.now() + 70_000).toISOString(),
+      refresh_expires_at: new Date(Date.now() + 600_000).toISOString(),
+      return_to: null,
+    };
+
+    mockedRefreshSession.mockRejectedValueOnce(new Error("boom"));
+
+    render(
+      <SessionProvider session={session} refetch={refetch}>
+        <div>Child</div>
+      </SessionProvider>,
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(mockedRefreshSession).toHaveBeenCalledTimes(1);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- schedule automatic session refresh in the SessionProvider so idle users renew their cookies before expiry
- add focused tests for the refresh timer behaviour and update the RequireSession test fixture to use future expirations
- document the session refresh fix in the changelog

## Testing
- npm test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f1257e7a6c832e95fdee1cfb16359c