### PR TITLE
feat: support inviting workspace members by email

### DIFF
--- a/frontend/src/features/users/api.ts
+++ b/frontend/src/features/users/api.ts
@@ -1,6 +1,15 @@
-import { get } from "@shared/api";
-import type { UserSummary } from "@types/users";
+import { get, post } from "@shared/api";
+import type { UserProfile, UserSummary } from "@types/users";
 
 export function fetchUsers() {
   return get<UserSummary[]>("/users");
+}
+
+export interface InviteUserPayload {
+  readonly email: string;
+  readonly display_name?: string | null;
+}
+
+export function inviteUser(payload: InviteUserPayload) {
+  return post<UserProfile>("/users/invitations", payload);
 }

--- a/frontend/src/features/users/hooks/useInviteUserMutation.ts
+++ b/frontend/src/features/users/hooks/useInviteUserMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { inviteUser } from "../api";
+
+interface InviteUserInput {
+  readonly email: string;
+  readonly displayName?: string;
+}
+
+export function useInviteUserMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ email, displayName }: InviteUserInput) =>
+      inviteUser({
+        email,
+        display_name: displayName?.trim() ? displayName.trim() : undefined,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["users", "all"] });
+    },
+  });
+}

--- a/frontend/src/ui/avatar.tsx
+++ b/frontend/src/ui/avatar.tsx
@@ -1,0 +1,49 @@
+import clsx from "clsx";
+import { useMemo } from "react";
+
+const SIZE_STYLES = {
+  sm: "h-8 w-8 text-sm",
+  md: "h-10 w-10 text-base",
+  lg: "h-12 w-12 text-lg",
+} as const;
+
+type AvatarSize = keyof typeof SIZE_STYLES;
+
+export interface AvatarProps {
+  readonly name?: string | null;
+  readonly email?: string | null;
+  readonly size?: AvatarSize;
+  readonly className?: string;
+}
+
+function getInitials(name?: string | null, email?: string | null) {
+  if (name && name.trim().length > 0) {
+    const parts = name.trim().split(/\s+/u);
+    const first = parts[0]?.[0];
+    const last = parts[parts.length - 1]?.[0];
+    if (first) {
+      return `${first}${last ?? ""}`.toUpperCase();
+    }
+  }
+  if (email && email.trim().length > 0) {
+    return email.trim()[0]?.toUpperCase();
+  }
+  return "?";
+}
+
+export function Avatar({ name, email, size = "md", className }: AvatarProps) {
+  const initials = useMemo(() => getInitials(name, email), [name, email]);
+
+  return (
+    <span
+      aria-hidden="true"
+      className={clsx(
+        "inline-flex select-none items-center justify-center rounded-full bg-gradient-to-br from-brand-100 via-brand-200 to-brand-300 font-semibold text-brand-900 shadow-sm",
+        SIZE_STYLES[size],
+        className,
+      )}
+    >
+      {initials}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- add a user invitation API helper and mutation for creating accounts by email
- extend the workspace members UI with an invite-method toggle and email-based invitation flow
- ensure invited users are added with selected roles once the invitation succeeds

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f651f29e78832e83bc73476a1b5ce3