### PR TITLE
Update workspace sidebar navigation

### DIFF
--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -16,7 +16,7 @@ import { workspaceLoader } from "./workspaces/loader";
 import { workspaceSections, defaultWorkspaceSection } from "./workspaces/sections";
 import type { WorkspaceRouteHandle } from "./workspaces/sections";
 
-const sectionsWithContextNav = new Set(["data", "config", "settings"]);
+const sectionsWithContextNav = new Set(["config", "settings"]);
 
 const workspaceSectionRoutes = workspaceSections.map((section) => ({
   path: section.path,

--- a/frontend/src/app/workspaces/navigation.ts
+++ b/frontend/src/app/workspaces/navigation.ts
@@ -3,14 +3,7 @@ import type { ComponentType, SVGProps } from "react";
 import type { WorkspaceProfile } from "../../shared/types/workspaces";
 import type { WorkspaceSectionDescriptor, WorkspaceSectionId } from "./sections";
 import { buildWorkspaceSectionPath, workspaceSections } from "./sections";
-import {
-  ConfigureIcon,
-  DataIcon,
-  DocumentsIcon,
-  OverviewIcon,
-  RunsIcon,
-  SettingsIcon,
-} from "./icons";
+import { ConfigureIcon, DocumentsIcon, SettingsIcon } from "./icons";
 
 export interface WorkspacePrimaryNavItem {
   readonly id: WorkspaceSectionId;
@@ -35,9 +28,6 @@ export interface WorkspaceSecondaryNavigation {
 
 const sectionIcons: Record<WorkspaceSectionId, ComponentType<SVGProps<SVGSVGElement>>> = {
   documents: DocumentsIcon,
-  overview: OverviewIcon,
-  runs: RunsIcon,
-  data: DataIcon,
   config: ConfigureIcon,
   settings: SettingsIcon,
 };
@@ -68,15 +58,6 @@ interface DynamicSecondaryNavConfig {
 type SecondaryNavConfig = StaticSecondaryNavConfig | DynamicSecondaryNavConfig;
 
 const secondaryDefinitions: Partial<Record<WorkspaceSectionId, SecondaryNavConfig>> = {
-  data: {
-    type: "static",
-    items: [
-      (workspaceId) => ({ id: "data-sources", label: "Sources", href: `/workspaces/${workspaceId}/data?view=sources` }),
-      (workspaceId) => ({ id: "data-schemas", label: "Schemas", href: `/workspaces/${workspaceId}/data?view=schemas` }),
-      (workspaceId) => ({ id: "data-exports", label: "Exports", href: `/workspaces/${workspaceId}/data?view=exports` }),
-    ],
-    emptyLabel: "Add a connector to populate data views.",
-  },
   config: {
     type: "static",
     items: [
@@ -89,9 +70,9 @@ const secondaryDefinitions: Partial<Record<WorkspaceSectionId, SecondaryNavConfi
   settings: {
     type: "static",
     items: [
-      (workspaceId) => ({ id: "settings-profile", label: "Workspace profile", href: `/workspaces/${workspaceId}/settings?view=profile` }),
-      (workspaceId) => ({ id: "settings-permissions", label: "Members & access", href: `/workspaces/${workspaceId}/settings?view=permissions` }),
-      (workspaceId) => ({ id: "settings-retention", label: "Retention", href: `/workspaces/${workspaceId}/settings?view=retention` }),
+      (workspaceId) => ({ id: "settings-general", label: "General", href: `/workspaces/${workspaceId}/settings?view=general` }),
+      (workspaceId) => ({ id: "settings-members", label: "Members", href: `/workspaces/${workspaceId}/settings?view=members` }),
+      (workspaceId) => ({ id: "settings-roles", label: "Roles", href: `/workspaces/${workspaceId}/settings?view=roles` }),
     ],
     emptyLabel: "Workspace settings will appear here soon.",
   },

--- a/frontend/src/app/workspaces/sections.ts
+++ b/frontend/src/app/workspaces/sections.ts
@@ -1,6 +1,6 @@
 import type { UIMatch } from "react-router-dom";
 
-export type WorkspaceSectionId = "documents" | "overview" | "runs" | "data" | "config" | "settings";
+export type WorkspaceSectionId = "documents" | "config" | "settings";
 
 export interface WorkspaceSectionDescriptor {
   readonly id: WorkspaceSectionId;
@@ -37,48 +37,12 @@ export const workspaceSections: readonly WorkspaceSectionDescriptor[] = [
     },
   },
   {
-    id: "overview",
-    path: "overview",
-    label: "Overview",
-    description: "Workspace health, metrics, and recent activity",
-    placeholder: {
-      title: "Workspace overview",
-      description:
-        "Dashboards for activity, throughput, and adoption will land here once analytics wiring is complete.",
-      cta: { href: "../documents", label: "View documents" },
-    },
-  },
-  {
-    id: "runs",
-    path: "runs",
-    label: "Runs & Jobs",
-    description: "Extraction queue, job history, and alerts",
-    placeholder: {
-      title: "Runs & Jobs",
-      description:
-        "Monitor active extraction jobs, retry failures, and audit job history. The orchestration view is under active development.",
-      cta: { href: "../documents", label: "View documents" },
-    },
-  },
-  {
-    id: "data",
-    path: "data",
-    label: "Data",
-    description: "Datasets, exports, and records",
-    placeholder: {
-      title: "Data",
-      description:
-        "Access curated datasets, exports, and downstream records once the data hub ships later this quarter.",
-      cta: { href: "../documents", label: "View documents" },
-    },
-  },
-  {
     id: "config",
     path: "config",
-    label: "Configure",
+    label: "Configuration",
     description: "Rules, pipelines, and automation",
     placeholder: {
-      title: "Configure",
+      title: "Configuration",
       description:
         "Define extraction rules, map columns, and manage deployment snapshots. The configuration hub is coming soon.",
       cta: { href: "../documents", label: "View documents" },
@@ -87,10 +51,10 @@ export const workspaceSections: readonly WorkspaceSectionDescriptor[] = [
   {
     id: "settings",
     path: "settings",
-    label: "Settings",
-    description: "Workspace preferences and integrations",
+    label: "Workspace Settings",
+    description: "Workspace preferences and access controls",
     placeholder: {
-      title: "Settings",
+      title: "Workspace settings",
       description:
         "Adjust workspace preferences, integrations, and retention rules. The full settings experience will appear after the authentication revamp ships.",
     },
@@ -135,20 +99,11 @@ export function matchWorkspaceSectionMeta(matches: readonly UIMatch[]): Workspac
 }
 
 export const workspacePlaceholderSections = new Map(
-  [
-    [
-      "overview",
-      {
-        title: "Workspace overview",
-        description:
-          "We’re building dashboards for workspace health, recent activity, and quick links to the actions you use every day.",
-        cta: { href: "../documents", label: "View documents" },
-      },
-    ],
-    ...workspaceSections.map((section) => [section.id, section.placeholder]),
-  ].filter(([, placeholder]) => Boolean(placeholder)) as Array<
-    [string, WorkspaceSectionDescriptor["placeholder"]]
-  >,
+  workspaceSections
+    .map((section) => [section.id, section.placeholder])
+    .filter(([, placeholder]) => Boolean(placeholder)) as Array<
+      [string, WorkspaceSectionDescriptor["placeholder"]]
+    >,
 );
 
 export function getWorkspacePlaceholder(sectionId: string) {


### PR DESCRIPTION
## Summary
- limit workspace sections to Documents, Configuration, and Workspace Settings
- adjust secondary navigation so Workspace Settings exposes General, Members, and Roles shortcuts
- ensure only sections with secondary navigation render the context sidebar

## Testing
- npm test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f13d9a5b00832ebcf127553a50c688