### PR TITLE
Integrate documents filters with paginated envelope

### DIFF
--- a/ade/api/deps.py
+++ b/ade/api/deps.py
@@ -4,20 +4,58 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ade.db.session import get_session
 from ade.features.auth.dependencies import get_current_identity, get_current_user
 from ade.features.auth.service import AuthenticatedIdentity
 from ade.features.users.models import User
+from ade.core.pagination import PaginationParams
+
+
+def get_pagination_params(
+    page: Annotated[
+        int,
+        Query(
+            ge=1,
+            description="1-based page number.",
+            example=1,
+        ),
+    ] = 1,
+    per_page: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=200,
+            description="Maximum number of items to return per page (1-200).",
+            example=50,
+        ),
+    ] = 50,
+    include_total: Annotated[
+        bool,
+        Query(
+            description="Include an exact total count alongside the current page.",
+            example=False,
+        ),
+    ] = False,
+) -> PaginationParams:
+    """Return validated pagination parameters for list endpoints."""
+
+    return PaginationParams(page=page, per_page=per_page, include_total=include_total)
 
 SessionDependency = Annotated[AsyncSession, Depends(get_session)]
 CurrentIdentity = Annotated[AuthenticatedIdentity, Depends(get_current_identity)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
+PaginationParamsDependency = Annotated[
+    PaginationParams,
+    Depends(get_pagination_params),
+]
 
 __all__ = [
     "SessionDependency",
     "CurrentIdentity",
     "CurrentUser",
+    "PaginationParamsDependency",
+    "get_pagination_params",
 ]

--- a/ade/api/errors.py
+++ b/ade/api/errors.py
@@ -1,5 +1,95 @@
 """API error/response compatibility shims."""
 
-from ade.core.responses import DefaultResponse, JSONResponse
+from __future__ import annotations
 
-__all__ = ["DefaultResponse", "JSONResponse"]
+from fastapi import FastAPI, Request
+from pydantic import Field
+
+from ade.core.responses import DefaultResponse, JSONResponse
+from ade.core.schema import BaseSchema
+
+
+class ProblemDetail(BaseSchema):
+    """Problem+JSON payload compatible with RFC 7807."""
+
+    type: str = Field(default="about:blank", description="Problem type URI.")
+    title: str = Field(description="Short, human-readable summary of the problem.")
+    status: int = Field(ge=100, le=599, description="HTTP status code generated.")
+    detail: str | None = Field(
+        default=None,
+        description="Human-readable explanation for this occurrence of the problem.",
+    )
+    errors: dict[str, list[str]] | None = Field(
+        default=None,
+        description="Optional field-level validation errors.",
+    )
+
+
+class ProblemException(Exception):
+    """Exception signalling an RFC 7807 problem response."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        title: str,
+        detail: str | None = None,
+        type: str = "about:blank",
+        errors: dict[str, list[str]] | None = None,
+    ) -> None:
+        super().__init__(title)
+        self.problem = ProblemDetail(
+            type=type,
+            title=title,
+            status=status_code,
+            detail=detail,
+            errors=errors,
+        )
+
+
+def problem_response(
+    *,
+    status_code: int,
+    title: str,
+    detail: str | None = None,
+    type: str = "about:blank",
+    errors: dict[str, list[str]] | None = None,
+) -> JSONResponse:
+    """Return a ``JSONResponse`` encoded as Problem+JSON."""
+
+    problem = ProblemDetail(
+        type=type,
+        title=title,
+        status=status_code,
+        detail=detail,
+        errors=errors,
+    )
+    return JSONResponse(
+        problem,
+        status_code=status_code,
+        media_type="application/problem+json",
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register ADE API exception handlers."""
+
+    @app.exception_handler(ProblemException)
+    async def _problem_exception_handler(
+        request: Request, exc: ProblemException
+    ) -> JSONResponse:
+        return JSONResponse(
+            exc.problem,
+            status_code=exc.problem.status,
+            media_type="application/problem+json",
+        )
+
+
+__all__ = [
+    "DefaultResponse",
+    "JSONResponse",
+    "ProblemDetail",
+    "ProblemException",
+    "problem_response",
+    "register_exception_handlers",
+]

--- a/ade/core/pagination.py
+++ b/ade/core/pagination.py
@@ -1,0 +1,108 @@
+"""Shared pagination helpers for SQLAlchemy queries."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from pydantic import Field
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import ClauseElement
+
+from .schema import BaseSchema
+
+
+class PaginationParams(BaseSchema):
+    """Validated pagination parameters."""
+
+    page: int = Field(default=1, ge=1, description="1-based page number.")
+    per_page: int = Field(
+        default=50,
+        ge=1,
+        le=200,
+        description="Number of items per page (capped at 200).",
+    )
+    include_total: bool = Field(
+        default=False,
+        description="Whether to include a total count alongside the page results.",
+    )
+
+    @property
+    def offset(self) -> int:
+        """Return the SQL offset for this page."""
+
+        return (self.page - 1) * self.per_page
+
+    @property
+    def window(self) -> int:
+        """Return the number of rows to fetch including the lookahead sentinel."""
+
+        return self.per_page + 1
+
+
+class PaginationEnvelope(BaseSchema):
+    """Standardised response envelope for paginated endpoints."""
+
+    items: list[Any] = Field(default_factory=list)
+    page: int = Field(ge=1, description="1-based page number.")
+    per_page: int = Field(
+        ge=1,
+        le=200,
+        description="Number of items per page returned in this response.",
+    )
+    has_next: bool = Field(description="Whether another page exists after this one.")
+    total: int | None = Field(
+        default=None,
+        ge=0,
+        description="Total number of matching records when requested.",
+    )
+
+
+async def paginate(
+    session: AsyncSession,
+    query: Select[Any],
+    *,
+    page: int,
+    per_page: int,
+    order_by: Sequence[ClauseElement[Any]],
+    include_total: bool = False,
+) -> dict[str, Any]:
+    """Execute ``query`` with limit/offset pagination and return a serialisable envelope."""
+
+    if page < 1:
+        raise ValueError("page must be greater than or equal to 1")
+    if per_page < 1:
+        raise ValueError("per_page must be greater than or equal to 1")
+
+    lookahead = per_page + 1
+    offset = (page - 1) * per_page
+
+    ordered = query.order_by(*order_by)
+    statement = ordered.offset(offset).limit(lookahead)
+    result = await session.execute(statement)
+    rows = result.scalars().all()
+
+    has_next = len(rows) > per_page
+    if has_next:
+        rows = rows[:-1]
+
+    payload: dict[str, Any] = {
+        "items": rows,
+        "page": page,
+        "per_page": per_page,
+        "has_next": has_next,
+    }
+
+    if include_total:
+        count_query = select(func.count()).select_from(ordered.order_by(None).subquery())
+        total_result = await session.execute(count_query)
+        payload["total"] = int(total_result.scalar_one())
+
+    return payload
+
+
+__all__ = [
+    "PaginationEnvelope",
+    "PaginationParams",
+    "paginate",
+]

--- a/ade/core/tests/test_pagination.py
+++ b/ade/core/tests/test_pagination.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from ade.core.pagination import paginate
+from ade.db.session import get_sessionmaker
+from ade.features.workspaces.models import Workspace
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_paginate_returns_envelope_with_optional_total() -> None:
+    session_factory = get_sessionmaker()
+    async with session_factory() as session:
+        suffix = uuid.uuid4().hex[:8]
+        records = [
+            Workspace(name=f"Workspace {index}", slug=f"pagination-{suffix}-{index}")
+            for index in range(3)
+        ]
+        session.add_all(records)
+        await session.commit()
+
+        query = select(Workspace).where(
+            Workspace.slug.like(f"pagination-{suffix}-%")
+        )
+        envelope = await paginate(
+            session,
+            query,
+            page=1,
+            per_page=2,
+            order_by=(
+                Workspace.created_at.asc(),
+                Workspace.id.asc(),
+            ),
+            include_total=True,
+        )
+
+        assert envelope["page"] == 1
+        assert envelope["per_page"] == 2
+        assert envelope["has_next"] is True
+        assert envelope["total"] == 3
+        assert [item.slug for item in envelope["items"]] == [
+            records[0].slug,
+            records[1].slug,
+        ]

--- a/ade/features/documents/filtering.py
+++ b/ade/features/documents/filtering.py
@@ -1,0 +1,271 @@
+"""Filter primitives for the documents feature."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, Any
+
+from pydantic import Field, ValidationError, field_validator, model_validator
+
+from ade.core.schema import BaseSchema
+
+ULID_PATTERN = r"[0-9A-HJKMNP-TV-Z]{26}"
+ULIDStr = Annotated[
+    str,
+    Field(
+        min_length=26,
+        max_length=26,
+        pattern=ULID_PATTERN,
+        description="ULID (26-character string).",
+    ),
+]
+
+
+DOCUMENT_STATUS_VALUES: tuple[str, ...]
+DOCUMENT_SOURCE_VALUES: tuple[str, ...]
+
+
+class DocumentStatus(str, Enum):
+    """Canonical document processing states."""
+
+    UPLOADED = "uploaded"
+    PROCESSING = "processing"
+    PROCESSED = "processed"
+    FAILED = "failed"
+    ARCHIVED = "archived"
+
+
+class DocumentSource(str, Enum):
+    """Origins for uploaded documents."""
+
+    MANUAL_UPLOAD = "manual_upload"
+
+
+DOCUMENT_STATUS_VALUES = tuple(status.value for status in DocumentStatus)
+DOCUMENT_SOURCE_VALUES = tuple(source.value for source in DocumentSource)
+
+
+class DocumentSortableField(str, Enum):
+    """Fields that can be used for ordering document queries."""
+
+    CREATED_AT = "created_at"
+    STATUS = "status"
+    LAST_RUN_AT = "last_run_at"
+    BYTE_SIZE = "byte_size"
+    SOURCE = "source"
+    NAME = "name"
+
+
+class DocumentSort(BaseSchema):
+    """Single-field sort descriptor."""
+
+    field: DocumentSortableField = Field(description="Field used for ordering results.")
+    descending: bool = Field(default=False, description="Whether the sort is descending.")
+
+    @field_validator("field", mode="after")
+    @classmethod
+    def _coerce_field(
+        cls, value: DocumentSortableField | str
+    ) -> DocumentSortableField:
+        return DocumentSortableField(value)
+
+    @classmethod
+    def parse(cls, raw: str | None) -> "DocumentSort":
+        """Return a sort descriptor from the API-provided value.
+
+        The backend accepts an optional ``-`` prefix to denote descending order.
+        When ``raw`` is ``None`` a descending sort on ``created_at`` is returned so
+        callers inherit the contract's default ordering.
+        """
+
+        if not raw:
+            return cls(field=DocumentSortableField.CREATED_AT, descending=True)
+
+        descending = raw.startswith("-")
+        field_name = raw[1:] if descending else raw
+        try:
+            field = DocumentSortableField(field_name)
+        except ValueError as exc:  # pragma: no cover - guarded by validation layer
+            raise ValueError(f"Invalid sort field: {field_name}") from exc
+        return cls(field=field, descending=descending)
+
+    def api_param(self) -> str:
+        """Return the string representation suitable for query parameters."""
+
+        prefix = "-" if self.descending else ""
+        return f"{prefix}{self.field.value}"
+
+
+class DocumentFilters(BaseSchema):
+    """Normalised collection of filters applied to a document search."""
+
+    model_config = BaseSchema.model_config.copy()
+    model_config["extra"] = "forbid"
+
+    status: list[DocumentStatus] = Field(default_factory=list)
+    source: list[DocumentSource] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    uploader_me: bool = Field(
+        default=False,
+        description="Whether to restrict results to the authenticated uploader.",
+    )
+    uploader_ids: list[ULIDStr] = Field(default_factory=list)
+    q: str | None = Field(
+        default=None,
+        description="Substring search applied to document name or uploader metadata.",
+    )
+    created_from: datetime | None = Field(default=None)
+    created_to: datetime | None = Field(default=None)
+    last_run_from: datetime | None = Field(default=None)
+    last_run_to: datetime | None = Field(default=None)
+    byte_size_min: int | None = Field(default=None, ge=0)
+    byte_size_max: int | None = Field(default=None, ge=0)
+
+    @field_validator("status", "source", "tags", "uploader_ids", mode="before")
+    @classmethod
+    def _listify(cls, value: object) -> list[object]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, (set, tuple)):
+            return list(value)
+        return list(value)
+
+    @field_validator("tags")
+    @classmethod
+    def _normalise_tags(cls, value: list[str]) -> list[str]:
+        seen: set[str] = set()
+        unique: list[str] = []
+        for tag in value:
+            tag = tag.strip()
+            if not tag:
+                continue
+            if tag in seen:
+                continue
+            seen.add(tag)
+            unique.append(tag)
+        return unique
+
+    @field_validator("status", "source", "uploader_ids", mode="after")
+    @classmethod
+    def _deduplicate(cls, value: list[object]) -> list[object]:
+        seen: set[object] = set()
+        unique: list[object] = []
+        for item in value:
+            if item in seen:
+                continue
+            seen.add(item)
+            unique.append(item)
+        return unique
+
+    @field_validator("status", mode="after")
+    @classmethod
+    def _coerce_status(
+        cls, value: list[DocumentStatus | str]
+    ) -> list[DocumentStatus]:
+        return [DocumentStatus(item) for item in value]
+
+    @field_validator("source", mode="after")
+    @classmethod
+    def _coerce_source(
+        cls, value: list[DocumentSource | str]
+    ) -> list[DocumentSource]:
+        return [DocumentSource(item) for item in value]
+
+    @field_validator("q")
+    @classmethod
+    def _clean_query(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+    @model_validator(mode="after")
+    def _validate_ranges(self) -> "DocumentFilters":
+        if (
+            self.created_from
+            and self.created_to
+            and self.created_from > self.created_to
+        ):
+            raise ValueError("created_from must be earlier than or equal to created_to")
+        if (
+            self.last_run_from
+            and self.last_run_to
+            and self.last_run_from > self.last_run_to
+        ):
+            raise ValueError("last_run_from must be earlier than or equal to last_run_to")
+        if (
+            self.byte_size_min is not None
+            and self.byte_size_max is not None
+            and self.byte_size_min > self.byte_size_max
+        ):
+            raise ValueError("byte_size_min must be less than or equal to byte_size_max")
+        return self
+
+
+class DocumentFilterParams(DocumentFilters):
+    """Request-level filter payload including sort directives."""
+
+    sort: DocumentSort = Field(
+        default_factory=lambda: DocumentSort.parse(None),
+        description="Sort descriptor parsed from the `sort` query parameter.",
+    )
+    uploader: str | None = Field(
+        default=None,
+        description="Identity shortcut accepting the literal 'me'.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _prepare_payload(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        payload = dict(data)
+        uploader = payload.pop("uploader", None)
+        if uploader is not None:
+            if uploader != "me":
+                raise ValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("uploader",),
+                            "msg": "uploader must be the literal 'me'",
+                            "input": uploader,
+                        }
+                    ],
+                    cls,
+                )
+            payload["uploader_me"] = True
+
+        raw_sort = payload.get("sort")
+        if isinstance(raw_sort, DocumentSort):
+            payload["sort"] = raw_sort
+        else:
+            payload["sort"] = DocumentSort.parse(raw_sort)
+        return payload
+
+    def to_filters(self) -> DocumentFilters:
+        """Return the query-ready filter payload without sort metadata."""
+
+        return DocumentFilters.model_validate(
+            self.model_dump(
+                mode="python",
+                exclude={"sort", "uploader"},
+            )
+        )
+
+
+__all__ = [
+    "DOCUMENT_SOURCE_VALUES",
+    "DOCUMENT_STATUS_VALUES",
+    "DocumentFilterParams",
+    "DocumentFilters",
+    "DocumentSort",
+    "DocumentSortableField",
+    "DocumentSource",
+    "DocumentStatus",
+    "ULIDStr",
+]

--- a/ade/features/documents/models.py
+++ b/ade/features/documents/models.py
@@ -5,13 +5,29 @@ from __future__ import annotations
 from datetime import datetime
 from typing import cast
 
-from sqlalchemy import DateTime, JSON, ForeignKey, Index, Integer, String
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+    text,
+)
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ade.db import Base, TimestampMixin, ULIDPrimaryKeyMixin
 
 from ..workspaces.models import Workspace
+from ..users.models import User
+from .filtering import (
+    DOCUMENT_SOURCE_VALUES,
+    DOCUMENT_STATUS_VALUES,
+    DocumentSource,
+    DocumentStatus,
+)
 
 
 class Document(ULIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -25,7 +41,7 @@ class Document(ULIDPrimaryKeyMixin, TimestampMixin, Base):
         ForeignKey("workspaces.workspace_id", ondelete="CASCADE"),
         nullable=False,
     )
-    workspace: Mapped[Workspace] = relationship("Workspace", lazy="joined")
+    workspace: Mapped[Workspace] = relationship("Workspace", lazy="selectin")
 
     original_filename: Mapped[str] = mapped_column(String(255), nullable=False)
     content_type: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -38,15 +54,73 @@ class Document(ULIDPrimaryKeyMixin, TimestampMixin, Base):
         nullable=False,
         default=dict,
     )
+    uploaded_by_user_id: Mapped[str | None] = mapped_column(
+        String(26), ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True
+    )
+    uploaded_by_user: Mapped[User | None] = relationship(
+        "User",
+        lazy="selectin",
+        foreign_keys=[uploaded_by_user_id],
+    )
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=DocumentStatus.UPLOADED.value,
+        server_default=text("'uploaded'"),
+    )
+    source: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        default=DocumentSource.MANUAL_UPLOAD.value,
+        server_default=text("'manual_upload'"),
+    )
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     deleted_by_user_id: Mapped[str | None] = mapped_column(
         String(26), ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True
     )
-    produced_by_job_id: Mapped[str | None] = mapped_column(String(26), nullable=True)
+    produced_by_job_id: Mapped[str | None] = mapped_column(
+        String(26), ForeignKey("jobs.job_id", ondelete="SET NULL"), nullable=True
+    )
+    tags: Mapped[list["DocumentTag"]] = relationship(
+        "DocumentTag",
+        back_populates="document",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
     __table_args__ = (
-        Index("documents_workspace_id_idx", "workspace_id"),
+        CheckConstraint(
+            "status IN (" + ", ".join(f"'{value}'" for value in DOCUMENT_STATUS_VALUES) + ")",
+            name="documents_status_ck",
+        ),
+        CheckConstraint(
+            "source IN (" + ", ".join(f"'{value}'" for value in DOCUMENT_SOURCE_VALUES) + ")",
+            name="documents_source_ck",
+        ),
+        Index(
+            "documents_workspace_status_created_idx",
+            "workspace_id",
+            "status",
+            "created_at",
+        ),
+        Index(
+            "documents_workspace_created_idx",
+            "workspace_id",
+            "created_at",
+        ),
+        Index(
+            "documents_workspace_last_run_idx",
+            "workspace_id",
+            "last_run_at",
+        ),
+        Index("documents_workspace_source_idx", "workspace_id", "source"),
+        Index(
+            "documents_workspace_uploader_idx", "workspace_id", "uploaded_by_user_id"
+        ),
         Index("documents_produced_by_job_id_idx", "produced_by_job_id"),
     )
 
@@ -56,5 +130,35 @@ class Document(ULIDPrimaryKeyMixin, TimestampMixin, Base):
 
         return cast(str, self.id)
 
+    @property
+    def tag_values(self) -> list[str]:
+        """Return the tag strings associated with the document."""
 
-__all__ = ["Document"]
+        return [entry.tag for entry in getattr(self, "tags", [])]
+
+
+class DocumentTag(Base):
+    """Join table capturing string tags applied to documents."""
+
+    __tablename__ = "document_tags"
+
+    document_id: Mapped[str] = mapped_column(
+        String(26),
+        ForeignKey("documents.document_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    tag: Mapped[str] = mapped_column(String(100), primary_key=True)
+
+    document: Mapped[Document] = relationship(
+        "Document",
+        back_populates="tags",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        Index("document_tags_document_id_idx", "document_id"),
+        Index("document_tags_tag_idx", "tag"),
+    )
+
+
+__all__ = ["Document", "DocumentTag"]

--- a/ade/features/documents/schemas.py
+++ b/ade/features/documents/schemas.py
@@ -7,25 +7,51 @@ from typing import Any
 
 from pydantic import Field
 
+from ade.core.pagination import PaginationEnvelope
 from ade.core.schema import BaseSchema
+from .filtering import DocumentSource, DocumentStatus, ULIDStr
+
+
+class UploaderSummary(BaseSchema):
+    """Minimal representation of the user who uploaded the document."""
+
+    id: ULIDStr = Field(
+        description="Uploader ULID (26-character string).",
+    )
+    name: str | None = Field(
+        default=None,
+        alias="display_name",
+        serialization_alias="name",
+        description="Uploader display name when provided.",
+    )
+    email: str = Field(description="Uploader email address.")
 
 
 class DocumentRecord(BaseSchema):
     """Serialised representation of a stored document."""
 
-    document_id: str = Field(alias="id", serialization_alias="document_id")
-    workspace_id: str
-    original_filename: str
+    document_id: ULIDStr = Field(
+        alias="id",
+        serialization_alias="document_id",
+        description="Document ULID (26-character string).",
+    )
+    workspace_id: ULIDStr
+    name: str = Field(
+        alias="original_filename",
+        serialization_alias="name",
+        description="Display name mapped from the original filename.",
+    )
     content_type: str | None = None
     byte_size: int
-    sha256: str
-    stored_uri: str
     metadata: dict[str, Any] = Field(
         default_factory=dict,
         alias="attributes",
         serialization_alias="metadata",
     )
+    status: DocumentStatus
+    source: DocumentSource
     expires_at: datetime
+    last_run_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
     deleted_at: datetime | None = None
@@ -34,6 +60,33 @@ class DocumentRecord(BaseSchema):
         alias="deleted_by_user_id",
         serialization_alias="deleted_by",
     )
+    tags: list[str] = Field(
+        default_factory=list,
+        alias="tag_values",
+        serialization_alias="tags",
+        description="Tags applied to the document (empty list when none).",
+    )
+    uploader: UploaderSummary | None = Field(
+        default=None,
+        alias="uploaded_by_user",
+        serialization_alias="uploader",
+        description="Summary of the uploading user when available.",
+    )
+
+    @property
+    def original_filename(self) -> str:
+        """Retain compatibility with existing callers expecting ``original_filename``."""
+
+        return self.name
 
 
-__all__ = ["DocumentRecord"]
+class DocumentListResponse(PaginationEnvelope):
+    """Paginated envelope of document records."""
+
+    items: list[DocumentRecord] = Field(
+        default_factory=list,
+        description="Documents returned for the requested page.",
+    )
+
+
+__all__ = ["DocumentListResponse", "DocumentRecord", "UploaderSummary"]

--- a/ade/features/documents/tests/test_filtering.py
+++ b/ade/features/documents/tests/test_filtering.py
@@ -1,0 +1,126 @@
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from ade.features.documents.filtering import (
+    DOCUMENT_SOURCE_VALUES,
+    DOCUMENT_STATUS_VALUES,
+    DocumentFilterParams,
+    DocumentFilters,
+    DocumentSort,
+    DocumentSortableField,
+    DocumentSource,
+    DocumentStatus,
+)
+
+
+def test_document_filters_normalise_lists_and_strings() -> None:
+    filters = DocumentFilters(
+        status=[DocumentStatus.UPLOADED.value, DocumentStatus.PROCESSED],
+        source=[DocumentSource.MANUAL_UPLOAD, DocumentSource.MANUAL_UPLOAD.value],
+        tags=[" alpha ", "beta", "alpha", ""],
+        uploader_ids=[
+            "01H8M8Z1QB9X4Y7V5T2R3S4Q5A",
+            "01H8M8Z1QB9X4Y7V5T2R3S4Q5A",
+            "01H8M8Z1QB9X4Y7V5T2R3S4Q6A",
+        ],
+        q="  quarterly ",
+    )
+
+    assert filters.status == [DocumentStatus.UPLOADED, DocumentStatus.PROCESSED]
+    assert filters.source == [DocumentSource.MANUAL_UPLOAD]
+    assert filters.tags == ["alpha", "beta"]
+    assert filters.uploader_ids == [
+        "01H8M8Z1QB9X4Y7V5T2R3S4Q5A",
+        "01H8M8Z1QB9X4Y7V5T2R3S4Q6A",
+    ]
+    assert filters.q == "quarterly"
+    assert filters.uploader_me is False
+
+
+@pytest.mark.parametrize(
+    "created_from, created_to",
+    [
+        (
+            datetime(2024, 5, 2, tzinfo=UTC),
+            datetime(2024, 5, 1, tzinfo=UTC),
+        ),
+    ],
+)
+def test_document_filters_reject_invalid_created_range(
+    created_from: datetime, created_to: datetime
+) -> None:
+    with pytest.raises(ValidationError):
+        DocumentFilters(created_from=created_from, created_to=created_to)
+
+
+@pytest.mark.parametrize(
+    "last_run_from, last_run_to",
+    [
+        (
+            datetime(2024, 4, 10, tzinfo=UTC),
+            datetime(2024, 4, 9, tzinfo=UTC),
+        ),
+    ],
+)
+def test_document_filters_reject_invalid_last_run_range(
+    last_run_from: datetime, last_run_to: datetime
+) -> None:
+    with pytest.raises(ValidationError):
+        DocumentFilters(last_run_from=last_run_from, last_run_to=last_run_to)
+
+
+def test_document_filters_reject_invalid_byte_size_range() -> None:
+    with pytest.raises(ValidationError):
+        DocumentFilters(byte_size_min=500, byte_size_max=100)
+
+
+def test_document_sort_parsing_defaults_to_created_desc() -> None:
+    result = DocumentSort.parse(None)
+
+    assert result.field is DocumentSortableField.CREATED_AT
+    assert result.descending is True
+
+
+@pytest.mark.parametrize(
+    "raw, expected_field, expected_descending",
+    [
+        ("status", DocumentSortableField.STATUS, False),
+        ("-byte_size", DocumentSortableField.BYTE_SIZE, True),
+        ("name", DocumentSortableField.NAME, False),
+    ],
+)
+def test_document_sort_parsing_handles_prefixes(
+    raw: str, expected_field: DocumentSortableField, expected_descending: bool
+) -> None:
+    parsed = DocumentSort.parse(raw)
+
+    assert parsed.field is expected_field
+    assert parsed.descending is expected_descending
+
+
+def test_document_sort_parsing_rejects_unknown_field() -> None:
+    with pytest.raises(ValueError):
+        DocumentSort.parse("-unknown")
+
+
+def test_document_filter_enums_export_expected_values() -> None:
+    assert set(DOCUMENT_STATUS_VALUES) == {status.value for status in DocumentStatus}
+    assert set(DOCUMENT_SOURCE_VALUES) == {source.value for source in DocumentSource}
+
+
+def test_document_filter_params_normalise_uploader_and_sort() -> None:
+    params = DocumentFilterParams(
+        uploader="me",
+        sort="-status",
+        status=[DocumentStatus.PROCESSED.value, DocumentStatus.UPLOADED.value],
+    )
+
+    assert params.uploader_me is True
+    assert params.sort.field is DocumentSortableField.STATUS
+    assert params.sort.descending is True
+
+    filters = params.to_filters()
+    assert isinstance(filters, DocumentFilters)
+    assert filters.status == [DocumentStatus.PROCESSED, DocumentStatus.UPLOADED]

--- a/ade/features/documents/tests/test_service_filters.py
+++ b/ade/features/documents/tests/test_service_filters.py
@@ -1,0 +1,166 @@
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from ade import get_settings
+from ade.db import generate_ulid
+from ade.db.session import get_sessionmaker
+from ade.features.documents.filtering import (
+    DocumentFilters,
+    DocumentSort,
+    DocumentSortableField,
+    DocumentSource,
+    DocumentStatus,
+)
+from ade.features.documents.models import Document, DocumentTag
+from ade.features.documents.service import DocumentsService
+from ade.features.users.models import User
+from ade.features.workspaces.models import Workspace
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _build_documents_fixture(session):
+    workspace = Workspace(name="Workspace", slug=f"ws-{uuid4().hex[:6]}")
+    uploader = User(
+        id=generate_ulid(),
+        email="uploader@example.test",
+        display_name="Uploader One",
+        is_active=True,
+    )
+    colleague = User(
+        id=generate_ulid(),
+        email="colleague@example.test",
+        display_name="Colleague Two",
+        is_active=True,
+    )
+    session.add_all([workspace, uploader, colleague])
+    await session.flush()
+
+    now = datetime.now(tz=UTC)
+    expires = now + timedelta(days=30)
+
+    processed = Document(
+        id=generate_ulid(),
+        workspace_id=str(workspace.id),
+        original_filename="alpha-report.pdf",
+        content_type="application/pdf",
+        byte_size=512,
+        sha256="a" * 64,
+        stored_uri="alpha-report",
+        attributes={},
+        uploaded_by_user_id=uploader.id,
+        status=DocumentStatus.PROCESSED.value,
+        source=DocumentSource.MANUAL_UPLOAD.value,
+        expires_at=expires,
+        last_run_at=now - timedelta(days=1),
+    )
+    processed.tags.append(DocumentTag(document_id=processed.id, tag="finance"))
+
+    uploaded = Document(
+        id=generate_ulid(),
+        workspace_id=str(workspace.id),
+        original_filename="zeta-draft.docx",
+        content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        byte_size=128,
+        sha256="b" * 64,
+        stored_uri="zeta-draft",
+        attributes={},
+        uploaded_by_user_id=colleague.id,
+        status=DocumentStatus.UPLOADED.value,
+        source=DocumentSource.MANUAL_UPLOAD.value,
+        expires_at=expires,
+        last_run_at=None,
+    )
+
+    session.add_all([processed, uploaded])
+    await session.flush()
+
+    return workspace, uploader, colleague, processed, uploaded
+
+
+async def test_list_documents_applies_filters_and_sorting() -> None:
+    settings = get_settings()
+    session_factory = get_sessionmaker()
+
+    async with session_factory() as session:
+        workspace, uploader, colleague, processed, uploaded = await _build_documents_fixture(session)
+
+        service = DocumentsService(session=session, settings=settings)
+
+        filters = DocumentFilters(
+            status=[DocumentStatus.PROCESSED],
+            tags=["finance"],
+            uploader_me=True,
+            q="Uploader",
+        )
+        result = await service.list_documents(
+            workspace_id=str(workspace.id),
+            page=1,
+            per_page=50,
+            include_total=True,
+            filters=filters,
+            sort=DocumentSort(field=DocumentSortableField.CREATED_AT, descending=True),
+            actor=uploader,
+        )
+
+        assert result.total == 1
+        assert [item.document_id for item in result.items] == [processed.id]
+
+        # Sorting by name ascending should place the draft before the report.
+        name_sorted = await service.list_documents(
+            workspace_id=str(workspace.id),
+            page=1,
+            per_page=50,
+            filters=DocumentFilters(),
+            sort=DocumentSort(field=DocumentSortableField.NAME, descending=False),
+            actor=uploader,
+        )
+        assert [item.document_id for item in name_sorted.items] == [processed.id, uploaded.id]
+
+
+async def test_last_run_filters_include_nulls_in_upper_bound() -> None:
+    settings = get_settings()
+    session_factory = get_sessionmaker()
+
+    async with session_factory() as session:
+        workspace, uploader, colleague, processed, uploaded = await _build_documents_fixture(session)
+
+        service = DocumentsService(session=session, settings=settings)
+
+        filters = DocumentFilters(last_run_to=datetime.now(tz=UTC))
+        result = await service.list_documents(
+            workspace_id=str(workspace.id),
+            page=1,
+            per_page=50,
+            filters=filters,
+            sort=DocumentSort.parse(None),
+            actor=uploader,
+        )
+
+        returned_ids = {item.document_id for item in result.items}
+        assert uploaded.id in returned_ids  # null last_run_at treated as "never"
+        assert processed.id in returned_ids
+
+
+async def test_sorting_last_run_places_nulls_last() -> None:
+    settings = get_settings()
+    session_factory = get_sessionmaker()
+
+    async with session_factory() as session:
+        workspace, uploader, colleague, processed, uploaded = await _build_documents_fixture(session)
+
+        service = DocumentsService(session=session, settings=settings)
+
+        result = await service.list_documents(
+            workspace_id=str(workspace.id),
+            page=1,
+            per_page=50,
+            filters=DocumentFilters(),
+            sort=DocumentSort(field=DocumentSortableField.LAST_RUN_AT, descending=True),
+            actor=uploader,
+        )
+
+        assert [item.document_id for item in result.items] == [processed.id, uploaded.id]

--- a/ade/features/jobs/tests/test_service.py
+++ b/ade/features/jobs/tests/test_service.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, select
 from starlette.datastructures import Headers
 
 from ade import get_settings
+from ade.db import generate_ulid
 from ade.db.session import get_sessionmaker
 from ade.features.configurations.models import Configuration
 from ade.features.documents.service import DocumentsService
@@ -25,6 +26,7 @@ from ade.features.jobs.processor import (
 )
 from ade.features.jobs.service import JobsService
 from ade.features.workspaces.models import Workspace
+from ade.features.users.models import User
 
 
 pytestmark = pytest.mark.asyncio
@@ -44,7 +46,10 @@ async def test_submit_job_records_metrics() -> None:
         session.add(workspace)
         await session.flush()
 
-        actor = SimpleNamespace(id="user-1", email="user@example.test")
+        actor = SimpleNamespace(id=generate_ulid(), email="user@example.test")
+
+        session.add(User(id=actor.id, email=actor.email, display_name="User 1"))
+        await session.flush()
 
         documents_service = DocumentsService(session=session, settings=settings)
         upload = UploadFile(
@@ -55,6 +60,7 @@ async def test_submit_job_records_metrics() -> None:
         document_record = await documents_service.create_document(
             workspace_id=str(workspace.id),
             upload=upload,
+            actor=actor,
         )
 
         result = await session.execute(
@@ -107,7 +113,10 @@ async def test_submit_job_records_failure_and_raises() -> None:
         session.add(workspace)
         await session.flush()
 
-        actor = SimpleNamespace(id="user-2", email="user2@example.test")
+        actor = SimpleNamespace(id=generate_ulid(), email="user2@example.test")
+
+        session.add(User(id=actor.id, email=actor.email, display_name="User 2"))
+        await session.flush()
 
         documents_service = DocumentsService(session=session, settings=settings)
         upload = UploadFile(
@@ -118,6 +127,7 @@ async def test_submit_job_records_failure_and_raises() -> None:
         document_record = await documents_service.create_document(
             workspace_id=str(workspace.id),
             upload=upload,
+            actor=actor,
         )
 
         result = await session.execute(
@@ -170,7 +180,10 @@ async def test_custom_processor_override_returns_typed_payload() -> None:
         session.add(workspace)
         await session.flush()
 
-        actor = SimpleNamespace(id="user-3", email="user3@example.test")
+        actor = SimpleNamespace(id=generate_ulid(), email="user3@example.test")
+
+        session.add(User(id=actor.id, email=actor.email, display_name="User 3"))
+        await session.flush()
 
         documents_service = DocumentsService(session=session, settings=settings)
         upload = UploadFile(
@@ -181,6 +194,7 @@ async def test_custom_processor_override_returns_typed_payload() -> None:
         document_record = await documents_service.create_document(
             workspace_id=str(workspace.id),
             upload=upload,
+            actor=actor,
         )
 
         result = await session.execute(

--- a/ade/main.py
+++ b/ade/main.py
@@ -18,6 +18,7 @@ from .api.v1.router import router as api_router
 from .settings import Settings, get_settings
 from .core.logging import setup_logging
 from .core.middleware import register_middleware
+from .api.errors import register_exception_handlers
 from .lifecycles import create_application_lifespan
 from .features.auth.dependencies import configure_auth_dependencies
 from .services.task_queue import TaskQueue
@@ -61,6 +62,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     configure_auth_dependencies(settings=settings)
 
     register_middleware(app)
+    register_exception_handlers(app)
     _mount_static(app)
     _register_routes(app)
     _configure_openapi(app, settings)

--- a/agents/WP_DOCUMENTS_FILTER_REDESIGN.md
+++ b/agents/WP_DOCUMENTS_FILTER_REDESIGN.md
@@ -1,0 +1,146 @@
+# Work Package: Documents Filter Redesign
+
+## Summary
+Redesign the documents grid end to end so filtering, sorting, pagination, and URL state are shared between the frontend and backend. Ship the work in deliberate phases that harden the database first, adopt consistent terminology, introduce backend-enforced filters with a shared limit/offset pagination helper, and finally align the UI.
+
+## Phased delivery plan
+
+### Phase 1 – Database schema consolidation (SQLite-first, Postgres-ready)
+- Update `ade/alembic/versions/0001_initial_schema.py` directly, then recreate the local database (no data backfill required).
+- Apply the following deltas to the `documents` table:
+  - `uploaded_by_user_id TEXT NULL` referencing `users(user_id)` with `ON DELETE SET NULL`.
+  - `status TEXT NOT NULL CHECK (status IN ('uploaded','processing','processed','failed','archived'))`.
+  - `source TEXT NOT NULL CHECK (source IN ('manual_upload')) DEFAULT 'manual_upload'`.
+  - `last_run_at TIMESTAMP NULL` (timezone-aware in Postgres, nullable and should sort last when absent).
+  - Retain `created_at` as the canonical uploaded timestamp.
+- Create the `document_tags` join table: `(document_id TEXT, tag TEXT, PRIMARY KEY(document_id, tag))`.
+- Add indexes:
+  - `documents(workspace_id, status, created_at DESC)`
+  - `documents(workspace_id, last_run_at DESC)`
+  - `documents(workspace_id, source)`
+  - `documents(workspace_id, uploaded_by_user_id)`
+  - `document_tags(document_id)` (add `document_tags(tag)` when tag filtering ships).
+
+### Phase 2 – Backend filtering primitives
+- Introduce a canonical filter schema that matches the updated terminology.
+- Define shared enums/constants for `status`, `source`, sortable fields, and the shared ULID identifier type.
+- Model tag relationships via SQLAlchemy relationships or lightweight join queries.
+- Add validation utilities for repeatable list filters and date windows.
+
+### Phase 3 – API contract & pagination
+- Define a `FilterParams` Pydantic model injected with `Depends`, using `list[...]` for repeatable params.
+- Add a shared pagination helper (e.g., `ade/core/pagination.py`) that exposes `PaginationParams` (page/per_page validation, optional `include_total`) and `paginate_query(query, params)` to apply SQLAlchemy `offset/limit` and return `{items, page, per_page, has_next}` by default, adding `total` when totals are requested; make it reusable across feature routers.
+- Flatten the query string: `status=processing&status=processed` rather than JSON:API namespaces.
+- Build a query builder that translates `FilterParams` into SQLAlchemy filters (AND across keys, OR within repeatable values).
+- Support the following fields/operators:
+
+| Concern | Field(s) | Operators | Notes |
+| --- | --- | --- | --- |
+| Ownership | `uploader=me`, `uploader_id` | `eq` (server-resolved) / repeatable IDs | `uploader=me` resolves to `uploaded_by_user_id` server-side; `uploader_id` accepts explicit ULIDs (repeatable). |
+| Status | `status` | repeatable equality | Allowed values: `uploaded`, `processing`, `processed`, `failed`, `archived`. |
+| Source | `source` | repeatable equality | Allowed value today: `manual_upload`. |
+| Tags | `tag` | repeatable equality | Any-of semantics (OR within tags). |
+| Search | `q` | substring match | Case-insensitive match across the stored filename and uploader display name. |
+| Created window | `created_from`, `created_to` | inclusive datetime bounds | UTC ISO-8601 applied to `created_at`. |
+| Last run window | `last_run_from`, `last_run_to` | inclusive datetime bounds | UTC ISO-8601 applied to nullable `last_run_at`; treat `NULL` as "never". |
+| Byte size | `byte_size_min`, `byte_size_max` | numeric bounds | Optional filter. |
+
+- Sorting: accept a single `sort` field with optional `-` prefix. Allowed values: `created_at` (default `-created_at`), `status`, `last_run_at`, `byte_size`, `source`, `name` (maps to the `original_filename` column). Null `last_run_at` sorts last.
+- Pagination: `page` and `per_page` (default 50, max 200). Response shape: `{ "items": [...], "page": 1, "per_page": 50, "has_next": false }` by default; include `"total": 321` only when `include_total=true` is supplied.
+- Return payloads that expose `document_id` consistently across list and detail endpoints (alias to `id` internally only when needed).
+- Validation: reject unknown parameters or operators with HTTP 400 (Problem+JSON).
+
+### Phase 4 – Frontend integration & UX alignment
+- Update the Documents route to read/write flat query params and omit defaults when serialising the URL.
+- Introduce a shared hook/utility for translating between component state and the canonical filter schema.
+- Refresh toolbar controls to match the filter model: uploader toggle (All ↔ Me) that sets/clears `uploader=me`, status multiselect, tag combobox, substring search (`q`), date range pickers, and reset control.
+- Ensure pagination controls mirror backend expectations (page/per_page, has-next summary by default, show totals when available).
+- Update telemetry to emit the flattened filter payload and respect ULID string identifiers throughout.
+
+### Phase 5 – Verification & rollout
+- Add unit tests for filter serialisation/deserialisation and the query builder.
+- Add endpoint tests covering validation failure modes, pagination metadata, and tag any-of semantics.
+- QA the frontend to confirm URL round-tripping, inclusive date filters, nullable `last_run_at` sorting last, and `uploader=me` resolution.
+- Document migration steps (DB recreation) and rollout notes in `CHANGELOG.md` when shipping.
+
+## API contract
+
+### Request
+`GET /api/v1/workspaces/{workspace_id}/documents`
+
+Query parameters (all optional, flat namespace, ULID identifiers rendered as 26-character strings):
+- `status`: repeatable; allowed values `uploaded`, `processing`, `processed`, `failed`, `archived`.
+- `source`: repeatable; allowed values `manual_upload` (future sources extend the enum).
+- `tag`: repeatable; matches tag strings with any-of semantics.
+- `uploader`: `me` (server resolves to the authenticated user’s ID).
+- `uploader_id`: repeatable; explicit user IDs (ULIDs).
+- `q`: substring search across document name and uploader metadata.
+- `created_from`, `created_to`: inclusive UTC timestamps (ISO-8601) applied to `created_at`.
+- `last_run_from`, `last_run_to`: inclusive UTC timestamps applied to nullable `last_run_at`.
+- `byte_size_min`, `byte_size_max`: byte bounds.
+- `sort`: one of `created_at`, `-created_at`, `status`, `-status`, `last_run_at`, `-last_run_at`, `byte_size`, `-byte_size`, `source`, `-source`, `name`, `-name`.
+- `page`: 1-based page number (default 1).
+- `per_page`: page size (default 50, max 200).
+- `include_total`: boolean flag (default `false`) that triggers a total count query when true.
+
+### Response
+Default responses include `{"items", "page", "per_page", "has_next"}`. When `include_total=true` the payload also returns a `total` count, as illustrated below.
+```json
+{
+  "items": [
+    {
+      "document_id": "01HZ4GQ2VTWQX9SZ4CE00N7AZQ",
+      "name": "Quarterly Report.pdf",
+      "status": "processed",
+      "source": "manual_upload",
+      "tags": ["finance", "2024"],
+      "created_at": "2024-03-18T15:42:00Z",
+      "last_run_at": "2024-03-18T16:00:00Z",
+      "byte_size": 123456,
+      "content_type": "application/pdf",
+      "uploader": { "id": "01HYWQPZYTN7Z8KRYFXS8V1E4T", "name": "Alice Example", "email": "alice@example.com" }
+    }
+  ],
+  "page": 1,
+  "per_page": 50,
+  "has_next": false,
+  "total": 321
+}
+```
+
+### Behavioural notes
+- Unknown parameters or values outside the whitelists return HTTP 400 with Problem+JSON details.
+- `uploader=me` resolves server-side using the authenticated principal; omit client heuristics.
+- Tag filtering is inclusive OR within tags, AND across other filter categories.
+- Date range filters are inclusive and expect UTC ISO-8601 timestamps.
+- `last_run_at` is nullable; surface `null` when no extraction has run and treat those records as last when sorting (after non-null timestamps).
+- Pagination uses the shared helper so every endpoint returns the `{items, page, per_page, has_next}` envelope consistently, appending `total` when explicitly requested.
+- Document and user identifiers are ULIDs (26-character strings) exposed as plain strings in the API.
+- `name` remains the display-friendly field mapped from `original_filename` across the API and UI.
+
+## Minimal, consistent grid UX
+- Toolbar controls: uploader toggle (All / Me) mapped to `uploader` (`me` sets the filter, clearing returns to all), optional uploader picker for admins, status multiselect, tag combobox, substring search (`q`), date range pickers for created/last run, reset button, and upload CTA.
+- Active filters display as dismissible chips that mirror the flat query params (omit defaults in the URL).
+- Table columns: Document, Status, Source, Created (absolute + relative), Last run, Size, Tags, Actions. Column sorts align with backend-enforced options.
+- Pagination footer: page selector, per-page selector (25/50/100/200 capped at 200), has-next summary by default (show totals when available), upload shortcut.
+- Empty states add “Clear filters” when any filter is active and reuse existing copy otherwise.
+
+## Acceptance criteria
+1. Database schema matches Phase 1 (including new indexes) by editing `ade/alembic/versions/0001_initial_schema.py`; local databases are recreated with the new structure.
+2. Backend filters honour the flat query parameters, resolve `uploader=me`, apply tag any-of semantics, and treat date ranges as inclusive.
+3. Sorting accepts only the approved single-field values, maps `name` to `original_filename`, keeps created-date pagination stable via a `created_at DESC, document_id DESC` tie-breaker, and orders `last_run_at` nulls last.
+4. Pagination uses `page`/`per_page`, caps `per_page` at 200, and responds with `{items, page, per_page, has_next}` by default, adding `total` only when `include_total=true`.
+5. URL state and UI state round-trip without defaults: clearing filters removes params; adding filters populates matching keys.
+6. Validation rejects unknown parameters/operators with HTTP 400 (Problem+JSON).
+7. Pagination flows through the shared helper; tests cover validation, pagination, and query-builder branching.
+
+## FastAPI implementation notes
+- Define a `FilterParams` Pydantic model with fields matching the URL keys; inject via `Depends`.
+- Use `list[...]` annotations for repeatable params (`status`, `source`, `tag`, `uploader_id`).
+- Normalise `uploader=me` inside the dependency by looking up the authenticated user.
+- Build a query builder that converts `FilterParams` into SQLAlchemy filters (AND between categories, OR across repeatables).
+- Implement `ade/core/pagination.py` (or similar) with `PaginationParams`, `Paginated[T]` response model, and a helper that applies `offset/limit`, exposes `has_next`, and optionally performs a `select(func.count())` when `include_total` is true.
+- Keep response models and enums in `ade/features/documents/schemas.py` for reuse by tests, re-exporting the shared `Paginated[DocumentOut]` type.
+
+## Decision record
+We will replace the ad-hoc, client-only filters with a backend-enforced contract that keeps terminology, ULID identifiers, and pagination consistent across the stack. Locking the schema first eliminates downstream churn, and adopting flat query parameters plus a reusable limit/offset helper keeps FastAPI endpoints predictable without adding third-party dependencies. The phased approach ensures the API and frontend evolve together while remaining testable and predictable.

--- a/frontend.old/src/features/documents/api.ts
+++ b/frontend.old/src/features/documents/api.ts
@@ -4,7 +4,7 @@ import type { DocumentRecord, WorkspaceDocumentSummary } from "../../shared/type
 function normaliseDocument(record: DocumentRecord): WorkspaceDocumentSummary {
   return {
     id: record.document_id,
-    name: record.original_filename,
+    name: record.name,
     updatedAt: record.updated_at,
     createdAt: record.created_at,
     byteSize: record.byte_size,

--- a/frontend.old/src/shared/types/documents.ts
+++ b/frontend.old/src/shared/types/documents.ts
@@ -1,17 +1,26 @@
+export interface UploaderSummary {
+  id: string;
+  name: string | null;
+  email: string;
+}
+
 export interface DocumentRecord {
   document_id: string;
   workspace_id: string;
-  original_filename: string;
+  name: string;
   content_type: string | null;
   byte_size: number;
-  sha256: string;
-  stored_uri: string;
   metadata: Record<string, unknown>;
+  status: string;
+  source: string;
   expires_at: string;
+  last_run_at: string | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
   deleted_by: string | null;
+  tags: string[];
+  uploader: UploaderSummary | null;
 }
 
 export interface WorkspaceDocumentSummary {

--- a/frontend/src/app/routes/documents/README.md
+++ b/frontend/src/app/routes/documents/README.md
@@ -1,0 +1,52 @@
+<!-- Keep this document up to date when the documents route changes. -->
+# Documents Route Reference
+
+## Overview
+The `DocumentsRoute` lists workspace documents, orchestrates uploads, and exposes per-row actions (details, download, delete). Filters live in the URL via `useDocumentsParams`, the data layer streams paginated results from `useDocumentsQuery`, and the route renders `DocumentsToolbar`, `DocumentsTable`, and `DocumentsEmptyState` to surface filters, results, and drag-and-drop uploads.
+
+```
+DocumentsRoute
+├─ useDocumentsParams      → URL ↔ filter/sort/pagination synchronisation
+├─ useDocumentsQuery       → GET /workspaces/:workspaceId/documents
+├─ useUploadDocumentsMutation → POST /workspaces/:workspaceId/documents
+├─ useDeleteDocumentsMutation → DELETE /workspaces/:workspaceId/documents/:documentId
+└─ downloadWorkspaceDocument   → GET /workspaces/:workspaceId/documents/:documentId/download
+```
+
+## Data flow
+1. `useDocumentsParams()` parses the current search string, debounces free-text search, and returns both the URL state and a normalised API payload.
+2. `useDocumentsQuery(workspace.id, apiParams)` fetches paginated `DocumentRecord` rows. `toDocumentRows` memoises the envelope as `DocumentRow` models for the grid.
+3. Table sorting is driven directly by the URL sort parameter (`parseSortParam`/`toSortParam`), guaranteeing server-side ordering.
+4. User actions bubble back to the route:
+   - Sorting → `handleSortChange` → `nextSort` + `setSort` → telemetry (`documents.sort`).
+   - Filtering → `setUploader` / `setStatuses` / `setCreatedRange` / `setLastRunRange` / `setSearch` / tag helpers → telemetry (`documents.filter_*`).
+   - Inspect → `handleInspect` → `WorkspaceChrome` inspector → telemetry (`documents.view_details`).
+   - Download → `handleDownload` → `downloadWorkspaceDocument` → `triggerBrowserDownload`.
+   - Delete → `handleDelete` → `useDeleteDocumentsMutation`.
+   - Upload (button, dropzone, or file input change) → `handleFilesSelected` → `useUploadDocumentsMutation`.
+5. Mutation hooks invalidate `documentKeys.lists(workspaceId)` so TanStack Query re-fetches the active result set with the current filters.
+
+## Local state
+- `sortState` ({ `column`, `direction` }): derived from the URL sort parameter, defaults to `uploadedAt` descending.
+- `feedback` (object or `null`): transient alerts for uploads/downloads/deletes.
+- `downloadingId` / `deletingId` (string or `null`): row-level loading states during actions.
+- `dragDepth` (number): tracks nested drag events to show the drop overlay.
+
+Derived helpers: `rows` (normalised page items), `availableTags` (tag suggestions from the current envelope), `hasActiveFilters`, `hasNext`, `showEmptyState`, and `isDragging`.
+
+## Filter logic details
+- **Uploader toggle:** `setUploader("me")` maps to `uploader=me`, instructing the API to resolve the current actor’s ULID server-side.
+- **Status multi-select:** `setStatuses([...])` forwards repeatable `status` params; the backend validates against the canonical enum.
+- **Tags:** `addTag`/`removeTag` manage repeatable `tag` params with deduplication; the backend treats tags as “any-of”.
+- **Date ranges:** `setCreatedRange` / `setLastRunRange` push inclusive UTC bounds via `created_from`/`created_to` and `last_run_from`/`last_run_to`.
+- **Search:** `setSearch` keeps the free-text term in the URL immediately; the API payload debounces to ~300 ms via `useDebouncedValue`.
+- **Sort:** `parseSortParam` normalises the API sort string and `toSortParam` serialises single-field requests, keeping pagination stable through `created_at DESC, document_id DESC` tie-breaks.
+
+## Component responsibilities
+- **`DocumentsToolbar`:** Renders the uploader toggle, status multi-select, tag combobox, date-range pickers, search input, pagination summary, and upload CTA. It omits default filters from the URL.
+- **`DocumentsTable`:** Displays the sortable grid, row actions, skeleton placeholders, and formatting helpers (timestamps, status badges, tags, file size). Headers emit `aria-sort` for accessibility.
+- **`DocumentsEmptyState`:** Shows onboarding copy when no documents exist or when filters hide all results, with quick actions to clear filters or upload.
+- **`DocumentDetails`:** Inspector content showing human-readable metadata (including uploader summary and retention window).
+
+## Telemetry
+All tracked events flow through `trackDocumentsEvent`, namespaced as `documents.<action>` with the current workspace ID (plus action-specific payload).

--- a/frontend/src/app/routes/documents/components/DocumentDetails.tsx
+++ b/frontend/src/app/routes/documents/components/DocumentDetails.tsx
@@ -1,5 +1,5 @@
 import type { DocumentRow } from "../utils";
-import { formatDateTime, formatFileSize, formatStatusLabel } from "../utils";
+import { formatDateTime, formatFileSize, formatLastRunLabel, formatStatusLabel } from "../utils";
 
 interface DocumentDetailsProps {
   readonly document: DocumentRow;
@@ -15,7 +15,11 @@ export function DocumentDetails({ document }: DocumentDetailsProps) {
           <Detail term="Status" value={formatStatusLabel(document.status)} />
           <Detail term="Source" value={document.source} />
           <Detail term="Uploaded" value={formatDateTime(document.uploadedAt)} />
-          <Detail term="Last run" value={document.lastRunAt ? `${document.lastRunLabel} (${formatDateTime(document.lastRunAt)})` : document.lastRunLabel} />
+          <Detail
+            term="Last run"
+            value={document.lastRunAt ? `${formatLastRunLabel(document.lastRunAt)} (${formatDateTime(document.lastRunAt)})` : "Never"}
+          />
+          <Detail term="Expires" value={formatDateTime(document.expiresAt)} />
           <Detail term="Size" value={formatFileSize(document.byteSize)} />
         </dl>
       </section>

--- a/frontend/src/app/routes/documents/components/DocumentsEmptyState.tsx
+++ b/frontend/src/app/routes/documents/components/DocumentsEmptyState.tsx
@@ -1,22 +1,17 @@
 import { Button } from "../../../../ui";
-import type { OwnerFilterValue, StatusFilterValue } from "../utils";
 
 interface DocumentsEmptyStateProps {
-  readonly owner: OwnerFilterValue;
-  readonly status: StatusFilterValue;
   readonly hasDocuments: boolean;
-  readonly onViewAll: () => void;
-  readonly onClearStatus: () => void;
+  readonly hasActiveFilters: boolean;
+  readonly onClearFilters: () => void;
   readonly onUpload: () => void;
   readonly isUploading: boolean;
 }
 
 export function DocumentsEmptyState({
-  owner,
-  status,
   hasDocuments,
-  onViewAll,
-  onClearStatus,
+  hasActiveFilters,
+  onClearFilters,
   onUpload,
   isUploading,
 }: DocumentsEmptyStateProps) {
@@ -34,33 +29,36 @@ export function DocumentsEmptyState({
     );
   }
 
-  const ownerDescription = owner === "mine" ? "your uploads" : "workspace uploads";
-  const statusDescription = status === "all" ? "" : ` (${status})`;
+  if (hasActiveFilters) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-800">No documents match the current filters</h2>
+          <p className="mt-2 max-w-md text-sm text-slate-500">
+            Adjust the filters or upload a new document to continue.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Button variant="secondary" onClick={onClearFilters}>
+            Clear filters
+          </Button>
+          <Button onClick={onUpload} isLoading={isUploading}>
+            Upload documents
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
-      <div>
-        <h2 className="text-lg font-semibold text-slate-800">No documents match the current filters</h2>
-        <p className="mt-2 max-w-md text-sm text-slate-500">
-          Showing {ownerDescription}
-          {statusDescription}. Adjust the filters or upload a new document.
-        </p>
-      </div>
-      <div className="flex flex-wrap items-center justify-center gap-3">
-        {owner === "mine" ? (
-          <Button variant="secondary" onClick={onViewAll}>
-            View all documents
-          </Button>
-        ) : null}
-        {status !== "all" ? (
-          <Button variant="secondary" onClick={onClearStatus}>
-            Clear status filter
-          </Button>
-        ) : null}
-        <Button onClick={onUpload} isLoading={isUploading}>
-          Upload documents
-        </Button>
-      </div>
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+      <h2 className="text-lg font-semibold text-slate-800">No documents available</h2>
+      <p className="max-w-md text-sm text-slate-500">
+        There are no documents on this page yet. Upload a file to populate the workspace.
+      </p>
+      <Button onClick={onUpload} isLoading={isUploading}>
+        Upload documents
+      </Button>
     </div>
   );
 }

--- a/frontend/src/app/routes/documents/components/DocumentsToolbar.tsx
+++ b/frontend/src/app/routes/documents/components/DocumentsToolbar.tsx
@@ -1,109 +1,313 @@
-import { useId } from "react";
+import clsx from "clsx";
+import { useId, useMemo, useState, type ChangeEvent, type KeyboardEvent } from "react";
 
 import { Button, Input, Select } from "../../../../ui";
-import { OWNER_FILTER_OPTIONS, STATUS_FILTER_OPTIONS } from "../utils";
-import type { OwnerFilterValue, StatusFilterValue } from "../utils";
+import type { UploaderFilterValue } from "../utils";
+import { formatStatusLabel } from "../utils";
+
+const STATUS_OPTIONS: readonly { value: string; label: string }[] = [
+  { value: "uploaded", label: formatStatusLabel("uploaded") },
+  { value: "processing", label: formatStatusLabel("processing") },
+  { value: "processed", label: formatStatusLabel("processed") },
+  { value: "failed", label: formatStatusLabel("failed") },
+  { value: "archived", label: formatStatusLabel("archived") },
+];
 
 interface DocumentsToolbarProps {
-  readonly owner: OwnerFilterValue;
-  readonly onOwnerChange: (value: OwnerFilterValue) => void;
-  readonly status: StatusFilterValue;
-  readonly onStatusChange: (value: StatusFilterValue) => void;
+  readonly uploader: UploaderFilterValue;
+  readonly onUploaderChange: (value: UploaderFilterValue) => void;
+  readonly statuses: readonly string[];
+  readonly onStatusesChange: (values: string[]) => void;
+  readonly tags: readonly string[];
+  readonly onAddTag: (tag: string) => void;
+  readonly onRemoveTag: (tag: string) => void;
+  readonly availableTags: readonly string[];
+  readonly createdFrom?: string;
+  readonly createdTo?: string;
+  readonly onCreatedRangeChange: (from?: string, to?: string) => void;
+  readonly lastRunFrom?: string;
+  readonly lastRunTo?: string;
+  readonly onLastRunRangeChange: (from?: string, to?: string) => void;
   readonly search: string;
   readonly onSearchChange: (value: string) => void;
+  readonly onClearFilters: () => void;
   readonly onUploadClick: () => void;
   readonly isUploading: boolean;
-  readonly resultCount: number;
-  readonly totalCount: number;
+  readonly itemCount: number;
+  readonly page: number;
+  readonly perPage: number;
+  readonly onPerPageChange: (value: number) => void;
+  readonly canClearFilters: boolean;
 }
 
 export function DocumentsToolbar({
-  owner,
-  onOwnerChange,
-  status,
-  onStatusChange,
+  uploader,
+  onUploaderChange,
+  statuses,
+  onStatusesChange,
+  tags,
+  onAddTag,
+  onRemoveTag,
+  availableTags,
+  createdFrom,
+  createdTo,
+  onCreatedRangeChange,
+  lastRunFrom,
+  lastRunTo,
+  onLastRunRangeChange,
   search,
   onSearchChange,
+  onClearFilters,
   onUploadClick,
   isUploading,
-  resultCount,
-  totalCount,
+  itemCount,
+  page,
+  perPage,
+  onPerPageChange,
+  canClearFilters,
 }: DocumentsToolbarProps) {
-  const showTotal = totalCount > 0 && totalCount !== resultCount;
-  const formattedCurrent = resultCount.toLocaleString();
-  const formattedTotal = totalCount.toLocaleString();
-  const label = showTotal ? `${formattedCurrent} of ${formattedTotal}` : formattedCurrent;
-  const noun = resultCount === 1 ? "result" : "results";
+  const statusSelectId = useId();
+  const tagInputId = useId();
+  const createdFromId = useId();
+  const createdToId = useId();
+  const lastRunFromId = useId();
+  const lastRunToId = useId();
+
+  const [tagDraft, setTagDraft] = useState("");
+
+  const perPageOptions = useMemo(
+    () => [25, 50, 100, 200],
+    [],
+  );
+
+  const handleStatusChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const values = Array.from(event.target.selectedOptions).map((option) => option.value);
+    onStatusesChange(values);
+  };
+
+  const handleTagKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      const value = tagDraft.trim();
+      if (value.length > 0) {
+        onAddTag(value);
+        setTagDraft("");
+      }
+    }
+  };
+
+  const handleTagBlur = () => {
+    const value = tagDraft.trim();
+    if (value.length > 0) {
+      onAddTag(value);
+      setTagDraft("");
+    }
+  };
+
+  const summary = `${itemCount === 1 ? "1 result" : `${itemCount} results`} • Page ${page}`;
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-5 py-3">
-      <div className="flex flex-1 flex-wrap items-center gap-3">
-        <FilterSelect
-          label="Showing"
-          value={owner}
-          onChange={onOwnerChange}
-          options={OWNER_FILTER_OPTIONS}
-          widthClass="w-44"
+    <div className="sticky top-0 z-20 flex flex-col gap-3 border-b border-slate-200 bg-white px-5 py-4 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <UploaderToggle value={uploader} onChange={onUploaderChange} />
+          <div className="flex flex-col gap-1">
+            <label htmlFor={statusSelectId} className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Status
+            </label>
+            <Select
+              id={statusSelectId}
+              multiple
+              value={statuses}
+              onChange={handleStatusChange}
+              className="h-[4.5rem] w-48"
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <TagFilter
+            id={tagInputId}
+            value={tagDraft}
+            tags={tags}
+            onChange={setTagDraft}
+            onKeyDown={handleTagKeyDown}
+            onBlur={handleTagBlur}
+            onRemove={onRemoveTag}
+            availableTags={availableTags}
+          />
+        </div>
+        <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <span aria-live="polite">{summary}</span>
+          <Select
+            value={perPage}
+            onChange={(event) => onPerPageChange(Number.parseInt(event.target.value, 10))}
+            className="h-9 w-24"
+          >
+            {perPageOptions.map((option) => (
+              <option key={option} value={option}>
+                {option} / page
+              </option>
+            ))}
+          </Select>
+          <Button onClick={onUploadClick} isLoading={isUploading} size="sm">
+            Upload
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <DateRange
+          idFrom={createdFromId}
+          idTo={createdToId}
+          label="Created"
+          from={createdFrom}
+          to={createdTo}
+          onChange={onCreatedRangeChange}
         />
-        <FilterSelect
-          label="Status"
-          value={status}
-          onChange={onStatusChange}
-          options={STATUS_FILTER_OPTIONS}
-          widthClass="w-48"
+        <DateRange
+          idFrom={lastRunFromId}
+          idTo={lastRunToId}
+          label="Last run"
+          from={lastRunFrom}
+          to={lastRunTo}
+          onChange={onLastRunRangeChange}
         />
         <SearchField value={search} onChange={onSearchChange} />
-      </div>
-      <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
-        <span aria-live="polite">
-          {label} {noun}
-        </span>
-        <Button onClick={onUploadClick} isLoading={isUploading} size="sm">
-          Upload
+        <Button variant="secondary" onClick={onClearFilters} disabled={!canClearFilters}>
+          Clear all
         </Button>
       </div>
     </div>
   );
 }
 
-type Option<T extends string> = { value: T; label: string };
-
-interface FilterSelectProps<T extends string> {
-  readonly label: string;
-  readonly value: T;
-  readonly onChange: (value: T) => void;
-  readonly options: readonly Option<T>[];
-  readonly widthClass: string;
-}
-
-function FilterSelect<T extends string>({ label, value, onChange, options, widthClass }: FilterSelectProps<T>) {
-  const id = useId();
-
+function UploaderToggle({ value, onChange }: { readonly value: UploaderFilterValue; readonly onChange: (value: UploaderFilterValue) => void }) {
   return (
-    <label htmlFor={id} className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-      <span>{label}</span>
-      <Select
-        id={id}
-        value={value}
-        onChange={(event) => onChange(event.target.value as T)}
-        className={widthClass}
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </Select>
-    </label>
+    <div className="flex items-center gap-2">
+      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Showing</span>
+      <div className="flex overflow-hidden rounded-md border border-slate-200">
+        <button
+          type="button"
+          onClick={() => onChange("all")}
+          className={clsxToggle(value === "all")}
+        >
+          All
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange("me")}
+          className={clsxToggle(value === "me")}
+        >
+          Me
+        </button>
+      </div>
+    </div>
   );
 }
 
-interface SearchFieldProps {
-  readonly value: string;
-  readonly onChange: (value: string) => void;
+function clsxToggle(active: boolean) {
+  return clsx(
+    "px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition",
+    active ? "bg-brand-600 text-white" : "bg-white text-slate-600 hover:bg-slate-100",
+  );
 }
 
-function SearchField({ value, onChange }: SearchFieldProps) {
+interface TagFilterProps {
+  readonly id: string;
+  readonly value: string;
+  readonly tags: readonly string[];
+  readonly availableTags: readonly string[];
+  readonly onChange: (value: string) => void;
+  readonly onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  readonly onBlur: () => void;
+  readonly onRemove: (tag: string) => void;
+}
+
+function TagFilter({ id, value, tags, availableTags, onChange, onKeyDown, onBlur, onRemove }: TagFilterProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={id} className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        Tags
+      </label>
+      <div className="flex min-w-[14rem] flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-slate-200 px-2 py-1">
+          {tags.length === 0 ? (
+            <span className="text-xs text-slate-400">Any tag</span>
+          ) : (
+            tags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => onRemove(tag)}
+                className="flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-200"
+              >
+                {tag}
+                <span aria-hidden="true">×</span>
+                <span className="sr-only">Remove tag {tag}</span>
+              </button>
+            ))
+          )}
+        </div>
+        <Input
+          id={id}
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={onKeyDown}
+          onBlur={onBlur}
+          list={`${id}-options`}
+          placeholder="Add tag"
+          className="h-9"
+        />
+        <datalist id={`${id}-options`}>
+          {availableTags.map((tag) => (
+            <option key={tag} value={tag} />
+          ))}
+        </datalist>
+      </div>
+    </div>
+  );
+}
+
+interface DateRangeProps {
+  readonly idFrom: string;
+  readonly idTo: string;
+  readonly label: string;
+  readonly from?: string;
+  readonly to?: string;
+  readonly onChange: (from?: string, to?: string) => void;
+}
+
+function DateRange({ idFrom, idTo, label, from, to, onChange }: DateRangeProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</span>
+      <div className="flex items-center gap-2">
+        <Input
+          id={idFrom}
+          type="date"
+          value={from ?? ""}
+          onChange={(event) => onChange(event.target.value || undefined, to)}
+          className="h-9"
+        />
+        <span className="text-slate-400">to</span>
+        <Input
+          id={idTo}
+          type="date"
+          value={to ?? ""}
+          onChange={(event) => onChange(from, event.target.value || undefined)}
+          className="h-9"
+        />
+      </div>
+    </div>
+  );
+}
+
+function SearchField({ value, onChange }: { readonly value: string; readonly onChange: (value: string) => void }) {
   const id = useId();
 
   return (

--- a/frontend/src/app/routes/documents/hooks/__tests__/useDocumentsParams.test.tsx
+++ b/frontend/src/app/routes/documents/hooks/__tests__/useDocumentsParams.test.tsx
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppProviders } from "../../../../AppProviders";
+import {
+  parseDocumentsSearchParams,
+  serialiseDocumentsSearchParams,
+  useDocumentsParams,
+} from "../useDocumentsParams";
+
+function createWrapper(initialSearch = "") {
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[`/workspaces/ws-1/documents${initialSearch}`]}>
+        <AppProviders>{children}</AppProviders>
+      </MemoryRouter>
+    );
+  };
+}
+
+describe("useDocumentsParams", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("omits defaults when serialising URL parameters", () => {
+    const search = new URLSearchParams({ page: "1", per_page: "50", sort: "-created_at" });
+    const parsed = parseDocumentsSearchParams(search);
+    const serialised = serialiseDocumentsSearchParams(parsed);
+    expect(serialised.toString()).toBe("");
+  });
+
+  it("resets the page when filters change", () => {
+    const wrapper = createWrapper("?page=3");
+    const { result } = renderHook(() => useDocumentsParams(), { wrapper });
+
+    act(() => {
+      result.current.setStatuses(["processed"]);
+    });
+
+    expect(result.current.urlState.page).toBe(1);
+    expect(result.current.urlState.status).toEqual(["processed"]);
+  });
+
+  it("normalises uploader=me for API params", () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useDocumentsParams(), { wrapper });
+
+    act(() => {
+      result.current.setUploader("me");
+    });
+
+    expect(result.current.apiParams.uploader).toBe("me");
+  });
+
+  it("debounces search input before updating API params", () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useDocumentsParams(), { wrapper });
+
+    act(() => {
+      result.current.setSearch("quarterly");
+    });
+
+    expect(result.current.apiParams.q).toBeUndefined();
+
+    act(() => {
+      vi.advanceTimersByTime(320);
+    });
+
+    expect(result.current.apiParams.q).toBe("quarterly");
+  });
+
+  it("deduplicates tags and exposes them for API calls", () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useDocumentsParams(), { wrapper });
+
+    act(() => {
+      result.current.addTag("finance");
+    });
+    expect(result.current.urlState.tags).toEqual(["finance"]);
+
+    act(() => {
+      result.current.addTag("finance");
+    });
+
+    act(() => {
+      result.current.addTag("ops");
+    });
+
+    expect(result.current.urlState.tags).toEqual(["finance", "ops"]);
+    expect(result.current.apiParams.tag).toEqual(["finance", "ops"]);
+  });
+});

--- a/frontend/src/app/routes/documents/hooks/useDocumentsParams.ts
+++ b/frontend/src/app/routes/documents/hooks/useDocumentsParams.ts
@@ -1,0 +1,312 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { useDebouncedValue } from "../../../../shared/hooks/useDebouncedValue";
+import type { DocumentsQueryParams } from "../../../../features/documents/api";
+
+export const DEFAULT_SORT_PARAM = "-created_at";
+const DEFAULT_PAGE = 1;
+const DEFAULT_PER_PAGE = 50;
+const DEBOUNCE_MS = 300;
+
+type MaybeMe = "me" | null;
+
+export interface DocumentsUrlState {
+  status: string[];
+  source: string[];
+  tags: string[];
+  uploader: MaybeMe;
+  uploaderIds: string[];
+  q: string;
+  createdFrom?: string;
+  createdTo?: string;
+  lastRunFrom?: string;
+  lastRunTo?: string;
+  sort: string;
+  page: number;
+  perPage: number;
+  includeTotal: boolean;
+}
+
+const EMPTY_STATE: DocumentsUrlState = {
+  status: [],
+  source: [],
+  tags: [],
+  uploader: null,
+  uploaderIds: [],
+  q: "",
+  sort: DEFAULT_SORT_PARAM,
+  page: DEFAULT_PAGE,
+  perPage: DEFAULT_PER_PAGE,
+  includeTotal: false,
+};
+
+function parseInteger(value: string | null, fallback: number) {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
+}
+
+function uniqueSorted(values: readonly string[]) {
+  return Array.from(new Set(values.filter((value) => value.trim().length > 0))).sort();
+}
+
+export function parseDocumentsSearchParams(searchParams: URLSearchParams): DocumentsUrlState {
+  const status = uniqueSorted(searchParams.getAll("status"));
+  const source = uniqueSorted(searchParams.getAll("source"));
+  const tags = uniqueSorted(searchParams.getAll("tag"));
+  const uploaderIds = uniqueSorted(searchParams.getAll("uploader_id"));
+  const uploader = searchParams.get("uploader") === "me" ? "me" : null;
+  const q = searchParams.get("q") ?? "";
+  const createdFrom = searchParams.get("created_from") ?? undefined;
+  const createdTo = searchParams.get("created_to") ?? undefined;
+  const lastRunFrom = searchParams.get("last_run_from") ?? undefined;
+  const lastRunTo = searchParams.get("last_run_to") ?? undefined;
+  const sort = searchParams.get("sort") ?? DEFAULT_SORT_PARAM;
+  const page = parseInteger(searchParams.get("page"), DEFAULT_PAGE);
+  const perPage = parseInteger(searchParams.get("per_page"), DEFAULT_PER_PAGE);
+  const includeTotal = searchParams.get("include_total") === "true";
+
+  return {
+    status,
+    source,
+    tags,
+    uploader,
+    uploaderIds,
+    q,
+    createdFrom,
+    createdTo,
+    lastRunFrom,
+    lastRunTo,
+    sort,
+    page,
+    perPage,
+    includeTotal,
+  };
+}
+
+export function serialiseDocumentsSearchParams(state: DocumentsUrlState) {
+  const params = new URLSearchParams();
+
+  for (const value of state.status) {
+    params.append("status", value);
+  }
+  for (const value of state.source) {
+    params.append("source", value);
+  }
+  for (const value of state.tags) {
+    params.append("tag", value);
+  }
+  for (const value of state.uploaderIds) {
+    params.append("uploader_id", value);
+  }
+
+  if (state.uploader === "me") {
+    params.set("uploader", "me");
+  }
+  if (state.q.trim().length > 0) {
+    params.set("q", state.q.trim());
+  }
+  if (state.createdFrom) {
+    params.set("created_from", state.createdFrom);
+  }
+  if (state.createdTo) {
+    params.set("created_to", state.createdTo);
+  }
+  if (state.lastRunFrom) {
+    params.set("last_run_from", state.lastRunFrom);
+  }
+  if (state.lastRunTo) {
+    params.set("last_run_to", state.lastRunTo);
+  }
+  if (state.sort !== DEFAULT_SORT_PARAM) {
+    params.set("sort", state.sort);
+  }
+  if (state.page !== DEFAULT_PAGE) {
+    params.set("page", state.page.toString());
+  }
+  if (state.perPage !== DEFAULT_PER_PAGE) {
+    params.set("per_page", state.perPage.toString());
+  }
+  if (state.includeTotal) {
+    params.set("include_total", "true");
+  }
+
+  return params;
+}
+
+export function useDocumentsParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlState = useMemo(
+    () => ({ ...EMPTY_STATE, ...parseDocumentsSearchParams(searchParams) }),
+    [searchParams],
+  );
+  const debouncedQuery = useDebouncedValue(urlState.q, DEBOUNCE_MS);
+
+  const apiParams: DocumentsQueryParams = useMemo(
+    () => ({
+      status: urlState.status,
+      source: urlState.source,
+      tag: urlState.tags,
+      uploader: urlState.uploader ?? undefined,
+      uploader_id: urlState.uploaderIds,
+      q: debouncedQuery.trim().length > 0 ? debouncedQuery.trim() : undefined,
+      created_from: urlState.createdFrom,
+      created_to: urlState.createdTo,
+      last_run_from: urlState.lastRunFrom,
+      last_run_to: urlState.lastRunTo,
+      sort: urlState.sort,
+      page: urlState.page,
+      per_page: urlState.perPage,
+      include_total: urlState.includeTotal,
+    }),
+    [
+      debouncedQuery,
+      urlState.createdFrom,
+      urlState.createdTo,
+      urlState.includeTotal,
+      urlState.lastRunFrom,
+      urlState.lastRunTo,
+      urlState.page,
+      urlState.perPage,
+      urlState.sort,
+      urlState.source,
+      urlState.status,
+      urlState.tags,
+      urlState.uploader,
+      urlState.uploaderIds,
+    ],
+  );
+
+  const applyState = useCallback(
+    (next: DocumentsUrlState) => {
+      const params = serialiseDocumentsSearchParams(next);
+      setSearchParams(params, { replace: true });
+    },
+    [setSearchParams],
+  );
+
+  const resetPage = useCallback(
+    (next: DocumentsUrlState) => ({ ...next, page: DEFAULT_PAGE }),
+    [],
+  );
+
+  const setStatuses = useCallback(
+    (values: string[]) => {
+      applyState(resetPage({ ...urlState, status: uniqueSorted(values) }));
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const setTags = useCallback(
+    (values: string[]) => {
+      applyState(resetPage({ ...urlState, tags: uniqueSorted(values) }));
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const addTag = useCallback(
+    (value: string) => {
+      if (!value.trim()) {
+        return;
+      }
+      const tags = uniqueSorted([...urlState.tags, value.trim()]);
+      applyState(resetPage({ ...urlState, tags }));
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const removeTag = useCallback(
+    (value: string) => {
+      const tags = urlState.tags.filter((tag) => tag !== value);
+      applyState(resetPage({ ...urlState, tags }));
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const setUploader = useCallback(
+    (value: MaybeMe) => {
+      applyState(resetPage({ ...urlState, uploader: value }));
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const setSearch = useCallback(
+    (value: string) => {
+      applyState(resetPage({ ...urlState, q: value }));
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const setSort = useCallback(
+    (value: string) => {
+      applyState(resetPage({ ...urlState, sort: value }));
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const setPage = useCallback(
+    (value: number) => {
+      const page = value < 1 ? DEFAULT_PAGE : value;
+      applyState({ ...urlState, page });
+    },
+    [applyState, urlState],
+  );
+
+  const setPerPage = useCallback(
+    (value: number) => {
+      const perPage = value < 1 ? DEFAULT_PER_PAGE : value;
+      applyState(resetPage({ ...urlState, perPage }));
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const setCreatedRange = useCallback(
+    (from?: string, to?: string) => {
+      applyState(
+        resetPage({
+          ...urlState,
+          createdFrom: from || undefined,
+          createdTo: to || undefined,
+        }),
+      );
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const setLastRunRange = useCallback(
+    (from?: string, to?: string) => {
+      applyState(
+        resetPage({
+          ...urlState,
+          lastRunFrom: from || undefined,
+          lastRunTo: to || undefined,
+        }),
+      );
+    },
+    [applyState, resetPage, urlState],
+  );
+
+  const clearFilters = useCallback(() => {
+    applyState({ ...EMPTY_STATE });
+  }, [applyState]);
+
+  return {
+    urlState,
+    apiParams,
+    setStatuses,
+    setTags,
+    addTag,
+    removeTag,
+    setUploader,
+    setSearch,
+    setSort,
+    setPage,
+    setPerPage,
+    setCreatedRange,
+    setLastRunRange,
+    clearFilters,
+  };
+}

--- a/frontend/src/features/documents/__tests__/api.test.ts
+++ b/frontend/src/features/documents/__tests__/api.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDocumentsSearchParams } from "../api";
+
+describe("buildDocumentsSearchParams", () => {
+  it("serialises repeatable parameters for arrays", () => {
+    const params = buildDocumentsSearchParams({
+      status: ["uploaded", "processed"],
+      tag: ["finance", "ops"],
+      uploader_id: ["01H", "01J"],
+      page: 2,
+      per_page: 100,
+      include_total: true,
+    });
+
+    expect(params.getAll("status")).toEqual(["uploaded", "processed"]);
+    expect(params.getAll("tag")).toEqual(["finance", "ops"]);
+    expect(params.getAll("uploader_id")).toEqual(["01H", "01J"]);
+    expect(params.get("page")).toBe("2");
+    expect(params.get("per_page")).toBe("100");
+    expect(params.get("include_total")).toBe("true");
+  });
+});

--- a/frontend/src/features/documents/hooks/__tests__/useUploadDocumentsMutation.test.tsx
+++ b/frontend/src/features/documents/hooks/__tests__/useUploadDocumentsMutation.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { WorkspaceDocumentSummary } from "../../../../shared/types/documents";
+import type { DocumentRecord } from "../../../../shared/types/documents";
 import { uploadWorkspaceDocument } from "../../api";
 import { useUploadDocumentsMutation } from "../useUploadDocumentsMutation";
 
@@ -24,14 +24,23 @@ describe("useUploadDocumentsMutation", () => {
 
     const mockedUpload = vi.mocked(uploadWorkspaceDocument);
     mockedUpload.mockImplementation(async (_workspaceId: string, { file }: { file: File }) => ({
-      id: `doc-${file.name}`,
+      document_id: `doc-${file.name}`,
+      workspace_id: "workspace-123",
       name: file.name,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      byteSize: file.size,
-      contentType: file.type,
+      content_type: file.type,
+      byte_size: file.size,
       metadata: {},
-    } as WorkspaceDocumentSummary));
+      status: "uploaded",
+      source: "manual_upload",
+      expires_at: new Date().toISOString(),
+      last_run_at: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      deleted_at: null,
+      deleted_by: null,
+      tags: [],
+      uploader: null,
+    } as DocumentRecord));
 
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },

--- a/frontend/src/features/documents/hooks/useDeleteDocumentsMutation.ts
+++ b/frontend/src/features/documents/hooks/useDeleteDocumentsMutation.ts
@@ -12,7 +12,7 @@ export function useDeleteDocumentsMutation(workspaceId: string) {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: documentKeys.list(workspaceId),
+        queryKey: documentKeys.lists(workspaceId),
         refetchType: "active",
       });
     },

--- a/frontend/src/features/documents/hooks/useUploadDocumentsMutation.ts
+++ b/frontend/src/features/documents/hooks/useUploadDocumentsMutation.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import type { WorkspaceDocumentSummary } from "../../../shared/types/documents";
 import { uploadWorkspaceDocument } from "../api";
 import { documentKeys } from "./useWorkspaceDocumentsQuery";
 
@@ -23,22 +22,19 @@ export function useUploadDocumentsMutation(workspaceId: string) {
   return useMutation({
     mutationFn: async (input: UploadDocumentsInput) => {
       const files = Array.from(input.files);
-      const results: WorkspaceDocumentSummary[] = [];
       const total = files.length;
       for (const [index, file] of files.entries()) {
-        const document = await uploadWorkspaceDocument(workspaceId, {
+        await uploadWorkspaceDocument(workspaceId, {
           file,
           metadata: input.metadata,
           expiresAt: input.expiresAt,
         });
-        results.push(document);
         input.onProgress?.({ file, index, total });
       }
-      return results;
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: documentKeys.list(workspaceId),
+        queryKey: documentKeys.lists(workspaceId),
         refetchType: "active",
       });
     },

--- a/frontend/src/features/documents/hooks/useWorkspaceDocumentsQuery.ts
+++ b/frontend/src/features/documents/hooks/useWorkspaceDocumentsQuery.ts
@@ -1,17 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { fetchWorkspaceDocuments } from "../api";
+import { fetchWorkspaceDocuments, type DocumentsQueryParams } from "../api";
+import type { DocumentListResponse } from "../../../shared/types/documents";
 
 export const documentKeys = {
   all: ["documents"] as const,
-  list: (workspaceId: string) => [...documentKeys.all, workspaceId, "list"] as const,
+  lists: (workspaceId: string) => [...documentKeys.all, workspaceId, "list"] as const,
+  list: (workspaceId: string, params: DocumentsQueryParams) => [
+    ...documentKeys.lists(workspaceId),
+    params,
+  ] as const,
 };
 
-export function useWorkspaceDocumentsQuery(workspaceId: string) {
-  return useQuery({
-    queryKey: documentKeys.list(workspaceId),
-    queryFn: ({ signal }) => fetchWorkspaceDocuments(workspaceId, signal),
+export function useDocumentsQuery(workspaceId: string, params: DocumentsQueryParams) {
+  return useQuery<DocumentListResponse>({
+    queryKey: documentKeys.list(workspaceId, params),
+    queryFn: ({ signal }) => fetchWorkspaceDocuments(workspaceId, params, signal),
     enabled: workspaceId.length > 0,
+    placeholderData: (previous) => previous,
     staleTime: 30_000,
   });
 }

--- a/frontend/src/shared/hooks/useDebouncedValue.ts
+++ b/frontend/src/shared/hooks/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delay: number) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/frontend/src/shared/types/documents.ts
+++ b/frontend/src/shared/types/documents.ts
@@ -1,25 +1,40 @@
+export type DocumentStatus = "uploaded" | "processing" | "processed" | "failed" | "archived";
+
+export type DocumentSource = "manual_upload";
+
+export interface UploaderSummary {
+  /** Uploader ULID (26-character string). */
+  id: string;
+  /** Human-friendly display name if available. */
+  name: string | null;
+  /** Uploader email address. */
+  email: string;
+}
+
 export interface DocumentRecord {
+  /** Document ULID (26-character string). */
   document_id: string;
   workspace_id: string;
-  original_filename: string;
+  name: string;
   content_type: string | null;
   byte_size: number;
-  sha256: string;
-  stored_uri: string;
   metadata: Record<string, unknown>;
+  status: DocumentStatus;
+  source: DocumentSource;
   expires_at: string;
+  last_run_at: string | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
   deleted_by: string | null;
+  tags: string[];
+  uploader: UploaderSummary | null;
 }
 
-export interface WorkspaceDocumentSummary {
-  id: string;
-  name: string;
-  updatedAt: string;
-  createdAt: string;
-  byteSize: number;
-  contentType: string | null;
-  metadata: Record<string, unknown>;
+export interface DocumentListResponse {
+  items: DocumentRecord[];
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  total?: number | null;
 }


### PR DESCRIPTION
## Summary
- document the shared pagination dependency and filter parameters while surfacing Problem+JSON errors and nulls-last ordering for document listings
- rework the documents route around URL-synchronised filters, paginated responses, and refreshed toolbar/table components with debounced search
- add reusable frontend helpers and tests for building document query params and deriving TanStack Query keys

## Testing
- pytest
- npm test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f124b6f32c832ea26f6cafd306030d