### PR TITLE
feat(configs): add activation environments

### DIFF
--- a/.workpackage/packages/0014-docs-code-parity-job-runtime/notes.md
+++ b/.workpackage/packages/0014-docs-code-parity-job-runtime/notes.md
@@ -1,8 +1,9 @@
 # Docs/code parity — job runtime (queue, deps, hooks)
 
 Owner: jkropp
-Status: active
+Status: active (implementation)
 Created: 2025-11-03T20:20:00Z
+Last reviewed: 2025-11-03T23:55:00Z
 
 ---
 
@@ -12,12 +13,24 @@ Align the **developer docs** and the **runtime** for job submission/processing, 
 
 ---
 
+## Repository reconnaissance
+
+* `backend/app/features/jobs/router.py` responds with **201** and returns a completed `JobRecord`; there is no async queue or `202 Accepted` path today, and HTTP headers/body lack a `Location` pointer or `{ status: "queued" }` payload.
+* `backend/app/features/jobs/service.py` executes jobs inline by calling `JobOrchestrator.run(...)` after marking the row `running`; saturation/back-pressure are absent.
+* `backend/app/features/configs/service.py::activate_version` only updates workspace state—no dependency install, `on_activate` hook execution, or environment metadata persistence.
+* `backend/app/features/jobs/orchestrator.py` always shells out with `sys.executable`; it never consults a per-config venv and always injects `config/vendor` onto `PYTHONPATH`.
+* `backend/app/features/jobs/runtime/pipeline.py` enforces hook ordering and deep-copies artifacts, but `on_activate` hooks are never invoked because activation skips runtime code, so the documented deps-first-then-hooks activation contract is unmet.
+* `backend/tests/api/jobs/test_jobs_router.py` asserts the current synchronous flow (201 + succeeded status); docs/tests will need wholesale updates for the queued contract.
+* Developer docs still reference `engine.defaults.allow_net` and per-job `vendor/` installs even though runtime uses `runtime_network_access` and never runs `pip`.
+
+---
+
 ## Scope
 
 **In scope (P0 unless marked):**
 
 * Job queue with bounded workers, `202 Accepted` semantics, `429` back‑pressure, status polling, and `/retry`.
-* Activation‑time dependency install (one **venv per config version**), job execution using that venv, and audit of installed packages.
+* Activation‑time dependency install (one **venv per config version**), job execution using that venv, and audit of installed packages (deps installed **before** hooks, with hooks running inside the venv).
 * Lifecycle hook behavior parity (`on_activate`, `on_job_start`, `on_after_extract`, `after_mapping`, `after_transform`, `after_validate`, `on_job_end`) with read‑only artifact snapshots and annotation returns.
 * Network policy: runtime network **off by default**, activation network **allowed for installs**; flag to permit runtime network when explicitly enabled.
 * Docs updates to match runtime (or vice versa) for queue, deps, hooks, and logs.
@@ -33,11 +46,11 @@ Align the **developer docs** and the **runtime** for job submission/processing, 
 
 ## Current gaps (audit)
 
-* **Queue semantics**: API returns `201` and runs work inline; docs describe queued `202`, worker pool, and `429` back‑pressure.
-* **Dependency handling**: Docs mention `requirements.txt` installs; runtime does not run `pip` nor isolate per config version.
-* **Hooks**: Docs describe gating `on_activate` and stage‑specific hook ordering; runtime only partially aligns.
-* **Network policy**: Docs imply network gating; runtime needs explicit enforcement for activation vs runtime.
-* **Logs**: Docs mention simple logs; runtime emits structured `events.ndjson`/`run-request.json`—docs must reflect this.
+* **Queue semantics** (`backend/app/features/jobs/router.py`, `service.py`): API currently returns `201` and blocks while the worker runs; docs promise a `202` queue, worker pool, and `429` back-pressure.
+* **Dependency handling** (`backend/app/features/configs/service.py`): Docs describe `requirements.txt` installs during activation; runtime never creates per-version environments.
+* **Hooks** (`backend/app/features/jobs/runtime/pipeline.py`): Stage hooks largely match docs, but `on_activate` is never executed and activation failures never gate publishing.
+* **Network policy** (`backend/app/features/jobs/worker.py`): Runtime disables sockets based on env, yet activation-time installs are unspecified and docs reference `allow_net` instead of `runtime_network_access`.
+* **Logs & metadata** (`backend/app/features/jobs/storage.py` + docs): Runtime emits structured `events.ndjson`/`run-request.json`, while docs assume plaintext logs and omit environment metadata.
 
 ---
 
@@ -45,51 +58,59 @@ Align the **developer docs** and the **runtime** for job submission/processing, 
 
 ### D1 — Queued job runner (P0)
 
-**Deliver:** Background queue with bounded concurrency; `POST /jobs` returns `202` + job resource; saturation returns `429`. `GET /jobs/{id}` exposes state machine (`queued → running → succeeded|failed`) and timestamps. `POST /jobs/{id}/retry` enqueues a new attempt with link to prior.
+**Deliver:** Introduce an async job manager (e.g., `backend/app/features/jobs/manager.py`) that owns a bounded queue and worker tasks running within a **single process/pod**. `JobsService.submit_job` should enqueue work instead of executing inline, `POST /jobs` must return `202 Accepted` with a `Location` header plus `{ job_id, status: "queued" }`, and saturation should produce `429 Too Many Requests` with a `Retry-After` hint. Extend `GET /jobs/{id}` to surface queue timestamps, attempts, retry lineage, and heartbeat data so the manager can rehydrate queued/running jobs on restart (stale "running" jobs fall back to `queued`). `POST /jobs/{id}/retry` should enqueue a fresh attempt linked to the prior run. Worker startup should rehydrate queue state from persistence.
 
 **Acceptance:**
 
-* [ ] Load test proves `429` when queue is full; no inline execution on submit.
-* [ ] Integration tests cover submit → poll → output/artifact download; retry path updates `attempt` and links history.
-* [ ] Structured events (`events.ndjson`) include `enqueue`, `start`, `exit`, `retry`, `error`, with durations.
+* [x] `POST /jobs` returns `202 Accepted` with `Location: /api/v1/.../jobs/{id}` and body `{ job_id, status: "queued" }`.
+* [x] Under configured saturation, the service returns `429 Too Many Requests` with `Retry-After: <seconds>` and queue metadata (e.g., `{ queue_size, max_concurrency }`).
+* [x] `GET /jobs/{id}` exposes `queued_at`, `started_at`, `completed_at`, and attempt counters reflecting `enqueue → start → exit/error` transitions.
+* [x] Worker startup rehydrates queued jobs from persistence; jobs lacking a heartbeat for >N seconds are marked back to `queued`.
+* [x] No synchronous execution path remains; service tests guard against inline worker invocation.
+* [x] Worker events include structured `enqueue`, `start`, `exit`, `retry`, `error` records emitted to storage using the `{ ts, event, job_id, attempt, state, duration_ms?, detail? }` schema.
 
-### D2 — Activation‑time deps & venv per config version (P0)
+### D2 — Activation-time deps & venv per config version (P0)
 
-**Deliver:** On config **activation**, if `requirements.txt` exists, create venv at `/var/lib/ade/venvs/<config_version_id>/` and `pip install -r`. Persist venv path and installed packages. Jobs run the worker using that venv’s Python if present; otherwise base interpreter.
+**Deliver:** During `ConfigsService.activate_version` (and publish paths that auto-activate), detect `requirements.txt`, create a virtualenv under `/var/lib/ade/venvs/<config_version_id>/`, install dependencies using hardened `pip install -r` flags (`--no-input --disable-pip-version-check`), then run `pip freeze` into `activation/packages.txt`. Execute `on_activate` hooks **after dependencies install** using the venv interpreter, capture hook diagnostics, and persist metadata (venv path, package list, install logs, hook annotations) under config storage (e.g., `/configs/<version>/activation/{log.txt, packages.txt, venv_path.json}`). Update `JobOrchestrator` to launch workers with the venv interpreter and surface `engine.environment.packages` through job/activation metadata. Ensure installs run once per version, reuse the same venv, and defer GC/disk reclamation (one venv per config version in v1).
 
 **Acceptance:**
 
-* [ ] Activation fails with diagnostic on `pip` error; jobs are not runnable until activation succeeds.
-* [ ] Artifact or job metadata records `engine.environment.packages` (name+version) on first run or via activation snapshot.
-* [ ] No per‑job installs; repeated jobs reuse the same venv.
+* [x] Activation fails fast on dependency install errors with actionable diagnostics and leaves the version inactive.
+* [x] `activation/packages.txt` exists, is referenced from job detail/artifact metadata, and reflects the frozen environment.
+* [x] Worker uses the venv interpreter (`sys.executable` recorded in `run-request.json`); per-job vendor installs are removed.
+* [x] `on_activate` hooks run after dependencies inside the venv; failures block activation and persist diagnostics.
 
 ### D3 — Hook lifecycle parity (P0)
 
-**Deliver:** Enforce documented hook groups and order. `on_activate` runs synchronously during activation and blocks on error. Stage hooks receive a **deep‑copied, read‑only** artifact snapshot and may return a small dict to append to `artifact.annotations[]` with `stage`, `hook`, and timestamp.
+**Deliver:** Execute manifest `on_activate` hooks during activation using the stored package, aborting on failure. Confirm runtime hook execution order matches docs, tighten artifact immutability guarantees (deep copies or frozen views), ensure hook annotations share a consistent schema (e.g., `{stage, hook, annotated_at, detail?}`), and respect hook enable flags everywhere. Persist hook annotations alongside job artifacts and activation metadata.
 
 **Acceptance:**
 
-* [ ] Tests show each hook executes at the correct point with read‑only artifact and that returned annotations are persisted.
-* [ ] Activation fails if any `on_activate` hook errors; other stages do not abort the job unless they raise.
-* [ ] Hook enable flags in manifest respected.
+* [x] `on_activate` runs after dependency installs within the venv; failure blocks activation and records diagnostics.
+* [ ] Runtime hook order matches `on_job_start → on_after_extract → after_mapping → after_transform → after_validate → on_job_end` exactly.
+* [ ] Hook return dicts appear in `artifact.annotations[]` with `{stage, hook, annotated_at}` (and optional `detail`).
+* [ ] Artifacts remain read-only to hooks; tests enforce immutability.
+* [ ] Hook enable/disable flags honored consistently across activation and runtime.
 
 ### D4 — Network policy enforcement (P0)
 
-**Deliver:** Network **allowed during activation** for `pip` by default; **blocked during job runtime** unless manifest `engine.defaults.runtime_network_access: true`. Replace ambiguous `allow_net` with `runtime_network_access` in code/docs.
+**Deliver:** Allow outbound network during activation installs, then enforce socket blocking in the worker when `runtime_network_access` is false. Accept legacy `engine.defaults.allow_net` manifest fields for one release window, map them to `runtime_network_access`, and emit a deprecation diagnostic during validation. Propagate manifest/env toggles cleanly through activation and runtime, expose overrides in metadata for auditing, and keep runtime default offline.
 
 **Acceptance:**
 
-* [ ] Worker socket creation blocked when `runtime_network_access` is false (tests verify).
-* [ ] Activation installs work under default policy; runtime remains offline unless opt‑in.
+* [ ] Worker socket creation fails by default and succeeds only when `runtime_network_access` (or legacy `allow_net`) enables it.
+* [ ] Validation maps `allow_net` to `runtime_network_access` with a warning diagnostic.
+* [ ] Runtime metadata exposes the resolved network access flag for audit.
 
 ### D5 — Documentation parity & examples (P0)
 
-**Deliver:** Update developer docs to reflect: queued runner/API; activation‑time deps with venv path; hook lifecycle; network policy; structured logs & request artifacts. Provide a minimal example manifest with `runtime_network_access` and `requirements.txt`.
+**Deliver:** Refresh developer docs to cover the queued API (including headers/bodies for 202/429), activation-time dependency flow with venv storage paths, hook lifecycle (including `on_activate` ordering), network policy defaults, structured logs/events schema, and manifest validation changes (e.g., `allow_net` deprecation, manifest version bump). Provide an example manifest showing `requirements.txt` plus `engine.defaults.runtime_network_access`.
 
 **Acceptance:**
 
-* [ ] Docs match endpoints, states, and file paths produced by the system.
-* [ ] Quickstart: activate config with deps → submit job → inspect artifact/output → view events.
+* [ ] Docs show request/response examples with headers (`Location`, `Retry-After`) and polling flow diagrams.
+* [ ] Config packages doc shows activation flow diagram, venv storage path, and hook ordering.
+* [ ] Glossary aligns hook stages and network policy names; schemas/manifests bumped as needed with migration guidance.
 
 ---
 
@@ -97,43 +118,84 @@ Align the **developer docs** and the **runtime** for job submission/processing, 
 
 ### Phase A — Queue & API
 
-* [ ] Add `JobState` machine and persisted fields: `queued_at`, `started_at`, `completed_at`, `attempt`, `error_message`.
-* [ ] Introduce in‑process worker pool (configurable size); pluggable queue interface for future external broker.
-* [ ] `POST /jobs` → create record, enqueue, return `202` with `Location`.
-* [ ] Saturation policy → `429 Too Many Requests` with `Retry-After`.
-* [ ] `GET /jobs/{id}` → json with state and links (`/artifact`, `/output`, `/logs`).
-* [ ] `POST /jobs/{id}/retry` → idempotent retry creation, links attempts.
-* [ ] Emit `events.ndjson` entries for enqueue/start/exit/retry/error.
+* [x] Add an async `JobQueueManager` with bounded workers, metrics, and graceful shutdown hooks (new module under `backend/app/features/jobs/`).
+* [x] Update `JobsService.submit_job` to enqueue and return immediately; propagate saturation via `JobSubmissionError` so the router emits `429` + `Retry-After`.
+* [x] Adjust `backend/app/features/jobs/router.py` + schemas to return `202`, include `Location`, and expose queue timestamps/links.
+* [x] Extend persistence (`models.py`, `repository.py`, `schemas.py`) to track queue timestamps, attempts, retry lineage, and expose `events.ndjson` URIs.
+* [x] Persist worker heartbeats / last_seen to support rehydration and stale-run detection on restart.
+* [x] Ensure worker lifecycle appends `enqueue`/`start`/`finish`/`retry`/`error` events to storage with durations.
 
-### Phase B — Activation‑time venv
+### Phase B — Activation-time venv (deps first, then `on_activate`)
 
-* [ ] On activation: if `requirements.txt` present → `python -m venv /var/lib/ade/venvs/<config_version_id>` then `pip install -r`.
-* [ ] Persist `venv_path` and list of installed packages.
-* [ ] Worker launcher selects venv Python when present.
-* [ ] Add health check: verify venv integrity (python exists, import of installed packages succeeds).
-* [ ] Migrate away from any “vendor/” concept; **no per‑job site‑packages**.
-* [ ] Clear diagnostics on failure; re‑activation reattempts install.
+* [x] Extend config storage metadata to track activation environment (venv path, installed packages, install log, timestamps).
+* [x] Run activation pipeline: detect `requirements.txt`, build virtualenv, install dependencies (`pip install -r` with hardened flags), capture `pip freeze`, snapshot environment metadata, then execute `on_activate` hooks using the venv interpreter.
+* [x] Update `JobOrchestrator` to use the venv interpreter/site-packages; remove vendor-based PYTHONPATH injection and call out no GC (one venv per config version).
+* [ ] Provide health checks + reactivation paths when venv creation fails, surfacing errors through API responses/logs and leaving the version inactive.
 
 ### Phase C — Hooks
 
-* [ ] Guarantee hook groups/order; respect `enabled`.
-* [ ] Run `on_activate` with failure gating.
-* [ ] Pass deep‑copied artifact snapshot to stage hooks; append returned dicts to `artifact.annotations[]` with ISO timestamp.
-* [ ] Tests for each stage ordering and error handling.
+* [ ] Wire activation hook execution into `ConfigsService.activate_version`, sharing manifest/context and persisting structured results/errors.
+* [ ] Harden runtime hook pipeline to enforce ordering, immutability, and annotation schema consistency.
+* [ ] Expand tests for activation + runtime hooks (services + worker) covering success/failure/annotation cases.
 
 ### Phase D — Network policy
 
-* [ ] Rename `allow_net` → `runtime_network_access` (manifest default `false`).
-* [ ] Enforce socket denial in worker when `false`.
-* [ ] Allow activation network for `pip`; document separation.
-* [ ] Tests: activation installs OK; runtime detectors/validators fail on net unless opt‑in.
+* [ ] Audit code/docs for lingering `allow_net` references; migrate to `runtime_network_access` nomenclature.
+* [ ] Ensure activation installs run with temporary network access and capture audit logs of dependency downloads; runtime remains offline unless explicitly enabled.
+* [ ] Reinforce worker socket patching + env propagation; add tests that simulate blocked/allowed connections and cover legacy `allow_net` mapping.
+* [ ] Surface manifest/global overrides in API responses for observability.
 
 ### Phase E — Docs parity
 
-* [ ] Update: `02-job-orchestration.md` (queue, 202/429, polling, retry, logs).
-* [ ] Update: `01-config-packages.md` (activation installs, venv path, artifact fields).
-* [ ] Update: `12-glossary.md` (hook lifecycle, network policy).
-* [ ] Add: minimal example manifest snippet with `engine.defaults.runtime_network_access` and `requirements.txt`.
+* [x] Update: `02-job-orchestration.md` (queued lifecycle, polling/retry examples, structured events/logs).
+* [x] Update: `01-config-packages.md` (activation flow, venv storage, `on_activate`, environment metadata).
+* [x] Update: `05-pass-transform-values.md` + `12-glossary.md` for runtime network terminology and hook lifecycle definitions.
+* [ ] Refresh schemas/examples to include `runtime_network_access`, environment metadata, event schema, and manifest snippets with `requirements.txt` plus legacy `allow_net` deprecation note.
+
+---
+
+### Near-term vertical slices (next three PRs)
+
+1. **Queue skeleton & 202/429 contract**
+   * Add `JobQueueManager` (bounded asyncio queue; N workers; single-process assumption) and flip `POST /jobs` to enqueue + `202` with `Location` header/body payload.
+   * Emit `429` with `Retry-After` when saturated; persist queue timestamps/events; add feature flag for rollback.
+   * Update API tests in `backend/tests/api/jobs/` for the new contract.
+2. **Activation pipeline: venv + deps + `on_activate`**
+   * Extend `ConfigsService.activate_version` to create the venv, install deps (hardened pip flags), freeze, and run hooks within the venv.
+   * Persist activation metadata under config storage; orchestrator uses venv interpreter; remove vendor PYTHONPATH injection.
+   * Add service tests covering install failure and hook failure gating activation.
+3. **Runtime network gating & `allow_net` deprecation**
+   * Enforce `runtime_network_access` in the worker (socket patch + tests) and accept legacy `allow_net` with warning diagnostics.
+   * Surface runtime network flag in job/artifact metadata; document the behavior.
+   * Prep docs for manifest/schema updates in the follow-up docs PR.
+
+---
+
+### Day-one checklist
+
+* [ ] Draft ADR at `docs/developers/design-decisions/dd-????-queued-runner-and-activation-env.md` capturing queue semantics (202/429, single-node, rehydration), deps-before-hooks activation, per-version venv, and runtime network policy default.
+* [ ] Create stubs for `backend/app/features/jobs/manager.py`, `backend/app/features/jobs/models.py` (state enums/heartbeat), and `backend/app/features/configs/activation_env.py` (venv helpers).
+* [ ] Flip router/service to return `202` + `Location` behind `ADE_QUEUE_ENABLED` flag; keep legacy tests as `_legacy` fixtures for comparison.
+* [ ] Add manifest validation mapping `engine.defaults.allow_net` → `engine.defaults.runtime_network_access` with a deprecation diagnostic.
+
+---
+
+## Testing & validation plan
+
+* Expand backend API tests for queued submission, polling, retry semantics, `Retry-After`, and artifact retrieval under the queued flow.
+* Add service-level tests for activation env install success/failure, hook execution (deps-before-hooks), and metadata persistence.
+* Introduce worker-level tests (possibly invoking subprocesses) to validate network blocking, venv interpreter selection, heartbeat recovery, and hook immutability.
+* Ensure docs updates reference generated schemas/examples; consider smoke checks if available.
+
+---
+
+## Open questions / follow-ups
+
+* How should the queue manager lifecycle integrate with FastAPI startup/shutdown (lifespan vs background task)?
+* Single-node guarantee in v1: do we need explicit guardrails/config to prevent multi-pod workers, or is documentation sufficient?
+* How aggressive should heartbeat-based requeue timing be, and where do we persist heartbeat timestamps?
+* Do we need migrations to store venv metadata, activation diagnostics, heartbeat, or retry lineage beyond existing columns?
+* Should runtime network overrides be configurable per workspace/job beyond the manifest default (e.g., admin override flag)?
 
 ---
 
@@ -149,7 +211,7 @@ Align the **developer docs** and the **runtime** for job submission/processing, 
 
 ## Risks & mitigations
 
-* **Queue starvation / unbounded growth:** enforce queue size + `429`; metrics + alerts.
+* **Queue starvation / unbounded growth:** enforce queue size + `429`; metrics + alerts; heartbeat-driven requeue on restart.
 * **Dependency install flakiness:** pin `pip` flags; timeout + retries; clear diagnostics.
 * **Hook errors blocking activation:** surface actionable errors; safe no‑ops for non‑activation hooks.
 * **Regressions in existing synchronous flows:** feature flag the queue path; migrate gradually.
@@ -168,5 +230,9 @@ Align the **developer docs** and the **runtime** for job submission/processing, 
 ## Notes
 
 * 2025-11-03T20:32:00Z • Decision: **no per‑job site‑packages**; use **one venv per config version** at activation.
-* 2025-11-03T20:34:00Z • Naming: replace `allow_net` with `runtime_network_access` across manifest, worker, and docs.
+* 2025-11-03T20:34:00Z • Naming: replace `allow_net` with `runtime_network_access` across manifest, worker, and docs; accept legacy field for one release with deprecation diagnostic.
 * 2025-11-03T20:36:00Z • Docs to update: `01-config-packages.md`, `02-job-orchestration.md`, `12-glossary.md`.
+* 2025-11-03T21:30:00Z • Event schema: `{ ts, event, job_id, attempt, state, duration_ms?, detail? }`; events include `enqueue`, `start`, `exit`, `retry`, `error`.
+* 2025-11-03T21:31:00Z • Manifest/schema: bump manifest minor version if we add `engine.environment` or rename fields; validation must emit actionable guidance.
+* 2025-11-03T22:40:00Z • Phase A shipped: queue manager, 202/429 API, retry route, heartbeats, rehydration, and normalized events are live behind the default path; saturation no longer persists failed rows.
+* 2025-11-03T22:42:00Z • Next up: start Phase B by adding `backend/app/features/configs/activation_env.py`, wiring `ConfigsService.activate_version` to create/use per-version venvs (deps → `on_activate`), and pointing the orchestrator at the venv interpreter; follow with network policy + docs (Phases D/E).

--- a/.workpackage/packages/0014-docs-code-parity-job-runtime/workpackage.json
+++ b/.workpackage/packages/0014-docs-code-parity-job-runtime/workpackage.json
@@ -6,7 +6,7 @@
   "summary": "Implement the job orchestration + config dependency features promised in dev docs (queueing, requirements install, activation hooks) and adjust docs/tests accordingly.",
   "status": "draft",
   "createdAt": "2025-11-03T19:59:46.296Z",
-  "updatedAt": "2025-11-03T19:59:46.296Z",
+  "updatedAt": "2025-11-03T21:32:00.000Z",
   "owner": "jkropp",
   "tags": [],
   "links": [],

--- a/backend/app/features/configs/activation_env.py
+++ b/backend/app/features/configs/activation_env.py
@@ -1,0 +1,414 @@
+"""Helpers for building and reading activation environments."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+import venv
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+from backend.app.features.configs.models import Config, ConfigVersion
+from backend.app.features.configs.spec import ManifestV1
+from backend.app.shared.core.config import Settings
+from backend.app.shared.core.time import utc_now
+
+from .storage import ConfigStorage
+
+__all__ = [
+    "ActivationEnvironmentManager",
+    "ActivationError",
+    "ActivationMetadata",
+    "ActivationMetadataStore",
+]
+
+
+@dataclass(slots=True)
+class ActivationMetadata:
+    """Snapshot of activation environment state for a config version."""
+
+    status: str
+    started_at: datetime | None
+    completed_at: datetime | None
+    error: str | None
+    venv_path: Path | None
+    python_executable: Path | None
+    packages_path: Path | None
+    install_log_path: Path | None
+    hooks_path: Path | None
+    annotations: list[dict[str, Any]]
+    diagnostics: list[dict[str, Any]]
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.status == "succeeded"
+            and self.python_executable is not None
+            and self.python_executable.exists()
+        )
+
+
+class ActivationError(Exception):
+    """Raised when activation fails to build a runnable environment."""
+
+    def __init__(self, message: str, *, diagnostics: Sequence[dict[str, Any]] | None = None) -> None:
+        super().__init__(message)
+        self.diagnostics = list(diagnostics or [])
+
+
+class ActivationMetadataStore:
+    """Load activation metadata persisted alongside config packages."""
+
+    _RESULT_FILENAME = "result.json"
+    _HOOKS_FILENAME = "hooks.json"
+    _VENV_INFO_FILENAME = "venv_path.json"
+
+    def __init__(self, storage: ConfigStorage) -> None:
+        self._storage = storage
+
+    def load(self, *, config_id: str, version: ConfigVersion) -> ActivationMetadata | None:
+        activation_dir = self._storage.activation_dir(config_id, version.sequence)
+        result_path = activation_dir / self._RESULT_FILENAME
+        if not result_path.exists():
+            return None
+
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+        status = str(payload.get("status") or "failed")
+        started_at = _parse_datetime(payload.get("started_at"))
+        completed_at = _parse_datetime(payload.get("completed_at"))
+        error = payload.get("error")
+        venv_path_text = payload.get("venv_path")
+        python_path_text = payload.get("python_executable")
+        packages_file = payload.get("packages_file")
+        install_log = payload.get("install_log")
+        hooks_file = payload.get("hooks_file") or self._HOOKS_FILENAME
+
+        packages_path = _resolve_relative(activation_dir, packages_file)
+        install_log_path = _resolve_relative(activation_dir, install_log)
+        hooks_path = _resolve_relative(activation_dir, hooks_file)
+        annotations: list[dict[str, Any]] = []
+        diagnostics: list[dict[str, Any]] = []
+        if hooks_path and hooks_path.exists():
+            try:
+                hooks_payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                hooks_payload = {}
+            annotations = _ensure_dict_list(hooks_payload.get("annotations"))
+            diagnostics = _ensure_dict_list(hooks_payload.get("diagnostics"))
+
+        venv_info_path = activation_dir / self._VENV_INFO_FILENAME
+        if venv_info_path.exists():
+            try:
+                info = json.loads(venv_info_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                info = {}
+            venv_path_text = venv_path_text or info.get("venv_path")
+            python_path_text = python_path_text or info.get("python_executable")
+
+        venv_path = Path(venv_path_text).resolve() if venv_path_text else None
+        python_path = Path(python_path_text).resolve() if python_path_text else None
+
+        return ActivationMetadata(
+            status=status,
+            started_at=started_at,
+            completed_at=completed_at,
+            error=error,
+            venv_path=venv_path,
+            python_executable=python_path,
+            packages_path=packages_path,
+            install_log_path=install_log_path,
+            hooks_path=hooks_path,
+            annotations=annotations,
+            diagnostics=diagnostics,
+        )
+
+
+class ActivationEnvironmentManager:
+    """Create per-version virtual environments and execute activation hooks."""
+
+    _INSTALL_LOG = "install.log"
+    _PACKAGES_FILE = "packages.txt"
+
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+        storage: ConfigStorage,
+        metadata_store: ActivationMetadataStore,
+    ) -> None:
+        self._settings = settings
+        self._storage = storage
+        self._metadata_store = metadata_store
+        self._venv_root = settings.activation_envs_dir or (settings.storage_data_dir / "venvs")
+        self._venv_root = Path(self._venv_root).resolve()
+        self._venv_root.mkdir(parents=True, exist_ok=True)
+
+    async def ensure_environment(
+        self,
+        *,
+        config: Config,
+        version: ConfigVersion,
+        manifest: ManifestV1,
+    ) -> ActivationMetadata:
+        existing = self._metadata_store.load(config_id=config.id, version=version)
+        if existing and existing.ready:
+            return existing
+
+        try:
+            await self._build_environment(config=config, version=version, manifest=manifest)
+        except ActivationError:
+            # Result.json already written by _build_environment; re-raise for caller handling.
+            raise
+        except Exception as exc:  # pragma: no cover - defensive safety net
+            raise ActivationError(str(exc)) from exc
+
+        refreshed = self._metadata_store.load(config_id=config.id, version=version)
+        if refreshed is None:
+            raise ActivationError("Activation metadata missing after environment build")
+        if not refreshed.ready:
+            raise ActivationError("Activation completed but environment is not ready")
+        return refreshed
+
+    async def _build_environment(
+        self,
+        *,
+        config: Config,
+        version: ConfigVersion,
+        manifest: ManifestV1,
+    ) -> None:
+        activation_dir = self._storage.activation_dir(config.id, version.sequence)
+        if activation_dir.exists():
+            shutil.rmtree(activation_dir, ignore_errors=True)
+        activation_dir.mkdir(parents=True, exist_ok=True)
+
+        venv_path = self._venv_root / version.id
+        if venv_path.exists():
+            shutil.rmtree(venv_path, ignore_errors=True)
+
+        builder = venv.EnvBuilder(with_pip=True, clear=True, system_site_packages=True)
+        builder.create(venv_path)
+        python_path = _venv_python_path(venv_path)
+        if not python_path.exists():
+            raise ActivationError("Virtual environment python executable missing")
+
+        started_at = utc_now()
+        status = "succeeded"
+        error_message: str | None = None
+        diagnostics: list[dict[str, Any]] = []
+
+        install_log_path = activation_dir / self._INSTALL_LOG
+        packages_path = activation_dir / self._PACKAGES_FILE
+        hooks_path = activation_dir / ActivationMetadataStore._HOOKS_FILENAME
+        result_path = activation_dir / ActivationMetadataStore._RESULT_FILENAME
+        venv_info_path = activation_dir / ActivationMetadataStore._VENV_INFO_FILENAME
+
+        venv_info_path.write_text(
+            json.dumps(
+                {
+                    "venv_path": str(venv_path),
+                    "python_executable": str(python_path),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        package_dir = Path(version.package_path).resolve()
+        requirements_path = package_dir / "requirements.txt"
+
+        try:
+            await self._install_requirements(
+                python_path=python_path,
+                requirements_path=requirements_path,
+                log_path=install_log_path,
+            )
+            await self._snapshot_packages(python_path=python_path, output_path=packages_path)
+            if manifest.hooks.on_activate:
+                diagnostics = await self._run_activate_hooks(
+                    python_path=python_path,
+                    package_dir=package_dir,
+                    manifest_path=package_dir / "manifest.json",
+                    hooks_path=hooks_path,
+                )
+            else:
+                hooks_path.write_text(
+                    json.dumps({"annotations": [], "diagnostics": []}, indent=2),
+                    encoding="utf-8",
+                )
+        except ActivationError as exc:
+            status = "failed"
+            error_message = str(exc)
+            diagnostics = list(exc.diagnostics)
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            status = "failed"
+            error_message = str(exc)
+            raise ActivationError(str(exc)) from exc
+        finally:
+            completed_at = utc_now()
+            result_payload = {
+                "status": status,
+                "started_at": started_at.isoformat(),
+                "completed_at": completed_at.isoformat(),
+                "error": error_message,
+                "venv_path": str(venv_path),
+                "python_executable": str(python_path),
+                "packages_file": packages_path.name if packages_path.exists() else None,
+                "install_log": install_log_path.name if install_log_path.exists() else None,
+                "hooks_file": hooks_path.name if hooks_path.exists() else None,
+                "diagnostics": diagnostics,
+            }
+            result_path.write_text(json.dumps(result_payload, indent=2), encoding="utf-8")
+
+    async def _install_requirements(
+        self,
+        *,
+        python_path: Path,
+        requirements_path: Path,
+        log_path: Path,
+    ) -> None:
+        if not requirements_path.exists():
+            log_path.write_text("requirements.txt not present; skipping install.\n", encoding="utf-8")
+            return
+
+        command = [
+            str(python_path),
+            "-m",
+            "pip",
+            "install",
+            "--no-input",
+            "--disable-pip-version-check",
+            "--require-virtualenv",
+            "-r",
+            str(requirements_path),
+        ]
+        returncode, stdout, stderr = await _run_subprocess(command)
+        log_path.write_text(stdout + stderr, encoding="utf-8")
+        if returncode != 0:
+            raise ActivationError(
+                "Dependency installation failed",
+                diagnostics=[
+                    {
+                        "level": "error",
+                        "code": "activation.install.failed",
+                        "message": "pip install returned non-zero status",
+                        "hint": log_path.as_posix(),
+                    }
+                ],
+            )
+
+    async def _snapshot_packages(self, *, python_path: Path, output_path: Path) -> None:
+        command = [str(python_path), "-m", "pip", "freeze"]
+        returncode, stdout, stderr = await _run_subprocess(command)
+        output_path.write_text(stdout or "", encoding="utf-8")
+        if returncode != 0:
+            raise ActivationError(
+                "Failed to capture installed packages",
+                diagnostics=[
+                    {
+                        "level": "error",
+                        "code": "activation.freeze.failed",
+                        "message": stderr.strip() or "pip freeze returned non-zero status",
+                    }
+                ],
+            )
+
+    async def _run_activate_hooks(
+        self,
+        *,
+        python_path: Path,
+        package_dir: Path,
+        manifest_path: Path,
+        hooks_path: Path,
+    ) -> list[dict[str, Any]]:
+        command = [
+            str(python_path),
+            "-m",
+            "backend.app.features.configs.activation_worker",
+            "--config-dir",
+            str(package_dir),
+            "--manifest-path",
+            str(manifest_path),
+            "--output",
+            str(hooks_path),
+        ]
+        returncode, stdout, stderr = await _run_subprocess(command)
+        if not hooks_path.exists():
+            hooks_path.write_text(
+                json.dumps({"annotations": [], "diagnostics": []}, indent=2),
+                encoding="utf-8",
+            )
+
+        diagnostics: list[dict[str, Any]] = []
+        if returncode != 0:
+            try:
+                hooks_payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+                diagnostics = _ensure_dict_list(hooks_payload.get("diagnostics"))
+            except json.JSONDecodeError:
+                diagnostics = []
+            if stderr.strip():
+                diagnostics.append(
+                    {
+                        "level": "error",
+                        "code": "activation.hooks.stderr",
+                        "message": stderr.strip(),
+                    }
+                )
+            raise ActivationError("on_activate hooks failed", diagnostics=diagnostics)
+
+        if not diagnostics:
+            try:
+                hooks_payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+                diagnostics = _ensure_dict_list(hooks_payload.get("diagnostics"))
+            except json.JSONDecodeError:
+                diagnostics = []
+
+        return diagnostics
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+def _resolve_relative(base: Path, filename: str | None) -> Path | None:
+    if not filename:
+        return None
+    return (base / filename).resolve()
+
+
+def _ensure_dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    items: list[dict[str, Any]] = []
+    for entry in value:
+        if isinstance(entry, dict):
+            items.append(entry)
+    return items
+
+
+def _venv_python_path(venv_path: Path) -> Path:
+    if os.name == "nt":
+        return venv_path / "Scripts" / "python.exe"
+    return venv_path / "bin" / "python"
+
+
+async def _run_subprocess(command: list[str]) -> tuple[int, str, str]:
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout_bytes, stderr_bytes = await process.communicate()
+    stdout = stdout_bytes.decode("utf-8", errors="replace")
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+    return process.returncode or 0, stdout, stderr

--- a/backend/app/features/configs/activation_worker.py
+++ b/backend/app/features/configs/activation_worker.py
@@ -1,0 +1,100 @@
+"""Execute `on_activate` hooks inside an activated virtual environment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from backend.app.features.configs.spec import ManifestLoader
+from backend.app.features.jobs.runtime.loader import ConfigPackageLoader
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run on_activate hooks for a config package")
+    parser.add_argument("--config-dir", required=True, help="Path to the unpacked config package")
+    parser.add_argument("--manifest-path", required=True, help="Path to the manifest.json inside the package")
+    parser.add_argument("--output", required=True, help="Where to write hook annotations/diagnostics JSON")
+    return parser.parse_args(argv)
+
+
+def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    model = ManifestLoader().load(payload)
+    return model.model_dump(mode="json")
+
+
+def _run_hooks(config_dir: Path, manifest: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], bool]:
+    loader = ConfigPackageLoader(config_dir)
+    hook_modules = loader.load_hook_modules(manifest).get("on_activate", [])
+    annotations: list[dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
+    failed = False
+
+    for hook in hook_modules:
+        run_fn = getattr(hook.module, "run", None)
+        if not callable(run_fn):
+            diagnostics.append(
+                {
+                    "level": "warning",
+                    "code": "activation.hook.missing_run",
+                    "message": f"Hook {hook.path} does not define run()",
+                    "path": hook.path,
+                }
+            )
+            continue
+
+        context = {
+            "manifest": manifest,
+            "env": manifest.get("env") or {},
+            "artifact": {},
+            "job_context": {"phase": "activation"},
+        }
+        try:
+            result = run_fn(**context)
+        except Exception as exc:  # pragma: no cover - defensive
+            diagnostics.append(
+                {
+                    "level": "error",
+                    "code": "activation.hook.exception",
+                    "message": str(exc),
+                    "path": f"{hook.path}:run",
+                }
+            )
+            failed = True
+            continue
+
+        if isinstance(result, dict) and result:
+            annotation = {
+                "stage": "on_activate",
+                "hook": hook.path,
+                "annotated_at": datetime.now(timezone.utc).isoformat(),
+            }
+            annotation.update(result)
+            annotations.append(annotation)
+
+    return annotations, diagnostics, failed
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    config_dir = Path(args.config_dir).resolve()
+    manifest_path = Path(args.manifest_path).resolve()
+    output_path = Path(args.output).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if str(config_dir) not in sys.path:
+        sys.path.insert(0, str(config_dir))
+
+    manifest = _load_manifest(manifest_path)
+    annotations, diagnostics, failed = _run_hooks(config_dir, manifest)
+    payload = {"annotations": annotations, "diagnostics": diagnostics}
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/backend/app/features/configs/exceptions.py
+++ b/backend/app/features/configs/exceptions.py
@@ -63,8 +63,17 @@ class ConfigDraftFileTypeError(ConfigError):
         self.path = path
 
 
+class ConfigActivationError(ConfigError):
+    """Raised when a config version cannot be activated."""
+
+    def __init__(self, message: str, *, diagnostics: Sequence[object] | None = None) -> None:
+        super().__init__(message)
+        self.diagnostics = list(diagnostics or [])
+
+
 __all__ = [
     "ConfigError",
+    "ConfigActivationError",
     "ConfigDraftConflictError",
     "ConfigDraftFileTypeError",
     "ConfigDraftNotFoundError",

--- a/backend/app/features/configs/schemas.py
+++ b/backend/app/features/configs/schemas.py
@@ -6,6 +6,24 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class ConfigActivationMetadata(BaseModel):
+    """Metadata describing activation environment state."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    status: str
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    error: str | None = None
+    venv_path: str | None = None
+    python_executable: str | None = None
+    packages_uri: str | None = None
+    install_log_uri: str | None = None
+    hooks_uri: str | None = None
+    diagnostics: list[dict[str, Any]] = Field(default_factory=list)
+    annotations: list[dict[str, Any]] = Field(default_factory=list)
+
+
 class ConfigVersionRecord(BaseModel):
     """Serializable representation of a config version."""
 
@@ -22,6 +40,7 @@ class ConfigVersionRecord(BaseModel):
     created_at: datetime
     updated_at: datetime
     deleted_at: datetime | None = None
+    activation: ConfigActivationMetadata | None = None
 
 
 class ConfigSummary(BaseModel):
@@ -120,6 +139,7 @@ __all__ = [
     "ConfigDraftCreateRequest",
     "ConfigDraftPublishRequest",
     "ConfigDraftRecord",
+    "ConfigActivationMetadata",
     "ConfigFileContent",
     "ConfigFileUpdate",
     "ConfigPackageEntry",

--- a/backend/app/features/configs/storage.py
+++ b/backend/app/features/configs/storage.py
@@ -37,6 +37,7 @@ class ConfigStorage:
 
     _DRAFTS_DIRNAME = "drafts"
     _PACKAGE_SUBDIR = "package"
+    _ACTIVATION_SUBDIR = "activation"
     _METADATA_FILENAME = "metadata.json"
 
     def __init__(self, settings: Settings) -> None:
@@ -50,6 +51,9 @@ class ConfigStorage:
 
     def version_dir(self, config_id: str, sequence: int) -> Path:
         return self._root / config_id / f"{sequence:04d}"
+
+    def activation_dir(self, config_id: str, sequence: int) -> Path:
+        return self.version_dir(config_id, sequence) / self._ACTIVATION_SUBDIR
 
     def draft_dir(self, config_id: str, draft_id: str) -> Path:
         return self._drafts_root(config_id) / draft_id

--- a/backend/app/features/jobs/constants.py
+++ b/backend/app/features/jobs/constants.py
@@ -1,0 +1,8 @@
+"""Constants shared across the jobs feature."""
+
+SAFE_MODE_DISABLED_MESSAGE = (
+    "ADE_SAFE_MODE is enabled. Job execution is temporarily disabled so you can revert config changes and restart without safe mode."
+)
+
+
+__all__ = ["SAFE_MODE_DISABLED_MESSAGE"]

--- a/backend/app/features/jobs/dependencies.py
+++ b/backend/app/features/jobs/dependencies.py
@@ -2,22 +2,28 @@
 
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.shared.core.config import Settings, get_app_settings
 from backend.app.shared.db.session import get_session
 
+from .manager import JobQueueManager
 from .service import JobsService
+
+
+def _get_job_queue(request: Request) -> JobQueueManager | None:
+    return getattr(request.app.state, "job_queue", None)
 
 
 async def get_jobs_service(
     session: Annotated[AsyncSession, Depends(get_session)],
     settings: Annotated[Settings, Depends(get_app_settings)],
+    queue: Annotated[JobQueueManager | None, Depends(_get_job_queue)],
 ) -> JobsService:
     """Construct a request-scoped ``JobsService``."""
 
-    return JobsService(session=session, settings=settings)
+    return JobsService(session=session, settings=settings, queue=queue)
 
 
 __all__ = ["get_jobs_service"]

--- a/backend/app/features/jobs/exceptions.py
+++ b/backend/app/features/jobs/exceptions.py
@@ -12,4 +12,28 @@ class JobSubmissionError(Exception):
         super().__init__(message)
 
 
-__all__ = ["JobNotFoundError", "JobSubmissionError"]
+class JobQueueFullError(Exception):
+    def __init__(
+        self,
+        *,
+        max_size: int,
+        queue_size: int,
+        max_concurrency: int,
+    ) -> None:
+        super().__init__(f"Job queue is full (max {max_size} items)")
+        self.max_size = max_size
+        self.queue_size = queue_size
+        self.max_concurrency = max_concurrency
+
+
+class JobQueueUnavailableError(Exception):
+    def __init__(self) -> None:
+        super().__init__("Job queue is not available")
+
+
+__all__ = [
+    "JobNotFoundError",
+    "JobQueueFullError",
+    "JobQueueUnavailableError",
+    "JobSubmissionError",
+]

--- a/backend/app/features/jobs/manager.py
+++ b/backend/app/features/jobs/manager.py
@@ -1,0 +1,451 @@
+"""Asynchronous job queue manager."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from contextlib import suppress
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from backend.app.features.configs.activation_env import ActivationMetadataStore
+from backend.app.features.configs.models import ConfigVersion
+from backend.app.features.configs.repository import ConfigsRepository
+from backend.app.features.configs.spec import ManifestLoader, ManifestV1
+from backend.app.features.configs.storage import ConfigStorage
+from backend.app.features.documents.repository import DocumentsRepository
+from backend.app.features.documents.storage import DocumentStorage
+from backend.app.shared.core.config import Settings
+from backend.app.shared.core.time import utc_now
+
+from .constants import SAFE_MODE_DISABLED_MESSAGE
+from .exceptions import JobQueueFullError
+from .models import Job, JobStatus
+from .orchestrator import JobOrchestrator, RunResult
+from .repository import JobsRepository
+from .storage import JobStoragePaths, JobsStorage
+from .types import ResolvedInput
+
+logger = logging.getLogger(__name__)
+
+
+class QueueReservation:
+    """In-memory reservation for queue capacity."""
+
+    __slots__ = ("_manager", "_active")
+
+    def __init__(self, manager: "JobQueueManager") -> None:
+        self._manager = manager
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    async def commit(self, job_id: str, *, attempt: int) -> None:
+        """Place ``job_id`` on the queue using this reservation."""
+
+        if not self._active:
+            raise RuntimeError("Reservation has already been consumed")
+        await self._manager._commit_reservation(job_id, attempt=attempt)
+        self._active = False
+
+    async def release(self) -> None:
+        if not self._active:
+            return
+        await self._manager._release_reservation()
+        self._active = False
+
+
+class JobQueueManager:
+    """Bounded in-memory queue with async workers executing jobs."""
+
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        if settings.storage_documents_dir is None:
+            raise RuntimeError("Document storage directory is not configured")
+        self._settings = settings
+        self._session_factory = session_factory
+        self._queue: asyncio.Queue[str | None] = asyncio.Queue(maxsize=settings.queue_max_size)
+        self._workers: list[asyncio.Task[None]] = []
+        self._running = False
+        self._heartbeat_interval = settings.queue_heartbeat_interval
+        self._stale_after = settings.queue_stale_after
+        self._inflight: set[str] = set()
+        self._reservation_lock = asyncio.Lock()
+        self._reserved_slots = 0
+        self._storage = JobsStorage(settings)
+        self._document_storage = DocumentStorage(settings.storage_documents_dir)
+        self._manifest_loader = ManifestLoader()
+        self._config_storage = ConfigStorage(settings)
+        self._activation_store = ActivationMetadataStore(self._config_storage)
+        self._orchestrator = JobOrchestrator(
+            self._storage,
+            settings=settings,
+            safe_mode_message=SAFE_MODE_DISABLED_MESSAGE,
+            activation_store=self._activation_store,
+        )
+
+    @property
+    def max_concurrency(self) -> int:
+        return self._settings.queue_max_concurrency
+
+    @property
+    def max_size(self) -> int:
+        return self._settings.queue_max_size
+
+    def size(self) -> int:
+        return self._queue.qsize()
+
+    def metrics(self) -> dict[str, int]:
+        return {
+            "queue_size": self.size(),
+            "max_size": self.max_size,
+            "max_concurrency": self.max_concurrency,
+        }
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        for index in range(self._settings.queue_max_concurrency):
+            task = asyncio.create_task(self._worker_loop(index + 1), name=f"job-worker-{index+1}")
+            self._workers.append(task)
+        await self.rehydrate()
+
+    async def stop(self) -> None:
+        if not self._running:
+            return
+        self._running = False
+        for _ in self._workers:
+            await self._queue.put(None)
+        await asyncio.gather(*self._workers, return_exceptions=True)
+        self._workers.clear()
+
+    async def try_reserve(self) -> QueueReservation:
+        """Reserve a slot in the queue without enqueuing a job."""
+
+        async with self._reservation_lock:
+            if self.size() + self._reserved_slots >= self._settings.queue_max_size:
+                raise JobQueueFullError(
+                    max_size=self._settings.queue_max_size,
+                    queue_size=self.size(),
+                    max_concurrency=self._settings.queue_max_concurrency,
+                )
+            self._reserved_slots += 1
+        return QueueReservation(self)
+
+    async def enqueue(
+        self,
+        job_id: str,
+        *,
+        attempt: int,
+        reservation: QueueReservation | None = None,
+        force: bool = False,
+    ) -> None:
+        if job_id in self._inflight:
+            return
+
+        if reservation is not None:
+            try:
+                await reservation.commit(job_id, attempt=attempt)
+            except Exception:
+                await reservation.release()
+                raise
+        elif force:
+            await self._put_job(job_id)
+            self._record_enqueue_event(job_id=job_id, attempt=attempt)
+        else:
+            # No reservation and not forced indicates misuse.
+            raise RuntimeError("Queue reservation required for enqueue")
+
+    async def _commit_reservation(self, job_id: str, *, attempt: int) -> None:
+        async with self._reservation_lock:
+            if self._reserved_slots <= 0:
+                raise RuntimeError("No reservation available to commit")
+            self._reserved_slots -= 1
+            try:
+                self._put_job_nowait(job_id)
+            except asyncio.QueueFull as exc:  # pragma: no cover - defensive
+                self._reserved_slots += 1
+                raise RuntimeError("Reserved slot unavailable") from exc
+
+        self._record_enqueue_event(job_id=job_id, attempt=attempt)
+
+    async def _release_reservation(self) -> None:
+        async with self._reservation_lock:
+            if self._reserved_slots > 0:
+                self._reserved_slots -= 1
+
+    def _put_job_nowait(self, job_id: str) -> None:
+        self._inflight.add(job_id)
+        self._queue.put_nowait(job_id)
+
+    async def _put_job(self, job_id: str) -> None:
+        self._inflight.add(job_id)
+        await self._queue.put(job_id)
+
+    def _record_enqueue_event(self, *, job_id: str, attempt: int) -> None:
+        logs_path = self._storage.ensure_logs_path(job_id)
+        self._storage.record_event(
+            logs_path,
+            event="enqueue",
+            job_id=job_id,
+            attempt=attempt,
+            state=JobStatus.QUEUED.value,
+            detail=self.metrics(),
+        )
+
+
+    async def rehydrate(self) -> None:
+        async with self._session_factory() as session:
+            jobs_repo = JobsRepository(session)
+            queued = await jobs_repo.list_jobs_by_status(JobStatus.QUEUED)
+            for job in queued:
+                await self.enqueue(job.id, attempt=job.attempt, force=True)
+            running = await jobs_repo.list_jobs_by_status(JobStatus.RUNNING)
+            cutoff = utc_now() - self._stale_after
+            for job in running:
+                if job.last_heartbeat and job.last_heartbeat >= cutoff:
+                    continue
+                await jobs_repo.requeue(job)
+                await session.commit()
+                await self.enqueue(job.id, attempt=job.attempt, force=True)
+                logs_path = self._storage.ensure_logs_path(job.id)
+                self._storage.record_event(
+                    logs_path,
+                    event="retry",
+                    job_id=job.id,
+                    attempt=job.attempt,
+                    state=JobStatus.QUEUED.value,
+                )
+
+    async def _worker_loop(self, worker_id: int) -> None:
+        logger.info("job worker %s started", worker_id)
+        try:
+            while True:
+                job_id = await self._queue.get()
+                if job_id is None:
+                    self._queue.task_done()
+                    break
+                self._inflight.discard(job_id)
+                try:
+                    await self._process_job(job_id)
+                except Exception:  # pragma: no cover - defensive logging
+                    logger.exception("Unhandled error while processing job %s", job_id)
+                finally:
+                    self._queue.task_done()
+        finally:
+            logger.info("job worker %s stopped", worker_id)
+
+    async def _process_job(self, job_id: str) -> None:
+        async with self._session_factory() as session:
+            job = await self._lock_job(session, job_id)
+            if job is None:
+                return
+            config_version = await self._load_config(session, job)
+            if config_version is None:
+                await self._mark_failed(
+                    session,
+                    job,
+                    error_message="Config version is not available",
+                )
+                return
+            manifest = self._load_manifest(config_version)
+            resolved_inputs = await self._resolve_inputs(session, job)
+            trace_id = job.trace_id or job.id
+            now = utc_now()
+            repo = JobsRepository(session)
+            await repo.update_status(
+                job,
+                status=JobStatus.RUNNING,
+                started_at=now,
+                last_heartbeat=now,
+            )
+            await session.commit()
+            logs_path = self._storage.ensure_logs_path(job_id)
+            self._storage.record_event(
+                logs_path,
+                event="start",
+                job_id=job_id,
+                attempt=job.attempt,
+                state=JobStatus.RUNNING.value,
+            )
+
+        heartbeat_stop = asyncio.Event()
+        heartbeat_task = asyncio.create_task(self._heartbeat(job_id, heartbeat_stop))
+        prepared_paths = self._storage.prepare(job_id)
+        try:
+            start_time = time.monotonic()
+            run_result, paths = await self._orchestrator.run(
+                job_id=job_id,
+                attempt=job.attempt,
+                config_version=config_version,
+                manifest=manifest,
+                trace_id=trace_id,
+                input_files=resolved_inputs,
+                timeout_seconds=max(1.0, manifest.engine.defaults.timeout_ms / 1000),
+                paths=prepared_paths,
+            )
+            elapsed_ms = int((time.monotonic() - start_time) * 1000)
+            await self._complete_job(
+                job_id=job_id,
+                attempt=job.attempt,
+                run_result=run_result,
+                paths=paths,
+                elapsed_ms=elapsed_ms,
+            )
+        finally:
+            heartbeat_stop.set()
+            with suppress(Exception):
+                await heartbeat_task
+            self._storage.cleanup_inputs(prepared_paths)
+
+    async def _complete_job(
+        self,
+        *,
+        job_id: str,
+        attempt: int,
+        run_result: RunResult,
+        paths: JobStoragePaths,
+        elapsed_ms: int,
+    ) -> None:
+        async with self._session_factory() as session:
+            repo = JobsRepository(session)
+            job = await repo.load_job_by_id(job_id)
+            if job is None:
+                return
+            if run_result.status == "succeeded" and run_result.artifact_path and run_result.output_path:
+                await repo.update_status(
+                    job,
+                    status=JobStatus.SUCCEEDED,
+                    completed_at=utc_now(),
+                    artifact_uri=str(run_result.artifact_path),
+                    output_uri=str(run_result.output_path),
+                )
+            else:
+                error_message = run_result.error_message
+                if not error_message and run_result.diagnostics:
+                    first = run_result.diagnostics[0]
+                    message = first.get("message")
+                    code = first.get("code")
+                    error_message = f"{code}: {message}" if code and message else message or code
+                if run_result.timed_out:
+                    error_message = error_message or "Worker timed out"
+                await repo.update_status(
+                    job,
+                    status=JobStatus.FAILED,
+                    completed_at=utc_now(),
+                    error_message=error_message,
+                )
+            await repo.record_paths(
+                job,
+                logs_uri=str(paths.logs_path),
+                run_request_uri=str(paths.request_path),
+            )
+            await session.commit()
+            state = job.status
+            detail: dict[str, str] | None = None
+            if job.error_message:
+                detail = {"error": job.error_message}
+            self._storage.record_event(
+                paths.logs_path,
+                event="exit",
+                job_id=job_id,
+                attempt=attempt,
+                state=state,
+                duration_ms=elapsed_ms,
+                detail=detail,
+            )
+            if state == JobStatus.FAILED.value:
+                self._storage.record_event(
+                    paths.logs_path,
+                    event="error",
+                    job_id=job_id,
+                    attempt=attempt,
+                    state=state,
+                    detail=detail,
+                )
+
+    async def _lock_job(self, session: AsyncSession, job_id: str) -> Job | None:
+        repo = JobsRepository(session)
+        job = await repo.load_job_by_id(job_id)
+        if job is None:
+            return None
+        if JobStatus(job.status) != JobStatus.QUEUED:
+            return None
+        # Single-process invariant: the queue manager is the sole mutator of queued jobs,
+        # so we rely on that guarantee rather than explicit row-level locks.
+        return job
+
+    async def _load_config(self, session: AsyncSession, job: Job) -> ConfigVersion | None:
+        if job.config_version is not None:
+            return job.config_version
+        configs = ConfigsRepository(session)
+        return await configs.get_version_by_id(job.config_version_id)
+
+    def _load_manifest(self, version: ConfigVersion) -> ManifestV1:
+        return self._manifest_loader.load(version.manifest)
+
+    async def _resolve_inputs(self, session: AsyncSession, job: Job) -> list[ResolvedInput]:
+        documents = DocumentsRepository(session)
+        resolved: list[ResolvedInput] = []
+        for document_id in job.input_documents:
+            document = await documents.get_document(
+                workspace_id=job.workspace_id,
+                document_id=document_id,
+            )
+            if document is None:
+                raise RuntimeError(f"Document {document_id} is not available")
+            source_path = self._document_storage.path_for(document.stored_uri)
+            if not source_path.exists():
+                raise RuntimeError(f"Document {document_id} content is missing from storage")
+            filename = document.original_filename or f"{document_id}.bin"
+            resolved.append(
+                ResolvedInput(
+                    document_id=document.document_id,
+                    source_path=source_path,
+                    filename=filename,
+                    sha256=document.sha256,
+                )
+            )
+        return resolved
+
+    async def _heartbeat(self, job_id: str, stop_event: asyncio.Event) -> None:
+        interval = max(1.0, self._heartbeat_interval.total_seconds())
+        while True:
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval)
+                break
+            except asyncio.TimeoutError:
+                async with self._session_factory() as session:
+                    repo = JobsRepository(session)
+                    job = await repo.load_job_by_id(job_id)
+                    if job is None:
+                        return
+                    await repo.set_last_heartbeat(job, heartbeat_at=utc_now())
+                    await session.commit()
+
+    async def _mark_failed(
+        self,
+        session: AsyncSession,
+        job: Job,
+        *,
+        error_message: str,
+    ) -> None:
+        repo = JobsRepository(session)
+        await repo.update_status(
+            job,
+            status=JobStatus.FAILED,
+            completed_at=utc_now(),
+            error_message=error_message,
+        )
+        await session.commit()
+
+
+__all__ = ["JobQueueManager", "QueueReservation"]

--- a/backend/app/features/jobs/models.py
+++ b/backend/app/features/jobs/models.py
@@ -1,10 +1,22 @@
 """SQLAlchemy models and enums for job execution."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import DateTime, Enum as SQLEnum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    Enum as SQLEnum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship, foreign
 
 from backend.app.features.configs.models import Config, ConfigVersion
 from backend.app.features.users.models import User
@@ -17,7 +29,6 @@ class JobStatus(str, Enum):
     RUNNING = "running"
     SUCCEEDED = "succeeded"
     FAILED = "failed"
-    CANCELLED = "cancelled"
 
 
 class Job(ULIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -73,6 +84,22 @@ class Job(ULIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     attempt: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    retry_of_job_id: Mapped[str | None] = mapped_column(String(26), nullable=True)
+    retry_of: Mapped[Job | None] = relationship(
+        "Job",
+        remote_side="Job.id",
+        lazy="selectin",
+        primaryjoin="Job.retry_of_job_id == foreign(Job.id)",
+    )
+    last_heartbeat: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    input_documents: Mapped[list[str]] = mapped_column(
+        JSON,
+        nullable=False,
+        default=list,
+    )
 
     artifact_uri: Mapped[str | None] = mapped_column(String(512), nullable=True)
     output_uri: Mapped[str | None] = mapped_column(String(512), nullable=True)
@@ -85,7 +112,17 @@ class Job(ULIDPrimaryKeyMixin, TimestampMixin, Base):
         Index("jobs_workspace_idx", "workspace_id", "created_at"),
         Index("jobs_config_version_idx", "config_version_id"),
         Index("jobs_input_idx", "workspace_id", "config_version_id", "input_hash"),
-        UniqueConstraint("workspace_id", "config_version_id", "input_hash", name="jobs_idempotency_key"),
+        Index(
+            "jobs_input_unique_idx",
+            "workspace_id",
+            "config_version_id",
+            "input_hash",
+            unique=True,
+            sqlite_where=text("retry_of_job_id IS NULL"),
+            postgresql_where=text("retry_of_job_id IS NULL"),
+        ),
+        Index("jobs_status_queued_idx", "status", "queued_at"),
+        Index("jobs_retry_of_idx", "retry_of_job_id"),
     )
 
 

--- a/backend/app/features/jobs/orchestrator.py
+++ b/backend/app/features/jobs/orchestrator.py
@@ -12,10 +12,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
+from backend.app.features.configs.activation_env import (
+    ActivationMetadata,
+    ActivationMetadataStore,
+)
 from backend.app.features.configs.spec import ManifestV1
 from backend.app.shared.core.config import Settings
 
 from ..configs.models import ConfigVersion
+from .models import JobStatus
 from .storage import JobStoragePaths, JobsStorage
 from .types import ResolvedInput
 
@@ -40,20 +45,30 @@ class RunResult:
 class JobOrchestrator:
     """Launch jobs in an isolated Python subprocess using a JSON protocol."""
 
-    def __init__(self, storage: JobsStorage, *, settings: Settings, safe_mode_message: str) -> None:
+    def __init__(
+        self,
+        storage: JobsStorage,
+        *,
+        settings: Settings,
+        safe_mode_message: str,
+        activation_store: ActivationMetadataStore,
+    ) -> None:
         self._storage = storage
         self._settings = settings
         self._safe_mode_message = safe_mode_message
+        self._activation_store = activation_store
 
     async def run(
         self,
         *,
         job_id: str,
+        attempt: int,
         config_version: ConfigVersion,
         manifest: ManifestV1,
         trace_id: str,
         input_files: Sequence[ResolvedInput],
         timeout_seconds: float,
+        paths: JobStoragePaths | None = None,
     ) -> tuple[RunResult, JobStoragePaths]:
         if self._settings.safe_mode:
             logger.warning(
@@ -66,9 +81,17 @@ class JobOrchestrator:
             )
             raise RuntimeError(self._safe_mode_message)
 
-        paths: JobStoragePaths = self._storage.prepare(job_id)
+        owns_paths = paths is None
+        paths = paths or self._storage.prepare(job_id)
         self._storage.copy_config(Path(config_version.package_path), paths.config_dir)
         staged_inputs = self._storage.stage_inputs(paths.inputs_dir, input_files)
+        activation = self._activation_store.load(config_id=config_version.config_id, version=config_version)
+        python_executable = (
+            activation.python_executable
+            if activation and activation.ready and activation.python_executable is not None
+            else Path(sys.executable)
+        )
+
         request_payload = {
             "schema": "ade.run_request/v1",
             "job_id": job_id,
@@ -85,15 +108,21 @@ class JobOrchestrator:
                 for descriptor, path in zip(input_files, staged_inputs)
             ],
             "work_dir": str(paths.job_dir),
+            "python_executable": str(python_executable),
         }
         self._storage.write_run_request(paths.request_path, request_payload)
 
-        env = self._build_env(paths=paths, manifest=manifest, trace_id=trace_id)
+        env = self._build_env(
+            paths=paths,
+            manifest=manifest,
+            trace_id=trace_id,
+            activation=activation,
+        )
         request_bytes = json.dumps(request_payload, separators=(",", ":")).encode("utf-8")
 
         start = time.monotonic()
         process = await asyncio.create_subprocess_exec(
-            sys.executable,
+            str(python_executable),
             "-I",
             "-B",
             str(WORKER_SCRIPT),
@@ -103,92 +132,108 @@ class JobOrchestrator:
             cwd=str(paths.job_dir),
             env=env,
         )
-        self._storage.append_log(
-            paths.logs_path,
-            {
-                "event": "worker.spawn",
-                "trace_id": trace_id,
-                "pid": process.pid,
-                "timeout_seconds": timeout_seconds,
-            },
-        )
-
         timed_out = False
         try:
-            stdout, stderr = await asyncio.wait_for(process.communicate(request_bytes), timeout_seconds)
-        except asyncio.TimeoutError:
-            timed_out = True
-            self._storage.append_log(
+            self._storage.record_event(
                 paths.logs_path,
-                {"event": "worker.timeout", "trace_id": trace_id},
-            )
-            process.terminate()
-            try:
-                await asyncio.wait_for(process.wait(), 5)
-            except asyncio.TimeoutError:
-                process.kill()
-                await process.wait()
-            stdout, stderr = b"", b""
-
-        elapsed_ms = int((time.monotonic() - start) * 1000)
-        exit_code = process.returncode if process.returncode is not None else -1
-
-        if stderr:
-            self._storage.append_log(
-                paths.logs_path,
-                {
-                    "event": "worker.stderr",
+                event="worker.spawn",
+                job_id=job_id,
+                attempt=attempt,
+                state=JobStatus.RUNNING.value,
+                detail={
                     "trace_id": trace_id,
-                    "payload": stderr.decode("utf-8", errors="replace")[:4000],
+                    "pid": process.pid,
+                    "timeout_seconds": timeout_seconds,
                 },
             )
 
-        result_payload: dict[str, Any] | None = None
-        error_message: str | None = None
-        diagnostics: list[dict[str, Any]] = []
-
-        if stdout:
             try:
-                result_payload = json.loads(stdout.decode("utf-8"))
-            except json.JSONDecodeError as exc:
-                error_message = f"Worker produced invalid JSON: {exc}"
-        elif not timed_out:
-            error_message = "Worker produced no output"
+                stdout, stderr = await asyncio.wait_for(process.communicate(request_bytes), timeout_seconds)
+            except asyncio.TimeoutError:
+                timed_out = True
+                self._storage.record_event(
+                    paths.logs_path,
+                    event="worker.timeout",
+                    job_id=job_id,
+                    attempt=attempt,
+                    state=JobStatus.RUNNING.value,
+                    detail={"trace_id": trace_id},
+                )
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), 5)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
+                stdout, stderr = b"", b""
 
-        if result_payload is not None:
-            diagnostics = list(result_payload.get("diagnostics", []))
-            error_message = result_payload.get("error_message") or error_message
-            status = str(result_payload.get("status", "failed"))
-            artifact_path = result_payload.get("artifact_path")
-            output_path = result_payload.get("output_path")
-        else:
-            status = "failed"
-            artifact_path = None
-            output_path = None
+            elapsed_ms = int((time.monotonic() - start) * 1000)
+            exit_code = process.returncode if process.returncode is not None else -1
 
-        self._storage.append_log(
-            paths.logs_path,
-            {
-                "event": "worker.exit",
-                "trace_id": trace_id,
-                "exit_code": exit_code,
-                "elapsed_ms": elapsed_ms,
-                "timed_out": timed_out,
-                "status": status,
-            },
-        )
+            if stderr:
+                self._storage.record_event(
+                    paths.logs_path,
+                    event="worker.stderr",
+                    job_id=job_id,
+                    attempt=attempt,
+                    state=JobStatus.RUNNING.value,
+                    detail={
+                        "trace_id": trace_id,
+                        "payload": stderr.decode("utf-8", errors="replace")[:4000],
+                    },
+                )
 
-        run_result = RunResult(
-            status=status,
-            artifact_path=Path(artifact_path).resolve() if artifact_path else None,
-            output_path=Path(output_path).resolve() if output_path else None,
-            diagnostics=diagnostics,
-            error_message=error_message,
-            timed_out=timed_out,
-            exit_code=exit_code,
-            elapsed_ms=elapsed_ms,
-        )
-        return run_result, paths
+            result_payload: dict[str, Any] | None = None
+            error_message: str | None = None
+            diagnostics: list[dict[str, Any]] = []
+
+            if stdout:
+                try:
+                    result_payload = json.loads(stdout.decode("utf-8"))
+                except json.JSONDecodeError as exc:
+                    error_message = f"Worker produced invalid JSON: {exc}"
+            elif not timed_out:
+                error_message = "Worker produced no output"
+
+            if result_payload is not None:
+                diagnostics = list(result_payload.get("diagnostics", []))
+                error_message = result_payload.get("error_message") or error_message
+                status = str(result_payload.get("status", "failed"))
+                artifact_path = result_payload.get("artifact_path")
+                output_path = result_payload.get("output_path")
+            else:
+                status = JobStatus.FAILED.value
+                artifact_path = None
+                output_path = None
+
+            self._storage.record_event(
+                paths.logs_path,
+                event="worker.exit",
+                job_id=job_id,
+                attempt=attempt,
+                state=status,
+                duration_ms=elapsed_ms,
+                detail={
+                    "trace_id": trace_id,
+                    "exit_code": exit_code,
+                    "timed_out": timed_out,
+                },
+            )
+
+            run_result = RunResult(
+                status=status,
+                artifact_path=Path(artifact_path).resolve() if artifact_path else None,
+                output_path=Path(output_path).resolve() if output_path else None,
+                diagnostics=diagnostics,
+                error_message=error_message,
+                timed_out=timed_out,
+                exit_code=exit_code,
+                elapsed_ms=elapsed_ms,
+            )
+            return run_result, paths
+        finally:
+            if owns_paths:
+                self._storage.cleanup_inputs(paths)
 
     def _build_env(
         self,
@@ -196,22 +241,20 @@ class JobOrchestrator:
         paths: JobStoragePaths,
         manifest: ManifestV1,
         trace_id: str,
+        activation: ActivationMetadata | None,
     ) -> dict[str, str]:
         default_cpu_seconds = max(1, manifest.engine.defaults.timeout_ms // 1000)
         cpu_override = os.environ.get("ADE_WORKER_CPU_SECONDS")
         mem_override = os.environ.get("ADE_WORKER_MEM_MB")
 
+        pythonpath_parts = [str(paths.config_dir.resolve())]
+        vendor_dir = (paths.config_dir / "vendor").resolve()
+        if not activation or not activation.ready:
+            pythonpath_parts.insert(0, str(vendor_dir))
+
         env = {
             "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-            "PYTHONPATH": os.pathsep.join(
-                filter(
-                    None,
-                    [
-                        str((paths.config_dir / "vendor").resolve()),
-                        str(paths.config_dir.resolve()),
-                    ],
-                )
-            ),
+            "PYTHONPATH": os.pathsep.join(filter(None, pythonpath_parts)),
             "ADE_CONFIG_DIR": str(paths.config_dir),
             "ADE_ARTIFACT_PATH": str(paths.artifact_path),
             "ADE_OUTPUT_PATH": str(paths.output_path),

--- a/backend/app/features/jobs/repository.py
+++ b/backend/app/features/jobs/repository.py
@@ -1,6 +1,7 @@
 """Database helpers for job persistence."""
 
 from datetime import datetime
+from typing import Sequence
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,6 +27,9 @@ class JobsRepository:
         actor_id: str | None,
         input_hash: str,
         trace_id: str,
+        document_ids: Sequence[str],
+        retry_of_job_id: str | None = None,
+        attempt: int = 1,
     ) -> Job:
         job = Job(
             workspace_id=workspace_id,
@@ -36,6 +40,9 @@ class JobsRepository:
             queued_at=utc_now(),
             input_hash=input_hash,
             trace_id=trace_id,
+            retry_of_job_id=retry_of_job_id,
+            attempt=attempt,
+            input_documents=list(document_ids),
         )
         self._session.add(job)
         await self._session.flush()
@@ -61,12 +68,15 @@ class JobsRepository:
         error_message: str | None = None,
         artifact_uri: str | None = None,
         output_uri: str | None = None,
+        last_heartbeat: datetime | None = None,
     ) -> Job:
         job.status = status.value
         if started_at is not None:
             job.started_at = started_at
         if completed_at is not None:
             job.completed_at = completed_at
+        if last_heartbeat is not None:
+            job.last_heartbeat = last_heartbeat
         job.error_message = error_message
         job.artifact_uri = artifact_uri or job.artifact_uri
         job.output_uri = output_uri or job.output_uri
@@ -102,7 +112,9 @@ class JobsRepository:
                 Job.workspace_id == workspace_id,
                 Job.config_version_id == config_version_id,
                 Job.input_hash == input_hash,
+                Job.retry_of_job_id.is_(None),
             )
+            .order_by(Job.created_at.desc())
             .options(selectinload(Job.config_version))
         )
         result = await self._session.execute(stmt)
@@ -121,9 +133,39 @@ class JobsRepository:
         job.run_request_uri = None
         job.attempt = job.attempt + 1
         job.trace_id = trace_id
+        job.last_heartbeat = None
         await self._session.flush()
         await self._session.refresh(job)
         return job
+
+    async def requeue(self, job: Job) -> Job:
+        job.status = JobStatus.QUEUED.value
+        job.queued_at = utc_now()
+        job.started_at = None
+        job.completed_at = None
+        job.error_message = None
+        job.logs_uri = None
+        job.run_request_uri = None
+        job.last_heartbeat = None
+        await self._session.flush()
+        await self._session.refresh(job)
+        return job
+
+    async def set_last_heartbeat(self, job: Job, *, heartbeat_at: datetime) -> Job:
+        job.last_heartbeat = heartbeat_at
+        await self._session.flush()
+        await self._session.refresh(job)
+        return job
+
+    async def list_jobs_by_status(self, status: JobStatus) -> list[Job]:
+        stmt = select(Job).where(Job.status == status.value).options(selectinload(Job.config_version))
+        result = await self._session.execute(stmt)
+        return list(result.scalars())
+
+    async def load_job_by_id(self, job_id: str) -> Job | None:
+        stmt = select(Job).where(Job.id == job_id).options(selectinload(Job.config_version))
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
 
 
 __all__ = ["JobsRepository"]

--- a/backend/app/features/jobs/schemas.py
+++ b/backend/app/features/jobs/schemas.py
@@ -1,9 +1,12 @@
 """Pydantic models for job API payloads."""
 
 from datetime import datetime
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from ..configs.schemas import ConfigActivationMetadata
 
 from .models import JobStatus
 
@@ -57,6 +60,7 @@ class JobConfigVersion(BaseModel):
     config_version_id: str
     config_id: str
     label: str | None = None
+    activation: ConfigActivationMetadata | None = None
 
 
 class JobRecord(BaseModel):
@@ -76,8 +80,10 @@ class JobRecord(BaseModel):
     queued_at: datetime
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    last_heartbeat: datetime | None = None
     error_message: str | None = None
     attempt: int
+    retry_of_job_id: str | None = None
     config_version: JobConfigVersion
 
 

--- a/backend/app/shared/core/config.py
+++ b/backend/app/shared/core/config.py
@@ -178,6 +178,7 @@ class Settings(BaseSettings):
     storage_data_dir: Path = Field(default=DEFAULT_DATA_DIR)
     storage_documents_dir: Path | None = None
     storage_configs_dir: Path | None = None
+    activation_envs_dir: Path | None = None
     storage_upload_max_bytes: int = Field(25 * 1024 * 1024, gt=0)
     storage_document_retention_period: timedelta = Field(default=timedelta(days=30))
     secret_key: SecretStr = Field(
@@ -190,6 +191,18 @@ class Settings(BaseSettings):
     database_pool_size: int = Field(5, ge=1)
     database_max_overflow: int = Field(10, ge=0)
     database_pool_timeout: int = Field(30, gt=0)
+
+    # Queue ----------------------------------------------------------------------
+    queue_enabled: bool = True
+    queue_max_concurrency: int = Field(2, ge=1)
+    queue_max_size: int = Field(64, ge=1)
+    queue_stale_after: timedelta = Field(default=timedelta(seconds=60))
+    queue_heartbeat_interval: timedelta = Field(default=timedelta(seconds=5))
+
+    @field_validator("queue_stale_after", "queue_heartbeat_interval", mode="before")
+    @classmethod
+    def _coerce_queue_durations(cls, value: Any, info: ValidationInfo) -> timedelta:
+        return _parse_duration(value, field_name=info.field_name)
 
     # JWT ------------------------------------------------------------------------
     jwt_secret: SecretStr = Field(default=SecretStr("development-secret"))
@@ -453,6 +466,12 @@ class Settings(BaseSettings):
             configs_dir = data_dir / DEFAULT_CONFIGS_SUBDIR
         configs_dir = _normalise_path(configs_dir, base=data_dir)
         self.storage_configs_dir = configs_dir
+
+        activation_dir = self.activation_envs_dir
+        if activation_dir is None:
+            activation_dir = data_dir / "venvs"
+        activation_dir = _normalise_path(activation_dir, base=data_dir)
+        self.activation_envs_dir = activation_dir
 
         if not self.database_dsn:
             sqlite_path = (data_dir / DEFAULT_DATABASE_SUBDIR / DEFAULT_DATABASE_FILENAME).resolve()

--- a/backend/app/shared/db/migrations/versions/0002_job_queue_metadata.py
+++ b/backend/app/shared/db/migrations/versions/0002_job_queue_metadata.py
@@ -1,0 +1,49 @@
+"""Add job queue metadata columns and indexes."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0002_job_queue_metadata"
+down_revision = "0001_initial_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("jobs") as batch:
+        batch.add_column(sa.Column("retry_of_job_id", sa.String(length=26), nullable=True))
+        batch.add_column(sa.Column("last_heartbeat", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(
+            sa.Column("input_documents", sa.JSON(), nullable=False, server_default=sa.text("'[]'"))
+        )
+        batch.drop_constraint("jobs_idempotency_key", type_="unique")
+        batch.create_index("jobs_status_queued_idx", ["status", "queued_at"], unique=False)
+        batch.create_index("jobs_retry_of_idx", ["retry_of_job_id"], unique=False)
+        batch.create_index(
+            "jobs_input_unique_idx",
+            ["workspace_id", "config_version_id", "input_hash"],
+            unique=True,
+            sqlite_where=sa.text("retry_of_job_id IS NULL"),
+            postgresql_where=sa.text("retry_of_job_id IS NULL"),
+        )
+    op.execute(
+        "UPDATE jobs SET input_documents = '[]' WHERE input_documents IS NULL"
+    )
+    op.execute(
+        "UPDATE jobs SET last_heartbeat = completed_at WHERE completed_at IS NOT NULL"
+    )
+    op.execute(
+        "UPDATE jobs SET last_heartbeat = started_at WHERE last_heartbeat IS NULL AND started_at IS NOT NULL"
+    )
+    op.execute(
+        "UPDATE jobs SET last_heartbeat = queued_at WHERE last_heartbeat IS NULL"
+    )
+    with op.batch_alter_table("jobs") as batch:
+        batch.alter_column("input_documents", server_default=None)
+
+
+def downgrade() -> None:  # pragma: no cover - irreversible migration
+    raise NotImplementedError("Downgrade is not supported for job queue metadata migration.")

--- a/backend/tests/api/jobs/test_jobs_router.py
+++ b/backend/tests/api/jobs/test_jobs_router.py
@@ -1,13 +1,22 @@
+import asyncio
 import io
 import json
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 from zipfile import ZipFile
 
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
 from openpyxl import Workbook
+from sqlalchemy import func, select
 
+from backend.app.features.jobs.models import Job, JobStatus
+from backend.app.features.jobs.repository import JobsRepository
+from backend.app.shared.core.config import get_settings
+from backend.app.shared.core.time import utc_now
+from backend.app.shared.db.session import get_sessionmaker
 from backend.tests.utils import login
 
 pytestmark = pytest.mark.asyncio
@@ -21,6 +30,13 @@ async def _auth(async_client: AsyncClient, identity: dict[str, Any]) -> tuple[di
         password=owner["password"],  # type: ignore[index]
     )
     return {"Authorization": f"Bearer {token}"}, identity["workspace_id"]  # type: ignore[return-value]
+
+
+def _csrf_headers(client: AsyncClient) -> dict[str, str]:
+    settings = get_settings()
+    token = client.cookies.get(settings.session_csrf_cookie_name)
+    assert token, "CSRF cookie missing"
+    return {"X-CSRF-Token": token}
 
 
 def _manifest(title: str, fields: list[str]) -> dict[str, Any]:
@@ -67,19 +83,30 @@ def _manifest(title: str, fields: list[str]) -> dict[str, Any]:
     }
 
 
-def _package(manifest: dict[str, Any], name: str) -> bytes:
+def _package(
+    manifest: dict[str, Any],
+    name: str,
+    *,
+    slow_iterations: int | None = None,
+) -> bytes:
     buffer = io.BytesIO()
     with ZipFile(buffer, "w") as archive:
         archive.writestr("manifest.json", json.dumps(manifest, indent=2))
         archive.writestr("columns/__init__.py", "")
         for field in manifest["columns"]["order"]:
+            slow_body = (
+                f"    for _ in range({slow_iterations}):\n        pass\n"
+                if slow_iterations
+                else ""
+            )
             archive.writestr(
                 f"columns/{field}.py",
                 (
                     "def detect_default(*, header, values_sample, column_index, table, job_context, env):\n"
-                    f"    return {{'scores': {{'{field}': 1.0}}}}\n\n"
-                    "def transform(*, header, values, column_index, table, job_context, env):\n"
-                    "    return {'values': list(values), 'warnings': []}\n"
+                    + slow_body
+                    + f"    return {{'scores': {{'{field}': 1.0}}}}\n\n"
+                    + "def transform(*, header, values, column_index, table, job_context, env):\n"
+                    + "    return {'values': list(values), 'warnings': []}\n"
                 ),
             )
     return buffer.getvalue()
@@ -89,10 +116,12 @@ async def _create_config(
     async_client: AsyncClient,
     headers: dict[str, str],
     workspace_id: str,
-) -> tuple[str, dict[str, Any]]:
+    *,
+    slow_iterations: int | None = None,
+) -> tuple[str, dict[str, Any], str]:
     base = f"/api/v1/workspaces/{workspace_id}/configs"
     manifest = _manifest("Job Config", ["member_id", "name"])
-    package_bytes = _package(manifest, "job-config")
+    package_bytes = _package(manifest, "job-config", slow_iterations=slow_iterations)
     created = await async_client.post(
         base,
         headers=headers,
@@ -106,7 +135,7 @@ async def _create_config(
     created.raise_for_status()
     detail = created.json()
     version = detail["versions"][0]
-    return version["config_version_id"], manifest
+    return version["config_version_id"], manifest, detail["config_id"]
 
 
 async def _upload_document(
@@ -134,9 +163,30 @@ async def _upload_document(
     return response.json()["document_id"]
 
 
+async def _wait_for_job(
+    async_client: AsyncClient,
+    headers: dict[str, str],
+    workspace_id: str,
+    job_id: str,
+    *,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    base = f"/api/v1/workspaces/{workspace_id}/jobs/{job_id}"
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        detail = await async_client.get(base, headers=headers)
+        detail.raise_for_status()
+        payload = detail.json()
+        if payload["status"] in {"succeeded", "failed"}:
+            return payload
+        if asyncio.get_event_loop().time() >= deadline:
+            raise AssertionError(f"Job {job_id} did not complete in time")
+        await asyncio.sleep(0.1)
+
+
 async def test_job_submission_produces_artifacts(async_client: AsyncClient, seed_identity: dict[str, Any]) -> None:
     headers, workspace_id = await _auth(async_client, seed_identity)
-    version_id, manifest = await _create_config(async_client, headers, workspace_id)
+    version_id, manifest, _ = await _create_config(async_client, headers, workspace_id)
 
     base = f"/api/v1/workspaces/{workspace_id}/jobs"
     submitted = await async_client.post(
@@ -144,16 +194,16 @@ async def test_job_submission_produces_artifacts(async_client: AsyncClient, seed
         headers=headers,
         json={"config_version_id": version_id},
     )
-    assert submitted.status_code == 201, submitted.text
+    assert submitted.status_code == 202, submitted.text
     job_payload = submitted.json()
     job_id = job_payload["job_id"]
-    assert job_payload["status"] == "succeeded"
-    assert job_payload["artifact_uri"].endswith("artifact.json")
-    assert job_payload["output_uri"].endswith("normalized.xlsx")
+    assert submitted.headers["Location"].endswith(f"/jobs/{job_id}")
 
-    detail = await async_client.get(f"{base}/{job_id}", headers=headers)
-    detail.raise_for_status()
-    detail_payload = detail.json()
+    detail_payload = await _wait_for_job(async_client, headers, workspace_id, job_id)
+    assert detail_payload["status"] == "succeeded"
+    assert detail_payload["artifact_uri"].endswith("artifact.json")
+    assert detail_payload["output_uri"].endswith("normalized.xlsx")
+
     assert detail_payload["config_version"]["config_version_id"] == version_id
 
     artifact = await async_client.get(f"{base}/{job_id}/artifact", headers=headers)
@@ -170,9 +220,38 @@ async def test_job_submission_produces_artifacts(async_client: AsyncClient, seed
     }
 
 
+async def test_run_request_records_activation_python(async_client: AsyncClient, seed_identity: dict[str, Any]) -> None:
+    headers, workspace_id = await _auth(async_client, seed_identity)
+    version_id, _, config_id = await _create_config(async_client, headers, workspace_id)
+
+    activation_headers = {**headers, **_csrf_headers(async_client)}
+    activate = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configs/{config_id}/versions/{version_id}/activate",
+        headers=activation_headers,
+    )
+    assert activate.status_code == 200, activate.text
+
+    submitted = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/jobs",
+        headers=headers,
+        json={"config_version_id": version_id},
+    )
+    assert submitted.status_code == 202, submitted.text
+    job_id = submitted.json()["job_id"]
+
+    detail_payload = await _wait_for_job(async_client, headers, workspace_id, job_id)
+    activation = detail_payload["config_version"].get("activation")
+    assert activation is not None
+    assert activation["status"] == "succeeded"
+
+    run_request = json.loads(Path(detail_payload["run_request_uri"]).read_text(encoding="utf-8"))
+    assert run_request["python_executable"] == activation["python_executable"]
+    assert activation["python_executable"] and Path(activation["python_executable"]).exists()
+
+
 async def test_job_submission_with_document_input(async_client: AsyncClient, seed_identity: dict[str, Any]) -> None:
     headers, workspace_id = await _auth(async_client, seed_identity)
-    version_id, _ = await _create_config(async_client, headers, workspace_id)
+    version_id, _, _ = await _create_config(async_client, headers, workspace_id)
 
     workbook = Workbook()
     sheet = workbook.active
@@ -184,18 +263,21 @@ async def test_job_submission_with_document_input(async_client: AsyncClient, see
     jobs_endpoint = f"/api/v1/workspaces/{workspace_id}/jobs"
     payload = {"config_version_id": version_id, "document_ids": [document_id]}
     submitted = await async_client.post(jobs_endpoint, headers=headers, json=payload)
-    assert submitted.status_code == 201, submitted.text
+    assert submitted.status_code == 202, submitted.text
     job_payload = submitted.json()
     job_id = job_payload["job_id"]
-    assert job_payload["status"] == "succeeded"
-    assert job_payload["input_hash"]
+    completed = await _wait_for_job(async_client, headers, workspace_id, job_id)
+    assert completed["status"] == "succeeded"
+    assert completed["input_hash"]
 
     # Resubmitting with the same document should reuse the existing job based on the derived hash.
     resubmitted = await async_client.post(jobs_endpoint, headers=headers, json=payload)
-    assert resubmitted.status_code == 201, resubmitted.text
-    assert resubmitted.json()["job_id"] == job_id
+    assert resubmitted.status_code == 202, resubmitted.text
+    resubmitted_payload = resubmitted.json()
+    assert resubmitted_payload["job_id"] == job_id
+    assert resubmitted_payload["status"] == "succeeded"
 
-    run_request = json.loads(Path(job_payload["run_request_uri"]).read_text(encoding="utf-8"))
+    run_request = json.loads(Path(completed["run_request_uri"]).read_text(encoding="utf-8"))
     assert run_request["input_paths"]
     assert run_request["input_documents"]
     first_document = run_request["input_documents"][0]
@@ -205,7 +287,7 @@ async def test_job_submission_with_document_input(async_client: AsyncClient, see
 
 async def test_job_submission_missing_document_id_returns_error(async_client: AsyncClient, seed_identity: dict[str, Any]) -> None:
     headers, workspace_id = await _auth(async_client, seed_identity)
-    version_id, _ = await _create_config(async_client, headers, workspace_id)
+    version_id, _, _ = await _create_config(async_client, headers, workspace_id)
 
     response = await async_client.post(
         f"/api/v1/workspaces/{workspace_id}/jobs",
@@ -218,7 +300,7 @@ async def test_job_submission_missing_document_id_returns_error(async_client: As
 
 async def test_job_submission_accepts_multiple_documents(async_client: AsyncClient, seed_identity: dict[str, Any]) -> None:
     headers, workspace_id = await _auth(async_client, seed_identity)
-    version_id, _ = await _create_config(async_client, headers, workspace_id)
+    version_id, _, _ = await _create_config(async_client, headers, workspace_id)
 
     workbook_a = Workbook()
     sheet_a = workbook_a.active
@@ -239,8 +321,167 @@ async def test_job_submission_accepts_multiple_documents(async_client: AsyncClie
         headers=headers,
         json=payload,
     )
-    assert response.status_code == 201, response.text
-    run_request = json.loads(Path(response.json()["run_request_uri"]).read_text(encoding="utf-8"))
+    assert response.status_code == 202, response.text
+    job_detail = await _wait_for_job(async_client, headers, workspace_id, response.json()["job_id"])
+    run_request = json.loads(Path(job_detail["run_request_uri"]).read_text(encoding="utf-8"))
     assert len(run_request["input_paths"]) == 2
     document_ids = [doc["document_id"] for doc in run_request["input_documents"]]
     assert document_ids == [doc_a, doc_b]
+
+
+async def test_concurrent_job_submissions_share_existing_job(async_client: AsyncClient, seed_identity: dict[str, Any]) -> None:
+    headers, workspace_id = await _auth(async_client, seed_identity)
+    version_id, _, _ = await _create_config(async_client, headers, workspace_id)
+
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.append(["Member ID", "First Name"])
+    sheet.append(["1001", "Alex"])
+    document_id = await _upload_document(async_client, headers, workspace_id, workbook)
+
+    payload = {"config_version_id": version_id, "document_ids": [document_id]}
+    base = f"/api/v1/workspaces/{workspace_id}/jobs"
+
+    first = await async_client.post(base, headers=headers, json=payload)
+    second = await async_client.post(base, headers=headers, json=payload)
+
+    statuses = {first.status_code, second.status_code}
+    assert statuses == {202}
+
+    job_ids = {first.json()["job_id"], second.json()["job_id"]}
+    assert len(job_ids) == 1
+    job_id = job_ids.pop()
+
+    detail = await _wait_for_job(async_client, headers, workspace_id, job_id)
+    assert detail["status"] == "succeeded"
+    assert detail["attempt"] == 1
+
+
+async def test_queue_returns_429_without_persisting_job(
+    async_client: AsyncClient,
+    seed_identity: dict[str, Any],
+    app: FastAPI,
+) -> None:
+    headers, workspace_id = await _auth(async_client, seed_identity)
+    version_id, _, _ = await _create_config(
+        async_client, headers, workspace_id, slow_iterations=500_000
+    )
+
+    queue = app.state.job_queue
+    assert queue is not None
+    await queue.stop()
+    original_settings = queue._settings
+    original_queue = queue._queue
+    queue._settings = original_settings.model_copy(update={"queue_max_size": 1, "queue_max_concurrency": 1})
+    queue._queue = asyncio.Queue(maxsize=queue._settings.queue_max_size)
+    queue._inflight.clear()
+
+    try:
+        await queue.start()
+
+        base = f"/api/v1/workspaces/{workspace_id}/jobs"
+        first = await async_client.post(base, headers=headers, json={"config_version_id": version_id})
+        second = await async_client.post(base, headers=headers, json={"config_version_id": version_id})
+        third = await async_client.post(base, headers=headers, json={"config_version_id": version_id})
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert third.status_code == 429
+
+        detail = third.json().get("detail", {})
+        assert detail.get("queue_size") == 1
+        assert detail.get("max_size") == 1
+        assert detail.get("max_concurrency") == 1
+
+        first_id = first.json()["job_id"]
+        second_id = second.json()["job_id"]
+
+        await _wait_for_job(async_client, headers, workspace_id, first_id)
+        await _wait_for_job(async_client, headers, workspace_id, second_id)
+    finally:
+        await queue.stop()
+        queue._settings = original_settings
+        queue._queue = original_queue
+        queue._inflight.clear()
+        await queue.start()
+
+    session_factory = get_sessionmaker(settings=get_settings())
+    async with session_factory() as session:
+        total = await session.scalar(
+            select(func.count()).select_from(Job).where(Job.config_version_id == version_id)
+        )
+    assert total == 2
+
+
+async def test_rehydration_requeues_stale_running_job(
+    async_client: AsyncClient,
+    seed_identity: dict[str, Any],
+    app: FastAPI,
+) -> None:
+    headers, workspace_id = await _auth(async_client, seed_identity)
+    version_id, _, config_id = await _create_config(async_client, headers, workspace_id)
+
+    settings = get_settings()
+    session_factory = get_sessionmaker(settings=settings)
+    async with session_factory() as session:
+        repo = JobsRepository(session)
+        job = await repo.create_job(
+            workspace_id=workspace_id,
+            config_id=config_id,
+            config_version_id=version_id,
+            actor_id=None,
+            input_hash="rehydrate-test",
+            trace_id="rehydrate-test",
+            document_ids=[],
+        )
+        job.status = JobStatus.RUNNING.value
+        job.started_at = utc_now() - timedelta(seconds=300)
+        job.last_heartbeat = None
+        await session.flush()
+        await session.commit()
+        job_id = job.id
+
+    queue = app.state.job_queue
+    assert queue is not None
+    await queue.stop()
+    await queue.start()
+
+    before_retry = await async_client.get(
+        f"/api/v1/workspaces/{workspace_id}/jobs/{job_id}", headers=headers
+    )
+    assert before_retry.status_code == 200
+    assert before_retry.json()["status"] in {"queued", "running"}
+
+    detail = await _wait_for_job(async_client, headers, workspace_id, job_id, timeout=20.0)
+    assert detail["status"] == "succeeded"
+
+    log_lines = Path(detail["logs_uri"]).read_text(encoding="utf-8").splitlines()
+    assert any(json.loads(line)["event"] == "retry" for line in log_lines)
+
+
+async def test_retry_endpoint_enqueues_new_attempt(async_client: AsyncClient, seed_identity: dict[str, Any]) -> None:
+    headers, workspace_id = await _auth(async_client, seed_identity)
+    version_id, _, config_id = await _create_config(async_client, headers, workspace_id)
+
+    base = f"/api/v1/workspaces/{workspace_id}/jobs"
+    submitted = await async_client.post(base, headers=headers, json={"config_version_id": version_id})
+    assert submitted.status_code == 202
+    job_id = submitted.json()["job_id"]
+
+    original = await _wait_for_job(async_client, headers, workspace_id, job_id)
+    assert original["status"] == "succeeded"
+    assert original["attempt"] == 1
+
+    retry = await async_client.post(f"{base}/{job_id}/retry", headers=headers)
+    assert retry.status_code == 202, retry.text
+    retry_payload = retry.json()
+    assert retry_payload["job_id"] != job_id
+    assert retry_payload["retry_of_job_id"] == job_id
+    assert retry_payload["attempt"] == 2
+
+    location = retry.headers.get("Location")
+    assert location and location.endswith(f"/jobs/{retry_payload['job_id']}")
+
+    retried = await _wait_for_job(async_client, headers, workspace_id, retry_payload["job_id"])
+    assert retried["status"] == "succeeded"
+    assert retried["attempt"] == 2

--- a/docs/developers/01-config-packages.md
+++ b/docs/developers/01-config-packages.md
@@ -354,10 +354,11 @@ def run(*, artifact: dict, **_):
 
 If your rules need third‑party libraries:
 
-* Add a **`requirements.txt`** to the package. ADE installs it into an **isolated per‑job environment** when `engine.defaults.runtime_network_access: true`.
-* Prefer **pinned versions**. For air‑gapped or reproducible runs, vendor pure‑Python deps (e.g., `vendor/`) and import them directly.
+* Add a **`requirements.txt`** to the package. ADE installs it during activation into a **per-version virtualenv** (`data/venvs/<config_version_id>` by default).
+* Prefer **pinned versions**. Vendored pure-Python code (`vendor/`) still works as a fallback when activation metadata is missing or you need offline installs.
+* Use `hooks/on_activate/*.py` for additional setup after dependencies land (e.g., downloading ML models into the config storage path).
 
-> The artifact records any packages/versions installed for the job.
+> Activation snapshots live under `configs/<config_id>/<sequence>/activation/` and include `packages.txt`, `install.log`, and the resolved interpreter path.
 
 ---
 

--- a/docs/developers/05-pass-transform-values.md
+++ b/docs/developers/05-pass-transform-values.md
@@ -52,7 +52,7 @@ For each table:
 
 * Functions run inside the job worker with explicit kwargs, not globals.
 * Keep them pure and fast; avoid I/O unless required.
-* **Network access** is **off by default** and governed by `engine.defaults.allow_net`. Enable only when strictly necessary.
+* **Network access** is **off by default** and governed by `engine.defaults.runtime_network_access`. Enable only when strictly necessary.
 
 ## See also
 

--- a/docs/developers/12-glossary.md
+++ b/docs/developers/12-glossary.md
@@ -22,6 +22,7 @@
 - Job context — Dict returned from `on_job_start` hooks; passed to detectors, transforms, validators, and later hooks.
 - Paths — Keyword-only argument with resolved directories like `paths["config"]`, `paths["resources"]`, `paths["cache"]`, `paths["job"]`, and `paths["job_input"]`.
 - Engine defaults — Limits in `manifest.engine.defaults` (timeouts, memory, `runtime_network_access`).
+- Runtime network access — Boolean flag (`manifest.engine.defaults.runtime_network_access`) that keeps the worker offline unless explicitly enabled.
 
 ## Spreadsheet structure
 
@@ -67,6 +68,7 @@
 - Resources directory — Optional `resources/` under the config directory for supporting data files.
 - Cache directory — Hook-accessible path (`paths["cache"]`) for temporary artifacts reused during jobs.
 - Job directory — Per-run folder referenced by `paths["job"]` that holds transient data and logs.
+- Activation snapshot — Folder under `configs/<config>/<sequence>/activation/` containing venv metadata (`result.json`, `packages.txt`, `install.log`, `hooks.json`).
 
 ## Security and lifecycle
 
@@ -74,6 +76,7 @@
 - Status — `draft | active | archived`; only draft configs are editable.
 - Active config — Exactly one active config per workspace at a time.
 - Sandbox — Restricted subprocess (`python -I -B`) with rlimits and no network unless enabled.
+- Activation environment — Virtualenv built during activation (`data/venvs/<config_version_id>`) reused for all jobs targeting that config version.
 
 ## IDs and addressing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
   "pytest==8.4.2",
   "pytest-asyncio==1.2.0",
   "pytest-cov==5.0.0",
+  "asgi-lifespan==2.1.0",
   "mypy==1.18.2",
   "ruff==0.13.1",
   "openapi-spec-validator==0.7.2",


### PR DESCRIPTION
## Summary
- build per-version activation environments that install requirements, run on_activate hooks, and persist metadata for reuse
- launch jobs with the activation interpreter, expose activation metadata in job records, and surface packages/logs through the API
- update activation and job tests plus developer docs to describe the queued workflow, virtualenv pipeline, and runtime network flag

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_690918ca1ed0832eada3d5141804ac19