### PR TITLE
feat: add backend support for configuration builds

### DIFF
--- a/apps/api/app/features/builds/__init__.py
+++ b/apps/api/app/features/builds/__init__.py
@@ -1,0 +1,23 @@
+"""Virtual environment build management for configurations."""
+
+from .exceptions import (
+    BuildAlreadyInProgressError,
+    BuildNotFoundError,
+    BuildWorkspaceMismatchError,
+)
+from .schemas import BuildRecord
+from .service import (
+    BuildEnsureMode,
+    BuildEnsureResult,
+    BuildsService,
+)
+
+__all__ = [
+    "BuildAlreadyInProgressError",
+    "BuildEnsureMode",
+    "BuildEnsureResult",
+    "BuildNotFoundError",
+    "BuildRecord",
+    "BuildWorkspaceMismatchError",
+    "BuildsService",
+]

--- a/apps/api/app/features/builds/builder.py
+++ b/apps/api/app/features/builds/builder.py
@@ -1,0 +1,216 @@
+"""Utilities to create isolated Python virtual environments for builds."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from fastapi.concurrency import run_in_threadpool
+
+from .exceptions import BuildExecutionError
+
+__all__ = [
+    "BuildArtifacts",
+    "VirtualEnvironmentBuilder",
+]
+
+
+@dataclass(slots=True)
+class BuildArtifacts:
+    """Metadata captured from a successful build."""
+
+    python_version: str
+    engine_version: str
+
+
+class VirtualEnvironmentBuilder:
+    """Create virtual environments containing ADE engine + config package."""
+
+    def __init__(self) -> None:
+        self._platform_bin = "Scripts" if os.name == "nt" else "bin"
+
+    async def build(
+        self,
+        *,
+        build_id: str,
+        workspace_id: str,
+        config_id: str,
+        target_path: Path,
+        config_path: Path,
+        engine_spec: str,
+        pip_cache_dir: Path | None,
+        python_bin: str | None,
+        timeout: float,
+    ) -> BuildArtifacts:
+        """Create a virtual environment at ``target_path`` and install packages."""
+
+        interpreter = python_bin or sys.executable
+        await self._prepare_target(target_path)
+
+        try:
+            await self._run(
+                [interpreter, "-m", "venv", str(target_path)],
+                timeout=timeout,
+            )
+            venv_python = self._venv_python(target_path)
+            await self._run(
+                [
+                    str(venv_python),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--upgrade",
+                    "pip",
+                    "wheel",
+                    "setuptools",
+                ],
+                timeout=timeout,
+                env=self._build_env(pip_cache_dir),
+            )
+            await self._run(
+                [
+                    str(venv_python),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-input",
+                    "--no-deps",
+                    engine_spec,
+                ],
+                timeout=timeout,
+                env=self._build_env(pip_cache_dir),
+            )
+            await self._run(
+                [
+                    str(venv_python),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-input",
+                    "--no-deps",
+                    str(config_path),
+                ],
+                timeout=timeout,
+                env=self._build_env(pip_cache_dir),
+            )
+
+            await self._run(
+                [str(venv_python), "-I", "-B", "-c", "import ade_engine, ade_config"],
+                timeout=timeout,
+                env=self._build_env(pip_cache_dir),
+            )
+
+            python_version = (
+                await self._capture(
+                    [
+                        str(venv_python),
+                        "-c",
+                        "import sys; print('.'.join(map(str, sys.version_info[:3])))",
+                    ],
+                    timeout=timeout,
+                )
+            ).strip()
+            engine_version = (
+                await self._capture(
+                    [
+                        str(venv_python),
+                        "-c",
+                        "import importlib.metadata as m; print(m.version('ade-engine'))",
+                    ],
+                    timeout=timeout,
+                )
+            ).strip()
+
+            await self._write_metadata(
+                target_path,
+                {
+                    "build_id": build_id,
+                    "workspace_id": workspace_id,
+                    "config_id": config_id,
+                    "python_version": python_version,
+                    "engine_version": engine_version,
+                },
+            )
+
+            return BuildArtifacts(
+                python_version=python_version,
+                engine_version=engine_version,
+            )
+        except Exception as exc:  # pragma: no cover - defensive cleanup
+            await self._remove_target(target_path)
+            message = (
+                f"Failed to build venv for workspace={workspace_id} config={config_id}: {exc}"
+            )
+            raise BuildExecutionError(message, build_id=build_id) from exc
+
+    async def _prepare_target(self, target: Path) -> None:
+        def _prepare() -> None:
+            if target.exists():
+                shutil.rmtree(target)
+            target.parent.mkdir(parents=True, exist_ok=True)
+
+        await run_in_threadpool(_prepare)
+
+    async def _remove_target(self, target: Path) -> None:
+        def _remove() -> None:
+            shutil.rmtree(target, ignore_errors=True)
+
+        await run_in_threadpool(_remove)
+
+    def _venv_python(self, target: Path) -> Path:
+        executable = "python.exe" if os.name == "nt" else "python"
+        return target / self._platform_bin / executable
+
+    async def _run(
+        self,
+        command: list[str],
+        *,
+        timeout: float,
+        env: Mapping[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        def _call() -> subprocess.CompletedProcess[str]:
+            env_vars = os.environ.copy()
+            if env:
+                env_vars.update(env)
+            return subprocess.run(
+                command,
+                check=True,
+                text=True,
+                capture_output=True,
+                env=env_vars,
+                timeout=timeout,
+            )
+
+        return await run_in_threadpool(_call)
+
+    async def _capture(
+        self,
+        command: list[str],
+        *,
+        timeout: float,
+    ) -> str:
+        completed = await self._run(command, timeout=timeout)
+        return (completed.stdout or "").strip()
+
+    async def _write_metadata(self, target: Path, payload: Mapping[str, object]) -> None:
+        runtime_dir = target / "ade-runtime"
+        packages_txt = runtime_dir / "packages.txt"
+        build_json = runtime_dir / "build.json"
+
+        def _write() -> None:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+            packages_txt.write_text("", encoding="utf-8")
+            build_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+        await run_in_threadpool(_write)
+
+    def _build_env(self, pip_cache_dir: Path | None) -> Mapping[str, str] | None:
+        if pip_cache_dir is None:
+            return None
+        return {"PIP_CACHE_DIR": str(pip_cache_dir)}

--- a/apps/api/app/features/builds/exceptions.py
+++ b/apps/api/app/features/builds/exceptions.py
@@ -1,0 +1,30 @@
+"""Custom exceptions for configuration build lifecycle management."""
+
+from __future__ import annotations
+
+__all__ = [
+    "BuildAlreadyInProgressError",
+    "BuildExecutionError",
+    "BuildNotFoundError",
+    "BuildWorkspaceMismatchError",
+]
+
+
+class BuildNotFoundError(Exception):
+    """Raised when the requested build pointer does not exist."""
+
+
+class BuildAlreadyInProgressError(Exception):
+    """Raised when a build is already running and cannot be coalesced."""
+
+
+class BuildWorkspaceMismatchError(Exception):
+    """Raised when a build record does not belong to the expected workspace."""
+
+
+class BuildExecutionError(Exception):
+    """Raised when the builder fails to produce a working virtual environment."""
+
+    def __init__(self, message: str, *, build_id: str) -> None:
+        super().__init__(message)
+        self.build_id = build_id

--- a/apps/api/app/features/builds/models.py
+++ b/apps/api/app/features/builds/models.py
@@ -1,0 +1,94 @@
+"""Database model for configuration build metadata."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    PrimaryKeyConstraint,
+    String,
+    Text,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from apps.api.app.shared.db import Base
+from apps.api.app.shared.db.mixins import TimestampMixin
+
+__all__ = ["BuildStatus", "ConfigurationBuild"]
+
+
+class BuildStatus(str, Enum):
+    """Lifecycle states for configuration build records."""
+
+    BUILDING = "building"
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    FAILED = "failed"
+
+
+class ConfigurationBuild(TimestampMixin, Base):
+    """Track virtual environment builds for workspace configurations."""
+
+    __tablename__ = "configuration_builds"
+
+    workspace_id: Mapped[str] = mapped_column(
+        String(26),
+        ForeignKey("workspaces.workspace_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    config_id: Mapped[str] = mapped_column(String(26), nullable=False)
+    build_id: Mapped[str] = mapped_column(String(26), nullable=False)
+
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    venv_path: Mapped[str] = mapped_column(Text, nullable=False)
+
+    config_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    content_digest: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    engine_version: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    engine_spec: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    python_version: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    python_interpreter: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    built_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        PrimaryKeyConstraint("workspace_id", "config_id", "build_id"),
+        ForeignKeyConstraint(
+            ["workspace_id", "config_id"],
+            ["configurations.workspace_id", "configurations.config_id"],
+            ondelete="CASCADE",
+        ),
+        CheckConstraint(
+            "status in ('building','active','inactive','failed')",
+            name="configuration_builds_status_check",
+        ),
+        Index(
+            "configuration_builds_active_idx",
+            "workspace_id",
+            "config_id",
+            unique=True,
+            sqlite_where=text("status = 'active'"),
+            postgresql_where=text("status = 'active'"),
+        ),
+        Index(
+            "configuration_builds_building_idx",
+            "workspace_id",
+            "config_id",
+            unique=True,
+            sqlite_where=text("status = 'building'"),
+            postgresql_where=text("status = 'building'"),
+        ),
+    )

--- a/apps/api/app/features/builds/repository.py
+++ b/apps/api/app/features/builds/repository.py
@@ -1,0 +1,209 @@
+"""Persistence helpers for configuration build metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+
+from sqlalchemy import Select, delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import BuildStatus, ConfigurationBuild
+
+__all__ = ["ConfigurationBuildsRepository"]
+
+
+class ConfigurationBuildsRepository:
+    """Read/write helpers encapsulating build-specific SQL operations."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    def base_query(self) -> Select[tuple[ConfigurationBuild]]:
+        return select(ConfigurationBuild)
+
+    async def get_build(
+        self,
+        *,
+        workspace_id: str,
+        config_id: str,
+        build_id: str,
+    ) -> ConfigurationBuild | None:
+        stmt = (
+            self.base_query()
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.build_id == build_id,
+            )
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_latest(
+        self, *, workspace_id: str, config_id: str
+    ) -> ConfigurationBuild | None:
+        stmt = (
+            self.base_query()
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+            )
+            .order_by(ConfigurationBuild.created_at.desc())
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_active(
+        self, *, workspace_id: str, config_id: str
+    ) -> ConfigurationBuild | None:
+        stmt = (
+            self.base_query()
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.status == BuildStatus.ACTIVE.value,
+            )
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_building(
+        self, *, workspace_id: str, config_id: str
+    ) -> ConfigurationBuild | None:
+        stmt = (
+            self.base_query()
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.status == BuildStatus.BUILDING.value,
+            )
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_inactive(
+        self, *, workspace_id: str, config_id: str
+    ) -> Sequence[ConfigurationBuild]:
+        stmt = (
+            self.base_query()
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.status.in_(
+                    [BuildStatus.INACTIVE.value, BuildStatus.FAILED.value]
+                ),
+            )
+            .order_by(ConfigurationBuild.created_at.asc())
+        )
+        result = await self._session.execute(stmt)
+        return result.scalars().all()
+
+    async def deactivate_all(
+        self, *, workspace_id: str, config_id: str, exclude_build_id: str
+    ) -> None:
+        stmt = (
+            update(ConfigurationBuild)
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.build_id != exclude_build_id,
+                ConfigurationBuild.status == BuildStatus.ACTIVE.value,
+            )
+            .values(status=BuildStatus.INACTIVE.value)
+        )
+        await self._session.execute(stmt)
+
+    async def mark_failed(
+        self,
+        *,
+        workspace_id: str,
+        config_id: str,
+        build_id: str,
+        error: str,
+        finished_at: datetime,
+    ) -> None:
+        stmt = (
+            update(ConfigurationBuild)
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.build_id == build_id,
+            )
+            .values(
+                status=BuildStatus.FAILED.value,
+                built_at=finished_at,
+                error=error,
+            )
+        )
+        await self._session.execute(stmt)
+
+    async def update_active(
+        self,
+        *,
+        workspace_id: str,
+        config_id: str,
+        build_id: str,
+        built_at: datetime,
+        python_version: str,
+        engine_version: str,
+        venv_path: str,
+    ) -> None:
+        stmt = (
+            update(ConfigurationBuild)
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.build_id == build_id,
+            )
+            .values(
+                status=BuildStatus.ACTIVE.value,
+                built_at=built_at,
+                last_used_at=built_at,
+                python_version=python_version,
+                engine_version=engine_version,
+                error=None,
+                venv_path=venv_path,
+            )
+        )
+        await self._session.execute(stmt)
+
+    async def update_last_used(
+        self,
+        *,
+        workspace_id: str,
+        config_id: str,
+        build_id: str,
+        last_used_at: datetime,
+    ) -> None:
+        stmt = (
+            update(ConfigurationBuild)
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.build_id == build_id,
+            )
+            .values(last_used_at=last_used_at)
+        )
+        await self._session.execute(stmt)
+
+    async def delete_build(
+        self,
+        *,
+        workspace_id: str,
+        config_id: str,
+        build_id: str,
+    ) -> None:
+        stmt = (
+            delete(ConfigurationBuild)
+            .where(
+                ConfigurationBuild.workspace_id == workspace_id,
+                ConfigurationBuild.config_id == config_id,
+                ConfigurationBuild.build_id == build_id,
+            )
+        )
+        await self._session.execute(stmt)

--- a/apps/api/app/features/builds/router.py
+++ b/apps/api/app/features/builds/router.py
@@ -1,0 +1,149 @@
+"""HTTP endpoints for managing configuration build environments."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Security, status
+
+from apps.api.app.shared.core.schema import ErrorMessage
+from apps.api.app.shared.dependency import (
+    get_builds_service,
+    require_authenticated,
+    require_csrf,
+    require_workspace,
+)
+
+from ..users.models import User
+from .exceptions import BuildAlreadyInProgressError, BuildExecutionError, BuildNotFoundError
+from .models import BuildStatus
+from .schemas import BuildEnsureRequest, BuildEnsureResponse, BuildRecord
+from .service import BuildEnsureMode, BuildsService
+
+router = APIRouter(
+    prefix="/workspaces/{workspace_id}/configurations/{config_id}",
+    tags=["builds"],
+    dependencies=[Security(require_authenticated)],
+)
+
+BUILD_BODY = Body(
+    BuildEnsureRequest(),
+    description="Options for ensuring the configuration build is up-to-date.",
+)
+
+
+@router.get(
+    "/build",
+    response_model=BuildRecord,
+    response_model_exclude_none=True,
+    summary="Get the active build pointer",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": ErrorMessage},
+        status.HTTP_403_FORBIDDEN: {"model": ErrorMessage},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorMessage},
+    },
+)
+async def get_build(
+    workspace_id: Annotated[str, Path(..., min_length=1, description="Workspace identifier")],
+    config_id: Annotated[str, Path(..., min_length=1, description="Configuration identifier")],
+    service: Annotated[BuildsService, Depends(get_builds_service)],
+    _actor: Annotated[
+        User,
+        Security(
+            require_workspace("Workspace.Configs.Read"),
+            scopes=["{workspace_id}"],
+        ),
+    ],
+) -> BuildRecord:
+    try:
+        build = await service.get_active_build(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+    except BuildNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="build_not_found") from exc
+    return BuildRecord.model_validate(build)
+
+
+@router.put(
+    "/build",
+    response_model=BuildEnsureResponse,
+    response_model_exclude_none=True,
+    dependencies=[Security(require_csrf)],
+    summary="Ensure the configuration build exists and is current",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": ErrorMessage},
+        status.HTTP_403_FORBIDDEN: {"model": ErrorMessage},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorMessage},
+        status.HTTP_409_CONFLICT: {"model": ErrorMessage},
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": ErrorMessage},
+    },
+)
+async def ensure_build(
+    workspace_id: Annotated[str, Path(..., min_length=1, description="Workspace identifier")],
+    config_id: Annotated[str, Path(..., min_length=1, description="Configuration identifier")],
+    service: Annotated[BuildsService, Depends(get_builds_service)],
+    _actor: Annotated[
+        User,
+        Security(
+            require_workspace("Workspace.Configs.ReadWrite"),
+            scopes=["{workspace_id}"],
+        ),
+    ],
+    *,
+    payload: BuildEnsureRequest = BUILD_BODY,
+) -> BuildEnsureResponse:
+    mode = BuildEnsureMode.BLOCKING if payload.wait else BuildEnsureMode.INTERACTIVE
+    try:
+        result = await service.ensure_build(
+            workspace_id=workspace_id,
+            config_id=config_id,
+            force=payload.force,
+            mode=mode,
+        )
+    except BuildAlreadyInProgressError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="build_in_progress") from exc
+    except BuildExecutionError as exc:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail="build_failed") from exc
+    except BuildNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="build_not_found") from exc
+
+    if result.build is None:
+        return BuildEnsureResponse(status=BuildStatus.BUILDING)
+
+    return BuildEnsureResponse(
+        status=result.status,
+        build=BuildRecord.model_validate(result.build),
+    )
+
+
+@router.delete(
+    "/build",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Security(require_csrf)],
+    summary="Delete the active build and remove its virtual environment",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": ErrorMessage},
+        status.HTTP_403_FORBIDDEN: {"model": ErrorMessage},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorMessage},
+    },
+)
+async def delete_build(
+    workspace_id: Annotated[str, Path(..., min_length=1, description="Workspace identifier")],
+    config_id: Annotated[str, Path(..., min_length=1, description="Configuration identifier")],
+    service: Annotated[BuildsService, Depends(get_builds_service)],
+    _actor: Annotated[
+        User,
+        Security(
+            require_workspace("Workspace.Configs.ReadWrite"),
+            scopes=["{workspace_id}"],
+        ),
+    ],
+) -> None:
+    try:
+        await service.delete_active_build(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+    except BuildNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="build_not_found") from exc

--- a/apps/api/app/features/builds/schemas.py
+++ b/apps/api/app/features/builds/schemas.py
@@ -1,0 +1,73 @@
+"""Pydantic schemas for configuration build API payloads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import BuildStatus
+
+__all__ = [
+    "BuildEnsureRequest",
+    "BuildEnsureResponse",
+    "BuildRecord",
+]
+
+
+class BuildRecord(BaseModel):
+    """Serialized representation of a configuration build pointer."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    workspace_id: str = Field(..., description="Workspace identifier")
+    config_id: str = Field(..., description="Configuration identifier")
+    build_id: str = Field(..., description="Build identifier (ULID)")
+    status: BuildStatus = Field(..., description="Current lifecycle status")
+    venv_path: str = Field(..., description="Absolute path to the venv root")
+
+    config_version: int | None = Field(None, description="Configuration version when built")
+    content_digest: str | None = Field(None, description="Content fingerprint of the config")
+    engine_version: str | None = Field(None, description="Installed ADE engine version")
+    engine_spec: str | None = Field(None, description="Engine installation spec")
+    python_version: str | None = Field(None, description="Interpreter version used")
+    python_interpreter: str | None = Field(
+        None, description="Path to the interpreter used for venv creation"
+    )
+
+    started_at: datetime | None = Field(None, description="When the build began")
+    built_at: datetime | None = Field(None, description="When the build completed")
+    expires_at: datetime | None = Field(None, description="When the build expires, if set")
+    last_used_at: datetime | None = Field(None, description="Last time the build was used")
+    error: str | None = Field(None, description="Error message, if build failed")
+
+
+class BuildEnsureRequest(BaseModel):
+    """Body accepted by PUT /build to trigger a rebuild."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    force: bool = Field(False, description="Force rebuild even if fingerprint matches")
+    wait: bool | None = Field(
+        None,
+        description=(
+            "When true, wait up to ADE_BUILD_ENSURE_WAIT_SECONDS for an in-progress "
+            "build to finish. When omitted, the default depends on the caller."
+        ),
+    )
+
+
+class BuildEnsureResponse(BaseModel):
+    """Response returned by ensure_build endpoints."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: BuildStatus = Field(..., description="Resulting build status")
+    build: BuildRecord | None = Field(
+        None,
+        description="Active build pointer when available",
+    )
+
+    def model_dump(self, *args, **kwargs):  # type: ignore[override]
+        kwargs.setdefault("exclude_none", True)
+        return super().model_dump(*args, **kwargs)

--- a/apps/api/app/features/builds/service.py
+++ b/apps/api/app/features/builds/service.py
@@ -1,0 +1,380 @@
+"""Service encapsulating configuration build orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import sys
+import tomllib
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api.app.features.configs.exceptions import ConfigurationNotFoundError
+from apps.api.app.features.configs.repository import ConfigurationsRepository
+from apps.api.app.features.configs.storage import ConfigStorage
+from apps.api.app.settings import Settings
+from apps.api.app.shared.core.time import utc_now
+from apps.api.app.shared.db.mixins import generate_ulid
+
+from .builder import VirtualEnvironmentBuilder
+from .exceptions import (
+    BuildAlreadyInProgressError,
+    BuildExecutionError,
+    BuildNotFoundError,
+)
+from .models import BuildStatus, ConfigurationBuild
+from .repository import ConfigurationBuildsRepository
+
+__all__ = [
+    "BuildEnsureMode",
+    "BuildEnsureResult",
+    "BuildsService",
+]
+
+
+class BuildEnsureMode(str, Enum):
+    """Identify caller expectations for ensure_build."""
+
+    INTERACTIVE = "interactive"
+    BLOCKING = "blocking"
+
+
+@dataclass(slots=True)
+class BuildEnsureResult:
+    """Result returned by ``ensure_build`` attempts."""
+
+    status: BuildStatus
+    build: ConfigurationBuild | None
+    just_built: bool = False
+
+
+class BuildsService:
+    """Coordinate build rows, filesystem state, and dedupe semantics."""
+
+    def __init__(
+        self,
+        *,
+        session: AsyncSession,
+        settings: Settings,
+        storage: ConfigStorage,
+        builder: VirtualEnvironmentBuilder | None = None,
+        now: Callable[[], datetime] = utc_now,
+    ) -> None:
+        self._session = session
+        self._settings = settings
+        self._storage = storage
+        self._builder = builder or VirtualEnvironmentBuilder()
+        self._configs = ConfigurationsRepository(session)
+        self._repository = ConfigurationBuildsRepository(session)
+        self._now = now
+
+    async def get_active_build(
+        self, *, workspace_id: str, config_id: str
+    ) -> ConfigurationBuild:
+        build = await self._repository.get_active(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+        if build is None:
+            raise BuildNotFoundError(
+                f"No active build for workspace={workspace_id} config={config_id}"
+            )
+        return build
+
+    async def ensure_build(
+        self,
+        *,
+        workspace_id: str,
+        config_id: str,
+        force: bool = False,
+        mode: BuildEnsureMode = BuildEnsureMode.INTERACTIVE,
+    ) -> BuildEnsureResult:
+        configuration = await self._configs.get(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+        if configuration is None:
+            raise ConfigurationNotFoundError(config_id)
+
+        config_path = await self._storage.ensure_config_path(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+
+        python_interpreter = self._settings.python_bin or sys.executable
+        python_interpreter = str(Path(python_interpreter).resolve())
+        engine_spec = self._settings.engine_spec
+        engine_version_hint = self._resolve_engine_version(engine_spec)
+        ttl = self._settings.build_ttl
+
+        await self._heal_stale_builder(workspace_id=workspace_id, config_id=config_id)
+
+        active = await self._repository.get_active(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+
+        if active and active.status != BuildStatus.ACTIVE.value:
+            active = None
+
+        should_rebuild = force or active is None
+        if active is not None and not should_rebuild:
+            should_rebuild = any(
+                [
+                    active.config_version != configuration.config_version,
+                    active.content_digest != configuration.content_digest,
+                    active.engine_version != engine_version_hint,
+                    active.engine_spec != engine_spec,
+                    active.python_interpreter != python_interpreter,
+                    ttl is not None
+                    and active.built_at is not None
+                    and active.built_at + ttl <= self._now(),
+                ]
+            )
+
+        if not should_rebuild and active is not None:
+            await self._repository.update_last_used(
+                workspace_id=workspace_id,
+                config_id=config_id,
+                build_id=active.build_id,
+                last_used_at=self._now(),
+            )
+            return BuildEnsureResult(status=BuildStatus.ACTIVE, build=active)
+
+        building = await self._repository.get_building(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+        if building is not None:
+            if mode is BuildEnsureMode.BLOCKING:
+                return await self._wait_for_build(
+                    workspace_id=workspace_id,
+                    config_id=config_id,
+                    timeout=self._settings.build_ensure_wait,
+                )
+            return BuildEnsureResult(status=BuildStatus.BUILDING, build=None)
+
+        build_id = generate_ulid()
+        target_path = (
+            self._settings.venvs_dir
+            / workspace_id
+            / config_id
+            / build_id
+        )
+        expires_at = (
+            self._now() + ttl if ttl is not None else None
+        )
+
+        record = ConfigurationBuild(
+            workspace_id=workspace_id,
+            config_id=config_id,
+            build_id=build_id,
+            status=BuildStatus.BUILDING.value,
+            venv_path=str(target_path),
+            config_version=configuration.config_version,
+            content_digest=configuration.content_digest,
+            engine_version=engine_version_hint,
+            engine_spec=engine_spec,
+            python_version=None,
+            python_interpreter=python_interpreter,
+            started_at=self._now(),
+            built_at=None,
+            expires_at=expires_at,
+            last_used_at=None,
+            error=None,
+        )
+        self._session.add(record)
+        try:
+            await self._session.commit()
+        except IntegrityError:
+            await self._session.rollback()
+            if mode is BuildEnsureMode.BLOCKING:
+                return await self._wait_for_build(
+                    workspace_id=workspace_id,
+                    config_id=config_id,
+                    timeout=self._settings.build_ensure_wait,
+                )
+            return BuildEnsureResult(status=BuildStatus.BUILDING, build=None)
+
+        try:
+            artifacts = await self._builder.build(
+                build_id=build_id,
+                workspace_id=workspace_id,
+                config_id=config_id,
+                target_path=target_path,
+                config_path=config_path,
+                engine_spec=engine_spec,
+                pip_cache_dir=self._settings.pip_cache_dir,
+                python_bin=python_interpreter,
+                timeout=self._settings.build_timeout.total_seconds(),
+            )
+        except BuildExecutionError as exc:
+            await self._repository.mark_failed(
+                workspace_id=workspace_id,
+                config_id=config_id,
+                build_id=build_id,
+                error=str(exc),
+                finished_at=self._now(),
+            )
+            await self._session.commit()
+            raise
+
+        built_at = self._now()
+        await self._repository.deactivate_all(
+            workspace_id=workspace_id,
+            config_id=config_id,
+            exclude_build_id=build_id,
+        )
+        await self._repository.update_active(
+            workspace_id=workspace_id,
+            config_id=config_id,
+            build_id=build_id,
+            built_at=built_at,
+            python_version=artifacts.python_version,
+            engine_version=artifacts.engine_version,
+            venv_path=str(target_path),
+        )
+        await self._session.commit()
+
+        await self._prune_inactive(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+
+        active = await self._repository.get_active(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+        return BuildEnsureResult(status=BuildStatus.ACTIVE, build=active, just_built=True)
+
+    async def delete_active_build(
+        self, *, workspace_id: str, config_id: str
+    ) -> None:
+        build = await self._repository.get_active(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+        if build is None:
+            raise BuildNotFoundError(
+                f"No active build for workspace={workspace_id} config={config_id}"
+            )
+        await self._repository.delete_build(
+            workspace_id=workspace_id,
+            config_id=config_id,
+            build_id=build.build_id,
+        )
+        await self._session.commit()
+        await self._remove_venv(build.venv_path)
+
+    async def _heal_stale_builder(self, *, workspace_id: str, config_id: str) -> None:
+        building = await self._repository.get_building(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+        if building is None or building.started_at is None:
+            return
+        timeout = self._settings.build_timeout
+        if building.started_at + timeout > self._now():
+            return
+        await self._repository.mark_failed(
+            workspace_id=workspace_id,
+            config_id=config_id,
+            build_id=building.build_id,
+            error="build_timeout",
+            finished_at=self._now(),
+        )
+        await self._session.commit()
+        await self._remove_venv(building.venv_path)
+
+    async def _wait_for_build(
+        self,
+        *,
+        workspace_id: str,
+        config_id: str,
+        timeout: timedelta,
+    ) -> BuildEnsureResult:
+        deadline = self._now() + timeout
+        while self._now() < deadline:
+            active = await self._repository.get_active(
+                workspace_id=workspace_id,
+                config_id=config_id,
+            )
+            if active is not None:
+                await self._repository.update_last_used(
+                    workspace_id=workspace_id,
+                    config_id=config_id,
+                    build_id=active.build_id,
+                    last_used_at=self._now(),
+                )
+                return BuildEnsureResult(status=BuildStatus.ACTIVE, build=active)
+
+            building = await self._repository.get_building(
+                workspace_id=workspace_id,
+                config_id=config_id,
+            )
+            if building is None:
+                latest = await self._repository.get_latest(
+                    workspace_id=workspace_id,
+                    config_id=config_id,
+                )
+                if latest is not None and latest.status == BuildStatus.FAILED.value:
+                    raise BuildExecutionError(
+                        latest.error or "build_failed",
+                        build_id=latest.build_id,
+                    )
+            await asyncio.sleep(1)
+        raise BuildAlreadyInProgressError(
+            f"Build still in progress for workspace={workspace_id} config={config_id}"
+        )
+
+    async def _prune_inactive(self, *, workspace_id: str, config_id: str) -> None:
+        retention = self._settings.build_retention
+        if retention is None:
+            return
+        threshold = self._now() - retention
+        builds = await self._repository.list_inactive(
+            workspace_id=workspace_id,
+            config_id=config_id,
+        )
+        pruned = False
+        for build in builds:
+            built_at = build.built_at or build.started_at or self._now()
+            if built_at <= threshold:
+                await self._repository.delete_build(
+                    workspace_id=workspace_id,
+                    config_id=config_id,
+                    build_id=build.build_id,
+                )
+                await self._remove_venv(build.venv_path)
+                pruned = True
+        if pruned:
+            await self._session.commit()
+
+    async def _remove_venv(self, venv_path: str | None) -> None:
+        if not venv_path:
+            return
+        path = Path(venv_path)
+
+        def _remove() -> None:
+            shutil.rmtree(path, ignore_errors=True)
+
+        await asyncio.to_thread(_remove)
+
+    def _resolve_engine_version(self, spec: str) -> str | None:
+        path = Path(spec)
+        if path.exists() and path.is_dir():
+            pyproject = path / "pyproject.toml"
+            try:
+                data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+            except OSError:
+                return None
+            return data.get("project", {}).get("version")
+        if "==" in spec:
+            return spec.split("==", 1)[1]
+        return None

--- a/apps/api/app/routers.py
+++ b/apps/api/app/routers.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 
 from .features.auth.router import router as auth_router
 from .features.auth.router import setup_router
+from .features.builds.router import router as builds_router
 from .features.configs.router import router as configs_router
 from .features.documents.router import router as documents_router
 from .features.health.router import router as health_router
@@ -22,5 +23,6 @@ api_router.include_router(roles_router)
 api_router.include_router(workspaces_router)
 api_router.include_router(documents_router)
 api_router.include_router(configs_router)
+api_router.include_router(builds_router)
 
 __all__ = ["api_router"]

--- a/apps/api/app/shared/dependency.py
+++ b/apps/api/app/shared/dependency.py
@@ -29,6 +29,7 @@ from fastapi.security import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 if TYPE_CHECKING:
+    from apps.api.app.features.builds.service import BuildsService
     from apps.api.app.features.configs.service import ConfigurationsService
     from apps.api.app.features.documents.service import DocumentsService
     from apps.api.app.features.health.service import HealthService
@@ -94,6 +95,27 @@ def get_configs_service(
         configs_root=settings.configs_dir,
     )
     return ConfigurationsService(session=session, storage=storage)
+
+
+def get_builds_service(
+    session: SessionDep,
+    settings: SettingsDep,
+) -> BuildsService:
+    """Return a builds service for virtual environment lifecycle APIs."""
+
+    from apps.api.app.features.builds.service import BuildsService
+    from apps.api.app.features.configs.storage import ConfigStorage
+
+    if settings.configs_dir is None:
+        raise RuntimeError("ADE_CONFIGS_DIR is not configured")
+
+    module_root = FilePath(__file__).resolve().parents[1]
+    templates_root = module_root / "templates" / "config_packages"
+    storage = ConfigStorage(
+        templates_root=templates_root,
+        configs_root=settings.configs_dir,
+    )
+    return BuildsService(session=session, settings=settings, storage=storage)
 
 
 _bearer_scheme = HTTPBearer(auto_error=False)

--- a/apps/api/migrations/versions/0004_configuration_builds_table.py
+++ b/apps/api/migrations/versions/0004_configuration_builds_table.py
@@ -1,0 +1,70 @@
+"""Create configuration_builds table for virtual environment tracking."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0004_configuration_builds_table"
+down_revision = "0003_configuration_digest_and_active_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "configuration_builds",
+        sa.Column("workspace_id", sa.String(length=26), nullable=False),
+        sa.Column("config_id", sa.String(length=26), nullable=False),
+        sa.Column("build_id", sa.String(length=26), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("venv_path", sa.Text(), nullable=False),
+        sa.Column("config_version", sa.Integer(), nullable=True),
+        sa.Column("content_digest", sa.String(length=128), nullable=True),
+        sa.Column("engine_version", sa.String(length=50), nullable=True),
+        sa.Column("engine_spec", sa.String(length=255), nullable=True),
+        sa.Column("python_version", sa.String(length=50), nullable=True),
+        sa.Column("python_interpreter", sa.String(length=255), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("built_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("workspace_id", "config_id", "build_id"),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"], ["workspaces.workspace_id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id", "config_id"],
+            ["configurations.workspace_id", "configurations.config_id"],
+            ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            "status in ('building','active','inactive','failed')",
+            name="configuration_builds_status_check",
+        ),
+    )
+    op.create_index(
+        "configuration_builds_active_idx",
+        "configuration_builds",
+        ["workspace_id", "config_id"],
+        unique=True,
+        sqlite_where=sa.text("status = 'active'"),
+        postgresql_where=sa.text("status = 'active'"),
+    )
+    op.create_index(
+        "configuration_builds_building_idx",
+        "configuration_builds",
+        ["workspace_id", "config_id"],
+        unique=True,
+        sqlite_where=sa.text("status = 'building'"),
+        postgresql_where=sa.text("status = 'building'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("configuration_builds_building_idx", table_name="configuration_builds")
+    op.drop_index("configuration_builds_active_idx", table_name="configuration_builds")
+    op.drop_table("configuration_builds")

--- a/apps/api/tests/unit/features/builds/test_service.py
+++ b/apps/api/tests/unit/features/builds/test_service.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from apps.api.app.features.builds.builder import BuildArtifacts
+from apps.api.app.features.builds.exceptions import BuildAlreadyInProgressError
+from apps.api.app.features.builds.models import BuildStatus, ConfigurationBuild
+from apps.api.app.features.builds.service import BuildEnsureMode, BuildsService
+from apps.api.app.features.configs.models import Configuration
+from apps.api.app.features.configs.storage import ConfigStorage
+from apps.api.app.features.workspaces.models import Workspace
+from apps.api.app.settings import Settings
+from apps.api.app.shared.core.time import utc_now
+from apps.api.app.shared.db import Base
+from apps.api.app.shared.db.mixins import generate_ulid
+
+
+@dataclass
+class BuilderCall:
+    build_id: str
+    workspace_id: str
+    config_id: str
+    target_path: Path
+
+
+class FakeBuilder:
+    """Test double for ``VirtualEnvironmentBuilder`` that avoids pip installs."""
+
+    def __init__(self, *, engine_version: str = "0.1.0", python_version: str = "3.12.1") -> None:
+        self.engine_version = engine_version
+        self.python_version = python_version
+        self.calls: list[BuilderCall] = []
+
+    async def build(
+        self,
+        *,
+        build_id: str,
+        workspace_id: str,
+        config_id: str,
+        target_path: Path,
+        config_path: Path,
+        engine_spec: str,
+        pip_cache_dir: Path | None,
+        python_bin: str | None,
+        timeout: float,
+    ) -> BuildArtifacts:
+        target_path.mkdir(parents=True, exist_ok=True)
+        self.calls.append(
+            BuilderCall(
+                build_id=build_id,
+                workspace_id=workspace_id,
+                config_id=config_id,
+                target_path=target_path,
+            )
+        )
+        return BuildArtifacts(
+            python_version=self.python_version,
+            engine_version=self.engine_version,
+        )
+
+
+class TimeStub:
+    """Mutable callable returning deterministic timestamps for the service."""
+
+    def __init__(self, initial: datetime | None = None) -> None:
+        self.current = initial or datetime.now(tz=UTC)
+
+    def advance(self, delta: timedelta) -> None:
+        self.current += delta
+
+    def __call__(self) -> datetime:
+        return self.current
+
+
+@pytest.fixture()
+async def session() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture()
+def service_factory(tmp_path: Path) -> Callable[[AsyncSession, dict[str, Any], FakeBuilder, Callable[[], datetime]], BuildsService]:
+    def _factory(
+        session: AsyncSession,
+        overrides: dict[str, Any] | None = None,
+        builder: FakeBuilder | None = None,
+        now: Callable[[], datetime] = utc_now,
+    ) -> BuildsService:
+        base_settings = Settings()
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir(parents=True, exist_ok=True)
+        (engine_dir / "pyproject.toml").write_text(
+            """
+[project]
+name = "ade-engine"
+version = "0.1.0"
+""".strip(),
+            encoding="utf-8",
+        )
+        configs_dir = tmp_path / "configs"
+        venvs_dir = tmp_path / "venvs"
+        pip_cache_dir = tmp_path / "pip-cache"
+        overrides = overrides or {}
+        settings = base_settings.model_copy(
+            update={
+                "configs_dir": configs_dir,
+                "venvs_dir": venvs_dir,
+                "pip_cache_dir": pip_cache_dir,
+                "engine_spec": str(engine_dir),
+                **overrides,
+            }
+        )
+        (tmp_path / "templates").mkdir(parents=True, exist_ok=True)
+        storage = ConfigStorage(
+            templates_root=tmp_path / "templates",
+            configs_root=settings.configs_dir,
+        )
+        builder = builder or FakeBuilder()
+        return BuildsService(
+            session=session,
+            settings=settings,
+            storage=storage,
+            builder=builder,
+            now=now,
+        )
+
+    return _factory
+
+
+async def _prepare_configuration(
+    session: AsyncSession,
+    *,
+    workspace_id: str | None = None,
+    config_id: str | None = None,
+    status: str = "active",
+    config_version: int = 1,
+    content_digest: str | None = "digest",
+) -> tuple[str, str]:
+    workspace = Workspace(name="Acme", slug=f"acme-{generate_ulid().lower()}")
+    session.add(workspace)
+    await session.flush()
+    workspace_id = workspace.id if workspace_id is None else workspace_id
+    config = Configuration(
+        workspace_id=workspace_id,
+        config_id=config_id or generate_ulid(),
+        display_name="Config",
+        status=status,
+        config_version=config_version,
+        content_digest=content_digest,
+    )
+    session.add(config)
+    await session.flush()
+    return workspace_id, config.config_id
+
+
+async def _ensure_config_path(root: Path, workspace_id: str, config_id: str) -> Path:
+    config_path = root / workspace_id / "config_packages" / config_id
+    config_path.mkdir(parents=True, exist_ok=True)
+    return config_path
+
+
+@pytest.mark.asyncio()
+async def test_ensure_build_creates_new_build(session: AsyncSession, tmp_path: Path, service_factory) -> None:
+    workspace_id, config_id = await _prepare_configuration(session)
+    await _ensure_config_path(tmp_path / "configs", workspace_id, config_id)
+
+    builder = FakeBuilder(engine_version="1.0.0", python_version="3.12.0")
+    service = service_factory(
+        session,
+        builder=builder,
+        now=utc_now,
+    )
+
+    result = await service.ensure_build(
+        workspace_id=workspace_id,
+        config_id=config_id,
+    )
+
+    assert result.status is BuildStatus.ACTIVE
+    assert result.just_built is True
+    assert result.build is not None
+    assert result.build.engine_version == "1.0.0"
+    assert result.build.python_version == "3.12.0"
+    assert builder.calls and builder.calls[0].build_id == result.build.build_id
+
+
+@pytest.mark.asyncio()
+async def test_ensure_build_reuses_active(session: AsyncSession, tmp_path: Path, service_factory) -> None:
+    workspace_id, config_id = await _prepare_configuration(session)
+    await _ensure_config_path(tmp_path / "configs", workspace_id, config_id)
+
+    builder = FakeBuilder()
+    service = service_factory(session, builder=builder)
+
+    first = await service.ensure_build(workspace_id=workspace_id, config_id=config_id)
+    assert first.just_built is True
+    assert len(builder.calls) == 1
+
+    second = await service.ensure_build(workspace_id=workspace_id, config_id=config_id)
+    assert second.just_built is False
+    assert second.build is not None
+    assert second.build.build_id == first.build.build_id
+    assert len(builder.calls) == 1
+
+
+@pytest.mark.asyncio()
+async def test_ensure_build_honours_ttl(session: AsyncSession, tmp_path: Path, service_factory) -> None:
+    workspace_id, config_id = await _prepare_configuration(session)
+    await _ensure_config_path(tmp_path / "configs", workspace_id, config_id)
+
+    clock = TimeStub(datetime(2024, 1, 1, tzinfo=UTC))
+    builder = FakeBuilder()
+    service = service_factory(
+        session,
+        overrides={"build_ttl": timedelta(seconds=30)},
+        builder=builder,
+        now=clock,
+    )
+
+    first = await service.ensure_build(workspace_id=workspace_id, config_id=config_id)
+    assert first.just_built is True
+    clock.advance(timedelta(seconds=31))
+
+    second = await service.ensure_build(workspace_id=workspace_id, config_id=config_id)
+    assert second.just_built is True
+    assert len(builder.calls) == 2
+
+
+@pytest.mark.asyncio()
+async def test_ensure_build_returns_building_when_in_progress(
+    session: AsyncSession, tmp_path: Path, service_factory
+) -> None:
+    workspace_id, config_id = await _prepare_configuration(session)
+    await _ensure_config_path(tmp_path / "configs", workspace_id, config_id)
+
+    building = ConfigurationBuild(
+        workspace_id=workspace_id,
+        config_id=config_id,
+        build_id=generate_ulid(),
+        status=BuildStatus.BUILDING.value,
+        venv_path=str(tmp_path / "venvs" / workspace_id / config_id / "build"),
+        config_version=1,
+        content_digest="digest",
+        engine_spec="spec",
+        engine_version="0.1.0",
+        python_interpreter=str(Path(sys.executable).resolve()),
+        started_at=datetime.now(tz=UTC),
+    )
+    session.add(building)
+    await session.commit()
+
+    service = service_factory(session)
+    result = await service.ensure_build(
+        workspace_id=workspace_id,
+        config_id=config_id,
+        mode=BuildEnsureMode.INTERACTIVE,
+    )
+    assert result.status is BuildStatus.BUILDING
+    assert result.build is None
+
+
+@pytest.mark.asyncio()
+async def test_ensure_build_blocks_and_times_out(session: AsyncSession, tmp_path: Path, service_factory) -> None:
+    workspace_id, config_id = await _prepare_configuration(session)
+    await _ensure_config_path(tmp_path / "configs", workspace_id, config_id)
+
+    building = ConfigurationBuild(
+        workspace_id=workspace_id,
+        config_id=config_id,
+        build_id=generate_ulid(),
+        status=BuildStatus.BUILDING.value,
+        venv_path=str(tmp_path / "venvs" / workspace_id / config_id / "build"),
+        config_version=1,
+        content_digest="digest",
+        engine_spec="spec",
+        engine_version="0.1.0",
+        python_interpreter=str(Path(sys.executable).resolve()),
+        started_at=datetime.now(tz=UTC),
+    )
+    session.add(building)
+    await session.commit()
+
+    service = service_factory(
+        session,
+        overrides={"build_ensure_wait": timedelta(seconds=0)},
+    )
+
+    with pytest.raises(BuildAlreadyInProgressError):
+        await service.ensure_build(
+            workspace_id=workspace_id,
+            config_id=config_id,
+            mode=BuildEnsureMode.BLOCKING,
+        )
+
+
+@pytest.mark.asyncio()
+async def test_delete_active_build_removes_row_and_directory(
+    session: AsyncSession, tmp_path: Path, service_factory
+) -> None:
+    workspace_id, config_id = await _prepare_configuration(session)
+    config_root = tmp_path / "configs"
+    await _ensure_config_path(config_root, workspace_id, config_id)
+
+    builder = FakeBuilder()
+    service = service_factory(session, builder=builder)
+
+    result = await service.ensure_build(workspace_id=workspace_id, config_id=config_id)
+    assert result.build is not None
+    venv_path = Path(result.build.venv_path)
+    assert venv_path.exists()
+
+    await service.delete_active_build(workspace_id=workspace_id, config_id=config_id)
+    lookup = await session.get(
+        ConfigurationBuild,
+        (workspace_id, config_id, result.build.build_id),
+    )
+    assert lookup is None
+    assert not venv_path.exists()


### PR DESCRIPTION
## Summary
- add a builds feature module with services, repository, and router for managing configuration virtual environments
- extend application settings and database schema to support build metadata and retention policies
- add unit tests that cover the ensure-build lifecycle behaviour

## Testing
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691298d2f014832e8db37e09facc2897)