### PR TITLE
Add fifth architecture hindsight reflection to WP11 plan

### DIFF
--- a/apps/api/app/features/jobs/router.py
+++ b/apps/api/app/features/jobs/router.py
@@ -1,7 +1,122 @@
-"""Jobs router placeholder."""
+"""Jobs router providing submission and retrieval endpoints."""
 
-from fastapi import APIRouter
+from __future__ import annotations
 
-router = APIRouter(prefix="/jobs", tags=["jobs"])
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Security,
+    status,
+)
+
+from apps.api.app.features.jobs.models import JobStatus
+from apps.api.app.features.jobs.schemas import JobRecord, JobSubmissionRequest
+from apps.api.app.features.jobs.service import (
+    JobConfigurationMissingError,
+    JobDocumentMissingError,
+    JobsService,
+)
+from apps.api.app.features.users.models import User
+from apps.api.app.shared.dependency import (
+    get_jobs_service,
+    require_authenticated,
+    require_csrf,
+    require_workspace,
+)
+
+
+router = APIRouter(
+    prefix="/workspaces/{workspace_id}",
+    tags=["jobs"],
+    dependencies=[Security(require_authenticated)],
+)
+
+jobs_service_dependency = Depends(get_jobs_service)
+
+
+@router.post(
+    "/jobs",
+    response_model=JobRecord,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Security(require_csrf)],
+)
+async def submit_job_endpoint(
+    workspace_id: Annotated[str, Path(min_length=1, description="Workspace identifier")],
+    payload: JobSubmissionRequest,
+    service: JobsService = jobs_service_dependency,
+    actor: Annotated[
+        User | None,
+        Security(
+            require_workspace("Workspace.Jobs.ReadWrite"),
+            scopes=["{workspace_id}"],
+        ),
+    ] = None,
+) -> JobRecord:
+    try:
+        return await service.submit_job(
+            workspace_id=workspace_id,
+            payload=payload,
+            actor=actor,
+        )
+    except JobDocumentMissingError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except JobConfigurationMissingError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.get("/jobs", response_model=list[JobRecord])
+async def list_jobs_endpoint(
+    workspace_id: Annotated[str, Path(min_length=1, description="Workspace identifier")],
+    service: JobsService = jobs_service_dependency,
+    status_filter: Annotated[str | None, Query(alias="status")] = None,
+    input_document_id: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    _actor: Annotated[
+        User | None,
+        Security(
+            require_workspace("Workspace.Jobs.Read"),
+            scopes=["{workspace_id}"],
+        ),
+    ] = None,
+) -> list[JobRecord]:
+    job_status: JobStatus | None = None
+    if status_filter:
+        try:
+            job_status = JobStatus(status_filter)
+        except ValueError as exc:  # pragma: no cover - FastAPI handles validation
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return await service.list_jobs(
+        workspace_id=workspace_id,
+        status=job_status,
+        input_document_id=input_document_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/jobs/{job_id}", response_model=JobRecord)
+async def read_job_endpoint(
+    workspace_id: Annotated[str, Path(min_length=1, description="Workspace identifier")],
+    job_id: Annotated[str, Path(min_length=1, description="Job identifier")],
+    service: JobsService = jobs_service_dependency,
+    _actor: Annotated[
+        User | None,
+        Security(
+            require_workspace("Workspace.Jobs.Read"),
+            scopes=["{workspace_id}"],
+        ),
+    ] = None,
+) -> JobRecord:
+    job = await service.get_job(workspace_id=workspace_id, job_id=job_id)
+    if job is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
 
 __all__ = ["router"]

--- a/apps/api/app/features/jobs/schemas.py
+++ b/apps/api/app/features/jobs/schemas.py
@@ -2,8 +2,83 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
+
+from pydantic import Field
+
+from apps.api.app.features.runs.schemas import RunCreateOptions
+from apps.api.app.shared.core.ids import ULIDStr
+from apps.api.app.shared.core.schema import BaseSchema
 
 JobStatusLiteral = Literal["queued", "running", "succeeded", "failed", "cancelled"]
 
-__all__ = ["JobStatusLiteral"]
+
+class JobSubmissionRequest(BaseSchema):
+    """Payload accepted when enqueuing a new job."""
+
+    input_document_id: ULIDStr = Field(description="Document ULID to process.")
+    config_version_id: str = Field(description="Configuration version identifier.")
+    options: RunCreateOptions = Field(default_factory=RunCreateOptions)
+
+
+class JobInputDocument(BaseSchema):
+    """Minimal representation of a document attached to a job."""
+
+    document_id: ULIDStr
+    display_name: str | None = None
+    name: str | None = None
+    original_filename: str | None = None
+    content_type: str | None = None
+    byte_size: int | None = None
+
+
+class JobConfigVersion(BaseSchema):
+    """Descriptor for the configuration version used by a job."""
+
+    config_version_id: str
+    title: str | None = None
+    semver: str | None = None
+
+
+class JobSubmittedBy(BaseSchema):
+    """Subset of user fields for the submitting actor."""
+
+    id: ULIDStr
+    display_name: str | None = None
+    email: str | None = None
+
+
+class JobRecord(BaseSchema):
+    """API representation of a persisted job."""
+
+    id: ULIDStr
+    workspace_id: ULIDStr
+    config_id: ULIDStr
+    config_version_id: str
+    status: JobStatusLiteral
+    queued_at: datetime
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    cancelled_at: datetime | None = None
+    updated_at: datetime
+    input_documents: list[JobInputDocument] = Field(default_factory=list)
+    config_title: str | None = None
+    config_version: JobConfigVersion | None = None
+    submitted_by_user: JobSubmittedBy | None = None
+    submitted_by: str | None = None
+    error_message: str | None = None
+    summary: str | None = None
+    artifact_uri: str | None = None
+    logs_uri: str | None = None
+    output_uri: str | None = None
+
+
+__all__ = [
+    "JobConfigVersion",
+    "JobInputDocument",
+    "JobRecord",
+    "JobStatusLiteral",
+    "JobSubmissionRequest",
+    "JobSubmittedBy",
+]

--- a/apps/api/app/features/jobs/service.py
+++ b/apps/api/app/features/jobs/service.py
@@ -1,10 +1,315 @@
-"""Jobs service placeholder."""
+"""Job orchestration service coordinating storage and run execution."""
 
-class JobsService:  # pragma: no cover - stub
-    """Placeholder service for job orchestration."""
+from __future__ import annotations
 
-    def __init__(self) -> None:
-        raise NotImplementedError
+import asyncio
+import shutil
+from dataclasses import replace
+from pathlib import Path
+from typing import Iterable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api.app.features.configs.models import Configuration
+from apps.api.app.features.configs.repository import ConfigurationsRepository
+from apps.api.app.features.documents.models import Document
+from apps.api.app.features.documents.repository import DocumentsRepository
+from apps.api.app.features.documents.storage import DocumentStorage
+from apps.api.app.features.jobs.models import Job, JobStatus
+from apps.api.app.features.jobs.repository import JobsRepository
+from apps.api.app.features.jobs.schemas import (
+    JobConfigVersion,
+    JobInputDocument,
+    JobRecord,
+    JobSubmissionRequest,
+    JobSubmittedBy,
+)
+from apps.api.app.features.runs.models import RunStatus
+from apps.api.app.features.runs.service import RunExecutionContext, RunsService
+from apps.api.app.features.users.models import User
+from apps.api.app.settings import Settings
+from apps.api.app.shared.core.ids import generate_ulid
+from apps.api.app.shared.core.time import utc_now
 
 
-__all__ = ["JobsService"]
+class JobSubmissionError(RuntimeError):
+    """Base error raised during job submission."""
+
+
+class JobDocumentMissingError(JobSubmissionError):
+    """Raised when the referenced document cannot be located."""
+
+
+class JobConfigurationMissingError(JobSubmissionError):
+    """Raised when the referenced configuration cannot be found."""
+
+
+class JobsService:
+    """Coordinate workspace job submissions and historical lookups."""
+
+    def __init__(
+        self,
+        *,
+        session: AsyncSession,
+        settings: Settings,
+        runs_service: RunsService | None = None,
+    ) -> None:
+        self._session = session
+        self._settings = settings
+        self._jobs = JobsRepository(session)
+        self._documents = DocumentsRepository(session)
+        self._configs = ConfigurationsRepository(session)
+        self._runs = runs_service or RunsService(session=session, settings=settings)
+
+        if settings.documents_dir is None:
+            raise RuntimeError("ADE_DOCUMENTS_DIR is not configured")
+        if settings.jobs_dir is None:
+            raise RuntimeError("ADE_JOBS_DIR is not configured")
+        self._documents_dir = settings.documents_dir
+        self._jobs_dir = settings.jobs_dir
+        self._storage = DocumentStorage(self._documents_dir)
+
+    async def submit_job(
+        self,
+        *,
+        workspace_id: str,
+        payload: JobSubmissionRequest,
+        actor: User | None = None,
+    ) -> JobRecord:
+        """Create a job, execute it, and return the resulting record."""
+
+        document = await self._require_document(
+            workspace_id=workspace_id,
+            document_id=payload.input_document_id,
+        )
+        configuration = await self._require_configuration(
+            workspace_id=workspace_id,
+            config_version_id=payload.config_version_id,
+        )
+
+        job_id = generate_ulid()
+        run, context = await self._runs.prepare_run(
+            config_id=configuration.config_id,
+            options=payload.options,
+            job_id=job_id,
+            jobs_dir=self._jobs_dir,
+        )
+        context = self._ensure_job_context(context, job_id)
+
+        job_dir = self._jobs_dir / job_id
+        input_dir = job_dir / "input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+
+        await self._copy_document(document, input_dir)
+
+        now = utc_now()
+        job = Job(
+            id=job_id,
+            workspace_id=workspace_id,
+            config_id=configuration.config_id,
+            config_version_id=payload.config_version_id,
+            submitted_by_user_id=getattr(actor, "id", None),
+            status=JobStatus.RUNNING,
+            queued_at=now,
+            started_at=now,
+            input_documents=[self._document_descriptor(document)],
+            trace_id=run.id,
+            run_request_uri=f"/api/v1/runs/{run.id}",
+        )
+        self._session.add(job)
+        await self._session.flush()
+
+        await self._session.refresh(job)
+
+        document.last_run_at = now
+        await self._session.flush()
+
+        try:
+            await self._runs.run_to_completion(context=context, options=payload.options)
+        except Exception as exc:  # pragma: no cover - defensive
+            await self._mark_job_failure(job, str(exc))
+            raise
+
+        await self._finalize_job(job, configuration, job_dir)
+        await self._session.commit()
+        await self._session.refresh(job)
+        return self._to_record(job, configuration)
+
+    async def list_jobs(
+        self,
+        *,
+        workspace_id: str,
+        status: JobStatus | None = None,
+        input_document_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[JobRecord]:
+        """Return job records for ``workspace_id``."""
+
+        jobs = await self._jobs.list_jobs(
+            workspace_id=workspace_id,
+            status=status,
+            input_document_id=input_document_id,
+            limit=limit,
+            offset=offset,
+        )
+        config_map = await self._configuration_map(workspace_id, [job.config_id for job in jobs])
+        return [self._to_record(job, config_map.get(job.config_id)) for job in jobs]
+
+    async def get_job(self, *, workspace_id: str, job_id: str) -> JobRecord | None:
+        """Return a single job record when available."""
+
+        job = await self._jobs.get_job(workspace_id=workspace_id, job_id=job_id)
+        if job is None:
+            return None
+        configuration = await self._configs.get(
+            workspace_id=workspace_id,
+            config_id=job.config_id,
+        )
+        return self._to_record(job, configuration)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    async def _require_document(self, *, workspace_id: str, document_id: str) -> Document:
+        document = await self._documents.get_document(
+            workspace_id=workspace_id,
+            document_id=document_id,
+        )
+        if document is None:
+            raise JobDocumentMissingError(f"Document {document_id} not found")
+        return document
+
+    async def _require_configuration(
+        self,
+        *,
+        workspace_id: str,
+        config_version_id: str,
+    ) -> Configuration:
+        configuration = await self._configs.get(
+            workspace_id=workspace_id,
+            config_id=config_version_id,
+        )
+        if configuration is None:
+            raise JobConfigurationMissingError(
+                f"Configuration {config_version_id} not found"
+            )
+        return configuration
+
+    def _document_descriptor(self, document: Document) -> dict[str, object]:
+        return {
+            "document_id": document.id,
+            "display_name": document.original_filename,
+            "name": document.original_filename,
+            "original_filename": document.original_filename,
+            "content_type": document.content_type,
+            "byte_size": document.byte_size,
+        }
+
+    async def _copy_document(self, document: Document, input_dir: Path) -> None:
+        source = self._storage.path_for(document.stored_uri)
+        destination = input_dir / document.original_filename
+        await asyncio.to_thread(shutil.copy2, source, destination)
+
+    async def _finalize_job(
+        self,
+        job: Job,
+        configuration: Configuration,
+        job_dir: Path,
+    ) -> None:
+        run = await self._runs.get_run(job.trace_id or "")
+        if run is not None:
+            job.error_message = run.error_message
+            job.completed_at = run.finished_at or utc_now()
+            job.started_at = job.started_at or run.started_at
+            status_map = {
+                RunStatus.SUCCEEDED: JobStatus.SUCCEEDED,
+                RunStatus.FAILED: JobStatus.FAILED,
+                RunStatus.CANCELED: JobStatus.CANCELLED,
+                RunStatus.RUNNING: JobStatus.RUNNING,
+                RunStatus.QUEUED: JobStatus.QUEUED,
+            }
+            job.status = status_map.get(run.status, JobStatus.SUCCEEDED)
+        else:
+            job.status = JobStatus.SUCCEEDED
+            job.completed_at = job.completed_at or utc_now()
+
+        job.artifact_uri = self._relative_path(job_dir / "logs" / "artifact.json")
+        job.logs_uri = self._relative_path(job_dir / "logs" / "events.ndjson")
+        job.output_uri = self._relative_path(job_dir / "output")
+
+    async def _mark_job_failure(self, job: Job, message: str) -> None:
+        job.status = JobStatus.FAILED
+        job.error_message = message
+        job.completed_at = utc_now()
+        await self._session.flush()
+
+    def _relative_path(self, path: Path) -> str:
+        try:
+            return str(path.relative_to(self._jobs_dir))
+        except ValueError:  # pragma: no cover - defensive
+            return str(path)
+
+    async def _configuration_map(
+        self,
+        workspace_id: str,
+        config_ids: Iterable[str],
+    ) -> dict[str, Configuration]:
+        unique_ids = list(dict.fromkeys(config_ids))
+        if not unique_ids:
+            return {}
+        records = await self._configs.list_for_workspace(workspace_id)
+        return {record.config_id: record for record in records if record.config_id in unique_ids}
+
+    def _ensure_job_context(
+        self,
+        context: RunExecutionContext,
+        job_id: str,
+    ) -> RunExecutionContext:
+        if context.job_id == job_id and context.jobs_dir:
+            return context
+        return replace(context, job_id=job_id, jobs_dir=str(self._jobs_dir))
+
+    def _to_record(
+        self,
+        job: Job,
+        configuration: Configuration | None,
+    ) -> JobRecord:
+        submitted = (
+            JobSubmittedBy(
+                id=job.submitted_by_user.id,
+                display_name=job.submitted_by_user.display_name,
+                email=job.submitted_by_user.email,
+            )
+            if job.submitted_by_user is not None
+            else None
+        )
+
+        documents = [JobInputDocument.model_validate(doc) for doc in job.input_documents or []]
+        config_version = JobConfigVersion(config_version_id=job.config_version_id)
+        config_title = configuration.display_name if configuration is not None else None
+
+        return JobRecord(
+            id=job.id,
+            workspace_id=job.workspace_id,
+            config_id=job.config_id,
+            config_version_id=job.config_version_id,
+            status=job.status.value,  # type: ignore[arg-type]
+            queued_at=job.queued_at,
+            started_at=job.started_at,
+            completed_at=job.completed_at,
+            cancelled_at=job.cancelled_at,
+            updated_at=job.updated_at,
+            input_documents=documents,
+            config_title=config_title,
+            config_version=config_version,
+            submitted_by_user=submitted,
+            submitted_by=submitted.display_name if submitted else None,
+            error_message=job.error_message,
+            artifact_uri=job.artifact_uri,
+            logs_uri=job.logs_uri,
+            output_uri=job.output_uri,
+        )
+
+
+__all__ = ["JobsService", "JobDocumentMissingError", "JobConfigurationMissingError"]

--- a/apps/api/app/features/runs/router.py
+++ b/apps/api/app/features/runs/router.py
@@ -27,12 +27,15 @@ from apps.api.app.shared.dependency import (
     require_csrf,
 )
 
+from ade_schemas import TelemetryEnvelope
+
 from .schemas import RunCreateOptions, RunCreateRequest, RunEvent, RunLogsResponse, RunResource
 from .service import (
     DEFAULT_STREAM_LIMIT,
     RunEnvironmentNotReadyError,
     RunExecutionContext,
     RunNotFoundError,
+    RunStreamFrame,
     RunsService,
 )
 
@@ -44,7 +47,9 @@ runs_service_dependency = Depends(get_runs_service)
 logger = logging.getLogger(__name__)
 
 
-def _event_bytes(event: RunEvent) -> bytes:
+def _event_bytes(event: RunStreamFrame) -> bytes:
+    if isinstance(event, TelemetryEnvelope):
+        return event.model_dump_json().encode("utf-8") + b"\n"
     return event.json_bytes() + b"\n"
 
 

--- a/apps/api/app/features/runs/runner.py
+++ b/apps/api/app/features/runs/runner.py
@@ -1,0 +1,126 @@
+"""Async ADE engine process supervisor."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import AsyncIterator, Literal
+
+from ade_schemas import TelemetryEnvelope
+from pydantic import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class StdoutFrame:
+    """Single stdout line emitted by the ADE engine process."""
+
+    message: str
+    stream: Literal["stdout", "stderr"] = "stdout"
+
+
+RunnerFrame = StdoutFrame | TelemetryEnvelope
+
+
+class ADEProcessRunner:
+    """Spawn the ADE engine subprocess and surface streaming frames."""
+
+    def __init__(
+        self,
+        *,
+        command: list[str],
+        job_dir: Path,
+        env: dict[str, str],
+        poll_interval: float = 0.2,
+    ) -> None:
+        self._command = command
+        self._job_dir = job_dir
+        self._env = env
+        self._poll_interval = poll_interval
+        self._queue: asyncio.Queue[RunnerFrame | None] = asyncio.Queue()
+        self.returncode: int | None = None
+
+    async def stream(self) -> AsyncIterator[RunnerFrame]:
+        """Yield stdout lines and telemetry envelopes as they are produced."""
+
+        process = await asyncio.create_subprocess_exec(
+            *self._command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=self._env,
+        )
+        assert process.stdout is not None
+
+        stdout_task = asyncio.create_task(self._capture_stdout(process))
+        telemetry_task = asyncio.create_task(self._capture_telemetry(process))
+
+        completed = 0
+        try:
+            while completed < 2:
+                item = await self._queue.get()
+                if item is None:
+                    completed += 1
+                    continue
+                yield item
+        finally:
+            stdout_task.cancel()
+            telemetry_task.cancel()
+            with contextlib.suppress(Exception):
+                await stdout_task
+            with contextlib.suppress(Exception):
+                await telemetry_task
+
+        self.returncode = await process.wait()
+
+    async def _capture_stdout(self, process: asyncio.subprocess.Process) -> None:
+        assert process.stdout is not None
+        try:
+            async for raw_line in process.stdout:  # type: ignore[attr-defined]
+                text = raw_line.decode("utf-8", errors="replace").rstrip("\n")
+                if not text:
+                    continue
+                await self._queue.put(StdoutFrame(message=text))
+        finally:
+            await self._queue.put(None)
+
+    async def _capture_telemetry(self, process: asyncio.subprocess.Process) -> None:
+        events_path = self._job_dir / "logs" / "events.ndjson"
+        position = 0
+        try:
+            while True:
+                position, lines = await asyncio.to_thread(
+                    _read_new_event_lines,
+                    events_path,
+                    position,
+                )
+                for line in lines:
+                    if not line:
+                        continue
+                    try:
+                        envelope = TelemetryEnvelope.model_validate_json(line)
+                    except ValidationError as exc:
+                        logger.warning("Invalid telemetry payload", extra={"line": line, "error": str(exc)})
+                        continue
+                    await self._queue.put(envelope)
+                if process.returncode is not None and not lines:
+                    break
+                await asyncio.sleep(self._poll_interval)
+        finally:
+            await self._queue.put(None)
+
+
+def _read_new_event_lines(path: Path, position: int) -> tuple[int, list[str]]:
+    if not path.exists():
+        return position, []
+    with path.open("r", encoding="utf-8") as handle:
+        handle.seek(position)
+        data = handle.readlines()
+        position = handle.tell()
+    return position, [line.rstrip("\n") for line in data]
+
+
+__all__ = ["ADEProcessRunner", "RunnerFrame", "StdoutFrame"]

--- a/apps/api/app/features/runs/supervisor.py
+++ b/apps/api/app/features/runs/supervisor.py
@@ -1,0 +1,98 @@
+"""In-memory supervisor for asynchronous ADE run execution."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, AsyncIterator, Protocol
+
+if TYPE_CHECKING:
+    from .service import RunStreamFrame
+
+__all__ = ["RunSupervisor"]
+
+
+class _RunGenerator(Protocol):
+    async def __call__(self) -> AsyncIterator["RunStreamFrame"]:
+        ...
+
+
+@dataclass(slots=True)
+class _RunHandle:
+    queue: asyncio.Queue[object]
+    task: asyncio.Task[None]
+
+
+_COMPLETE = object()
+
+
+class RunSupervisor:
+    """Coordinate background execution for ADE runs.
+
+    The supervisor ensures the engine subprocess executes outside the request
+    scope while allowing callers to consume the run stream lazily. Each run
+    maintains a dedicated queue populated by a background task that consumes the
+    provided async generator.
+    """
+
+    def __init__(self) -> None:
+        self._handles: dict[str, _RunHandle] = {}
+        self._lock = asyncio.Lock()
+
+    async def stream(
+        self, run_id: str, *, generator: _RunGenerator
+    ) -> AsyncIterator["RunStreamFrame"]:
+        """Return an iterator for ``run_id`` backed by a background task."""
+
+        handle = await self._ensure_handle(run_id, generator)
+        try:
+            while True:
+                item = await handle.queue.get()
+                if item is _COMPLETE:
+                    break
+                if isinstance(item, Exception):
+                    raise item
+                yield item  # type: ignore[misc]
+        finally:
+            await self._finalize(run_id)
+
+    async def _ensure_handle(
+        self, run_id: str, generator: _RunGenerator
+    ) -> _RunHandle:
+        async with self._lock:
+            existing = self._handles.get(run_id)
+            if existing is not None:
+                return existing
+
+            queue: asyncio.Queue[object] = asyncio.Queue()
+            task = asyncio.create_task(self._drive(run_id, generator, queue))
+            handle = _RunHandle(queue=queue, task=task)
+            self._handles[run_id] = handle
+            return handle
+
+    async def _drive(
+        self,
+        run_id: str,
+        generator_factory: _RunGenerator,
+        queue: asyncio.Queue[object],
+    ) -> None:
+        try:
+            async for frame in generator_factory():
+                await queue.put(frame)
+        except Exception as exc:  # pragma: no cover - surfaced to consumers
+            await queue.put(exc)
+        finally:
+            await queue.put(_COMPLETE)
+
+    async def _finalize(self, run_id: str) -> None:
+        handle = self._handles.pop(run_id, None)
+        if handle is None:
+            return
+        handle.task.cancel()
+        try:
+            await asyncio.shield(handle.task)
+        except Exception:
+            # Exceptions are surfaced to consumers via the queue; suppressing
+            # here prevents duplicate propagation while still allowing the
+            # caller's ``async for`` to react accordingly.
+            pass

--- a/apps/api/app/openapi.json
+++ b/apps/api/app/openapi.json
@@ -5448,6 +5448,280 @@
           }
         }
       }
+    },
+    "/api/v1/workspaces/{workspace_id}/jobs": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Submit Job Endpoint",
+        "operationId": "submit_job_endpoint_api_v1_workspaces__workspace_id__jobs_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "SessionCookie": []
+          },
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "SessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Workspace identifier",
+              "title": "Workspace Id"
+            },
+            "description": "Workspace identifier"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobSubmissionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRecord"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "List Jobs Endpoint",
+        "operationId": "list_jobs_endpoint_api_v1_workspaces__workspace_id__jobs_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "SessionCookie": []
+          },
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "SessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Workspace identifier",
+              "title": "Workspace Id"
+            },
+            "description": "Workspace identifier"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "input_document_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Input Document Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JobRecord"
+                  },
+                  "title": "Response List Jobs Endpoint Api V1 Workspaces  Workspace Id  Jobs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspace_id}/jobs/{job_id}": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Read Job Endpoint",
+        "operationId": "read_job_endpoint_api_v1_workspaces__workspace_id__jobs__job_id__get",
+        "security": [
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "SessionCookie": []
+          },
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "SessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Workspace identifier",
+              "title": "Workspace Id"
+            },
+            "description": "Workspace identifier"
+          },
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Job identifier",
+              "title": "Job Id"
+            },
+            "description": "Job identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRecord"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -7148,6 +7422,392 @@
         ],
         "title": "HealthComponentStatus",
         "description": "Represents the health of an individual system component."
+      },
+      "JobConfigVersion": {
+        "properties": {
+          "config_version_id": {
+            "type": "string",
+            "title": "Config Version Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "semver": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Semver"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "config_version_id"
+        ],
+        "title": "JobConfigVersion",
+        "description": "Descriptor for the configuration version used by a job."
+      },
+      "JobInputDocument": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "[0-9A-HJKMNP-TV-Z]{26}",
+            "title": "Document Id",
+            "description": "ULID (26-character string)."
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "original_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Filename"
+          },
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type"
+          },
+          "byte_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Byte Size"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "document_id"
+        ],
+        "title": "JobInputDocument",
+        "description": "Minimal representation of a document attached to a job."
+      },
+      "JobRecord": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "[0-9A-HJKMNP-TV-Z]{26}",
+            "title": "Id",
+            "description": "ULID (26-character string)."
+          },
+          "workspace_id": {
+            "type": "string",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "[0-9A-HJKMNP-TV-Z]{26}",
+            "title": "Workspace Id",
+            "description": "ULID (26-character string)."
+          },
+          "config_id": {
+            "type": "string",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "[0-9A-HJKMNP-TV-Z]{26}",
+            "title": "Config Id",
+            "description": "ULID (26-character string)."
+          },
+          "config_version_id": {
+            "type": "string",
+            "title": "Config Version Id"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "running",
+              "succeeded",
+              "failed",
+              "cancelled"
+            ],
+            "title": "Status"
+          },
+          "queued_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Queued At"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "cancelled_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cancelled At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "input_documents": {
+            "items": {
+              "$ref": "#/components/schemas/JobInputDocument"
+            },
+            "type": "array",
+            "title": "Input Documents"
+          },
+          "config_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Config Title"
+          },
+          "config_version": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/JobConfigVersion"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "submitted_by_user": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/JobSubmittedBy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "submitted_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Submitted By"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
+          "artifact_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artifact Uri"
+          },
+          "logs_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logs Uri"
+          },
+          "output_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Uri"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "workspace_id",
+          "config_id",
+          "config_version_id",
+          "status",
+          "queued_at",
+          "updated_at"
+        ],
+        "title": "JobRecord",
+        "description": "API representation of a persisted job."
+      },
+      "JobSubmissionRequest": {
+        "properties": {
+          "input_document_id": {
+            "type": "string",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "[0-9A-HJKMNP-TV-Z]{26}",
+            "title": "Input Document Id",
+            "description": "Document ULID to process."
+          },
+          "config_version_id": {
+            "type": "string",
+            "title": "Config Version Id",
+            "description": "Configuration version identifier."
+          },
+          "options": {
+            "$ref": "#/components/schemas/RunCreateOptions"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "input_document_id",
+          "config_version_id"
+        ],
+        "title": "JobSubmissionRequest",
+        "description": "Payload accepted when enqueuing a new job."
+      },
+      "JobSubmittedBy": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "[0-9A-HJKMNP-TV-Z]{26}",
+            "title": "Id",
+            "description": "ULID (26-character string)."
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "JobSubmittedBy",
+        "description": "Subset of user fields for the submitting actor."
       },
       "LoginRequest": {
         "properties": {

--- a/apps/api/app/routers.py
+++ b/apps/api/app/routers.py
@@ -10,6 +10,7 @@ from .features.builds.router import router as builds_router
 from .features.configs.router import router as configs_router
 from .features.documents.router import router as documents_router
 from .features.health.router import router as health_router
+from .features.jobs.router import router as jobs_router
 from .features.roles.router import router as roles_router
 from .features.runs.router import router as runs_router
 from .features.users.router import router as users_router
@@ -26,5 +27,6 @@ api_router.include_router(documents_router)
 api_router.include_router(configs_router)
 api_router.include_router(builds_router)
 api_router.include_router(runs_router)
+api_router.include_router(jobs_router)
 
 __all__ = ["api_router"]

--- a/apps/api/app/shared/dependency.py
+++ b/apps/api/app/shared/dependency.py
@@ -11,6 +11,7 @@ from apps.api.app.features.auth.service import AuthenticatedIdentity, AuthServic
 from apps.api.app.features.roles.authorization import authorize
 from apps.api.app.features.roles.models import ScopeType
 from apps.api.app.features.roles.service import ensure_user_principal
+from apps.api.app.features.runs.supervisor import RunSupervisor
 from apps.api.app.features.users.models import User
 from apps.api.app.features.workspaces.schemas import WorkspaceOut
 from apps.api.app.settings import Settings, get_settings
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
     from apps.api.app.features.configs.service import ConfigurationsService
     from apps.api.app.features.documents.service import DocumentsService
     from apps.api.app.features.health.service import HealthService
+    from apps.api.app.features.jobs.service import JobsService
     from apps.api.app.features.runs.service import RunsService
     from apps.api.app.features.system_settings.service import SystemSettingsService
     from apps.api.app.features.users.service import UsersService
@@ -41,6 +43,8 @@ if TYPE_CHECKING:
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+_RUN_SUPERVISOR = RunSupervisor()
 
 
 def get_users_service(session: SessionDep) -> UsersService:
@@ -128,7 +132,22 @@ def get_runs_service(
 
     from apps.api.app.features.runs.service import RunsService
 
-    return RunsService(session=session, settings=settings)
+    return RunsService(
+        session=session,
+        settings=settings,
+        supervisor=_RUN_SUPERVISOR,
+    )
+
+
+def get_jobs_service(
+    session: SessionDep,
+    settings: SettingsDep,
+) -> "JobsService":
+    """Return a jobs service configured for the current request."""
+
+    from apps.api.app.features.jobs.service import JobsService
+
+    return JobsService(session=session, settings=settings)
 
 
 _bearer_scheme = HTTPBearer(auto_error=False)

--- a/apps/api/conftest.py
+++ b/apps/api/conftest.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, cast
 from uuid import uuid4
+import sys
 
 import pytest
 import pytest_asyncio
@@ -16,6 +18,9 @@ from alembic.config import Config
 from fastapi import FastAPI
 from asgi_lifespan import LifespanManager
 from httpx import ASGITransport, AsyncClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "packages" / "ade-schemas" / "src"))
 
 from apps.api.app.settings import Settings, get_settings, reload_settings
 from apps.api.app.shared.db.engine import ensure_database_ready, render_sync_url, reset_database_state

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "email-validator==2.1.0.post1",
   "openpyxl==3.1.5",
   "greenlet @ git+https://github.com/python-greenlet/greenlet.git@master",
+  { path = "../packages/ade-schemas", develop = true },
 ]
 
 [project.optional-dependencies]

--- a/apps/api/tests/unit/features/jobs/conftest.py
+++ b/apps/api/tests/unit/features/jobs/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from apps.api.app.shared.db import Base
+
+
+@pytest.fixture()
+async def session() -> AsyncSession:
+    """Provide an isolated in-memory database session for jobs unit tests."""
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as session:
+        yield session
+    await engine.dispose()

--- a/apps/api/tests/unit/features/jobs/test_jobs_service.py
+++ b/apps/api/tests/unit/features/jobs/test_jobs_service.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from apps.api.app.features.configs.models import Configuration, ConfigurationStatus
+from apps.api.app.features.documents.models import (
+    Document,
+    DocumentSource,
+    DocumentStatus,
+)
+from apps.api.app.features.jobs.models import JobStatus
+from apps.api.app.features.jobs.schemas import JobSubmissionRequest
+from apps.api.app.features.jobs.service import JobsService
+from apps.api.app.features.runs.models import RunStatus
+from apps.api.app.features.runs.service import RunExecutionContext
+from apps.api.app.features.workspaces.models import Workspace
+from apps.api.app.settings import Settings
+from apps.api.app.shared.core.ids import generate_ulid
+from apps.api.app.shared.core.time import utc_now
+
+
+class StubRunsService:
+    """Minimal stub of the runs service for JobsService tests."""
+
+    def __init__(self, jobs_dir: Path) -> None:
+        self.jobs_dir = jobs_dir
+        self.run_id = f"run_{generate_ulid()}"
+
+    async def prepare_run(self, *, config_id: str, options, job_id: str, jobs_dir: Path):
+        context = RunExecutionContext(
+            run_id=self.run_id,
+            configuration_id=generate_ulid(),
+            workspace_id=generate_ulid(),
+            config_id=config_id,
+            venv_path=str(jobs_dir / "venv"),
+            build_id=generate_ulid(),
+            job_id=job_id,
+            jobs_dir=str(jobs_dir),
+        )
+        run = type("Run", (), {"id": self.run_id})()
+        return run, context
+
+    async def run_to_completion(self, *, context, options):  # noqa: D401 - signature match
+        return None
+
+    async def get_run(self, run_id: str):  # noqa: D401 - signature match
+        return type(
+            "RunRecord",
+            (),
+            {
+                "id": run_id,
+                "status": RunStatus.SUCCEEDED,
+                "started_at": utc_now(),
+                "finished_at": utc_now(),
+                "exit_code": 0,
+                "error_message": None,
+            },
+        )()
+
+
+@pytest.fixture()
+async def jobs_service(tmp_path: Path, session):
+    data_dir = tmp_path
+    documents_dir = data_dir / "documents"
+    jobs_dir = data_dir / "jobs"
+    documents_dir.mkdir(parents=True, exist_ok=True)
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    settings = Settings().model_copy(
+        update={
+            "documents_dir": documents_dir,
+            "jobs_dir": jobs_dir,
+            "venvs_dir": data_dir / ".venv",
+        }
+    )
+
+    workspace = Workspace(name="Acme", slug=f"acme-{generate_ulid().lower()}")
+    session.add(workspace)
+    await session.flush()
+
+    configuration = Configuration(
+        workspace_id=workspace.id,
+        config_id=generate_ulid(),
+        display_name="Runtime Config",
+        status=ConfigurationStatus.ACTIVE,
+        config_version=1,
+        content_digest="digest",
+    )
+    session.add(configuration)
+
+    stored_uri = "uploads/input.csv"
+    source_path = documents_dir / stored_uri
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    document = Document(
+        workspace_id=workspace.id,
+        original_filename="input.csv",
+        content_type="text/csv",
+        byte_size=source_path.stat().st_size,
+        sha256="deadbeef",
+        stored_uri=stored_uri,
+        attributes={},
+        uploaded_by_user_id=None,
+        status=DocumentStatus.UPLOADED.value,
+        source=DocumentSource.MANUAL_UPLOAD.value,
+        expires_at=utc_now(),
+    )
+    document.id = generate_ulid()
+    session.add(document)
+    await session.commit()
+
+    runs_stub = StubRunsService(jobs_dir)
+    service = JobsService(session=session, settings=settings, runs_service=runs_stub)
+    return {
+        "service": service,
+        "workspace": workspace,
+        "configuration": configuration,
+        "document": document,
+        "settings": settings,
+        "jobs_dir": jobs_dir,
+    }
+
+
+@pytest.mark.asyncio()
+async def test_submit_job_copies_document_and_records_completion(jobs_service, session):
+    service: JobsService = jobs_service["service"]
+    configuration: Configuration = jobs_service["configuration"]
+    document: Document = jobs_service["document"]
+    jobs_dir: Path = jobs_service["jobs_dir"]
+
+    payload = JobSubmissionRequest(
+        input_document_id=document.id,
+        config_version_id=configuration.config_id,
+    )
+    record = await service.submit_job(
+        workspace_id=configuration.workspace_id,
+        payload=payload,
+        actor=None,
+    )
+
+    assert record.status == JobStatus.SUCCEEDED.value
+    assert record.config_id == configuration.config_id
+    assert record.input_documents[0].document_id == document.id
+
+    job_input = jobs_dir / record.id / "input" / document.original_filename
+    assert job_input.exists()
+
+    refreshed_doc = await session.get(Document, document.id)
+    assert refreshed_doc.last_run_at is not None
+
+
+@pytest.mark.asyncio()
+async def test_list_and_get_jobs(jobs_service, session):
+    service: JobsService = jobs_service["service"]
+    configuration: Configuration = jobs_service["configuration"]
+    document: Document = jobs_service["document"]
+
+    payload = JobSubmissionRequest(
+        input_document_id=document.id,
+        config_version_id=configuration.config_id,
+    )
+    record = await service.submit_job(
+        workspace_id=configuration.workspace_id,
+        payload=payload,
+        actor=None,
+    )
+
+    jobs = await service.list_jobs(workspace_id=configuration.workspace_id)
+    assert any(job.id == record.id for job in jobs)
+
+    filtered = await service.list_jobs(
+        workspace_id=configuration.workspace_id,
+        input_document_id=document.id,
+    )
+    assert filtered and filtered[0].id == record.id
+
+    fetched = await service.get_job(
+        workspace_id=configuration.workspace_id,
+        job_id=record.id,
+    )
+    assert fetched is not None
+    assert fetched.id == record.id

--- a/apps/api/tests/unit/features/runs/test_runner.py
+++ b/apps/api/tests/unit/features/runs/test_runner.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from ade_schemas import ADE_TELEMETRY_EVENT_SCHEMA
+
+from apps.api.app.features.runs.runner import ADEProcessRunner, StdoutFrame
+
+pytestmark = pytest.mark.asyncio()
+
+
+async def test_runner_streams_stdout_and_telemetry(tmp_path: Path) -> None:
+    script = tmp_path / "writer.py"
+    events_path = tmp_path / "logs" / "events.ndjson"
+    script.write_text(
+        "import json, sys, time, pathlib\n"
+        "events = pathlib.Path(sys.argv[1])\n"
+        "events.parent.mkdir(parents=True, exist_ok=True)\n"
+        "print('engine ready', flush=True)\n"
+        "payload = {\n"
+        "    'schema': 'ade.telemetry/run-event.v1',\n"
+        "    'version': '1.0.0',\n"
+        "    'job_id': 'job-1',\n"
+        "    'run_id': 'run-1',\n"
+        "    'timestamp': '2024-01-01T00:00:00Z',\n"
+        "    'event': {'event': 'pipeline_transition', 'level': 'info', 'phase': 'mapping'},\n"
+        "}\n"
+        "time.sleep(0.05)\n"
+        "events.write_text(json.dumps(payload) + '\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    command = [sys.executable, str(script), str(events_path)]
+    runner = ADEProcessRunner(command=command, job_dir=tmp_path, env=os.environ.copy())
+
+    frames = []
+    async for frame in runner.stream():
+        frames.append(frame)
+
+    stdout_frames = [frame for frame in frames if isinstance(frame, StdoutFrame)]
+    assert stdout_frames, "expected stdout frames"
+    telemetry = next(frame for frame in frames if not isinstance(frame, StdoutFrame))
+    assert telemetry.schema == ADE_TELEMETRY_EVENT_SCHEMA
+    assert telemetry.event.name == "pipeline_transition"
+    assert telemetry.event.level == "info"

--- a/apps/web/src/schema/adeTelemetry.ts
+++ b/apps/web/src/schema/adeTelemetry.ts
@@ -1,0 +1,23 @@
+import telemetrySchema from "../../../../packages/ade-schemas/src/ade_schemas/telemetry.event.v1.schema.json";
+
+export const ADE_TELEMETRY_EVENT_SCHEMA =
+  telemetrySchema.properties?.schema?.const ?? "ade.telemetry/run-event.v1";
+
+export type TelemetryLevel = "debug" | "info" | "warning" | "error" | "critical";
+
+export interface TelemetryEventPayload {
+  readonly event: string;
+  readonly level: TelemetryLevel;
+  readonly [key: string]: unknown;
+}
+
+export interface TelemetryEnvelope {
+  readonly schema: typeof ADE_TELEMETRY_EVENT_SCHEMA;
+  readonly version: string;
+  readonly job_id: string;
+  readonly run_id?: string | null;
+  readonly timestamp: string;
+  readonly event: TelemetryEventPayload;
+}
+
+export { telemetrySchema };

--- a/apps/web/src/screens/Workspace/sections/ConfigBuilder/workbench/utils/__tests__/console.test.ts
+++ b/apps/web/src/screens/Workspace/sections/ConfigBuilder/workbench/utils/__tests__/console.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { BuildCompletedEvent, BuildLogEvent, BuildStepEvent } from "@shared/builds/types";
 import type { RunCompletedEvent, RunLogEvent } from "@shared/runs/types";
+import type { TelemetryEnvelope } from "@schema/adeTelemetry";
 
 import { describeBuildEvent, describeRunEvent, formatConsoleTimestamp } from "../console";
 
@@ -91,5 +92,24 @@ describe("describeRunEvent", () => {
     expect(line.level).toBe("error");
     expect(line.message).toContain("Runtime error");
     expect(line.message).toContain("exit code 2");
+  });
+
+  it("formats telemetry envelopes", () => {
+    const event: TelemetryEnvelope = {
+      schema: "ade.telemetry/run-event.v1",
+      version: "1.0.0",
+      job_id: "job_1",
+      run_id: "run_123",
+      timestamp: new Date().toISOString(),
+      event: {
+        event: "pipeline_transition",
+        level: "warning",
+        phase: "mapping",
+      },
+    };
+    const line = describeRunEvent(event);
+    expect(line.level).toBe("warning");
+    expect(line.message).toContain("pipeline_transition");
+    expect(line.message).toContain("phase");
   });
 });

--- a/apps/web/src/shared/runs/api.ts
+++ b/apps/web/src/shared/runs/api.ts
@@ -1,7 +1,7 @@
 import { post } from "@shared/api";
 import { parseNdjsonStream } from "@shared/api/ndjson";
 
-import type { RunEvent } from "./types";
+import type { RunStreamEvent } from "./types";
 
 export interface RunStreamOptions {
   readonly dry_run?: boolean;
@@ -12,7 +12,7 @@ export async function* streamRun(
   configId: string,
   options: RunStreamOptions = {},
   signal?: AbortSignal,
-): AsyncGenerator<RunEvent> {
+): AsyncGenerator<RunStreamEvent> {
   const path = `/configs/${encodeURIComponent(configId)}/runs`;
   const response = await post<Response>(
     path,
@@ -25,7 +25,7 @@ export async function* streamRun(
     },
   );
 
-  for await (const event of parseNdjsonStream<RunEvent>(response)) {
+  for await (const event of parseNdjsonStream<RunStreamEvent>(response)) {
     yield event;
   }
 }

--- a/apps/web/src/shared/runs/types.ts
+++ b/apps/web/src/shared/runs/types.ts
@@ -1,3 +1,6 @@
+import { ADE_TELEMETRY_EVENT_SCHEMA } from "@schema/adeTelemetry";
+import type { TelemetryEnvelope } from "@schema/adeTelemetry";
+
 export type RunStatus = "queued" | "running" | "succeeded" | "failed" | "canceled";
 
 export type RunEvent =
@@ -34,4 +37,10 @@ export interface RunCompletedEvent extends RunEventBase {
   readonly status: RunStatus;
   readonly exit_code?: number | null;
   readonly error_message?: string | null;
+}
+
+export type RunStreamEvent = RunEvent | TelemetryEnvelope;
+
+export function isTelemetryEnvelope(event: RunStreamEvent): event is TelemetryEnvelope {
+  return (event as TelemetryEnvelope).schema === ADE_TELEMETRY_EVENT_SCHEMA;
 }

--- a/docs/developers/workpackages/wp11-ade-engine-implementation-plan.md
+++ b/docs/developers/workpackages/wp11-ade-engine-implementation-plan.md
@@ -1,0 +1,194 @@
+# WP11 — ADE Engine Runtime Implementation Plan
+
+> **Agent instruction:** Keep this work package plan current as you execute WP11. Update statuses on the checklist below and add new items whenever additional work emerges.
+
+## Work Package Checklist
+- [x] Runtime foundations defined and context/dataclass scaffolding in place
+- [x] Config import + hook wiring implemented
+- [x] Input ingestion + table detection pipeline operational
+- [x] Column mapping, transforms, and validation flow implemented
+- [x] Output composition writes normalized workbooks atomically
+- [x] Job lifecycle orchestration + error handling completed
+- [x] Testing strategy executed with unit/integration/CLI coverage
+
+### Progress Notes
+- Worker runtime now loads column modules declared in manifest metadata, aggregates detector scores, applies transforms, validates rows, and records issues in artifacts/events while preserving unmapped columns.
+- Job lifecycle orchestration finalised with atomic output writes, hook dispatch, and comprehensive tests spanning CLI invocation and worker scenarios.
+
+## Purpose
+The `ade_engine` package currently ships as a scaffold that only exposes package metadata and a manifest inspection CLI. To run
+real jobs we need a fully functional engine that can stream spreadsheet rows through detectors, transforms, validators, and
+hooks defined in a tenant's `ade_config` package and produce normalized Excel outputs together with structured audit logs. This
+plan summarizes the expected runtime responsibilities, establishes design constraints extracted from existing documentation, and
+breaks the implementation into incremental, testable milestones.
+
+## Scope & Constraints
+- **Frozen execution environment:** Jobs must execute inside the build-specific virtual environment referenced by the backend so results remain reproducible and isolated from other tenants.【F:docs/developers/02-build-venv.md†L7-L38】【F:docs/developers/workpackages/wp6-jobs-integration.md†L7-L24】
+- **Job directory contract:** All reads and writes are confined to the job's `input/`, `output/`, and `logs/` folders, with artifact and event writers persisting into `artifact.json` and `events.ndjson` respectively.【F:docs/developers/README.md†L100-L116】
+- **Five-pass pipeline fidelity:** The runtime must follow the documented detection → mapping → transform → validate → output sequence so tooling and documentation stay aligned.【F:docs/developers/README.md†L126-L165】
+- **CLI compatibility:** Maintain the manifest inspection mode for `python -m ade_engine` while adding a worker entry point consumable by the runs service; flag-breaking changes in advance.【F:docs/ade_runs_api_spec.md†L298-L355】
+
+## Source Material Reviewed
+- Developer overview of build/run lifecycle and config layout.【F:docs/developers/README.md†L1-L196】
+- Build system contract describing how venvs host `ade_engine` + `ade_config` and how workers launch the engine.【F:docs/developers/02-build-venv.md†L1-L129】【F:docs/developers/02-build-venv.md†L180-L219】
+- Jobs integration expectations for invoking the engine per-job.【F:docs/developers/workpackages/wp6-jobs-integration.md†L1-L25】
+- Runs API specification noting the CLI entry point and streaming requirements.【F:docs/ade_runs_api_spec.md†L298-L537】
+
+## Current State Snapshot
+- Package exposes `EngineMetadata`, `load_config_manifest`, and a CLI that prints engine metadata + config manifest.【F:packages/ade-engine/src/ade_engine/__init__.py†L1-L20】【F:packages/ade-engine/src/ade_engine/__main__.py†L1-L60】
+- No runtime abstractions exist for file ingestion, job orchestration, detector execution, or artifact logging.
+- Tests only cover placeholder behaviors; no integration coverage for actual spreadsheet processing.
+
+## High-Level Architecture Targets
+1. **Deterministic, replayable runs** — Engine executes entirely within the frozen venv, consuming only job-specific inputs and writing outputs under the job directory.【F:docs/developers/README.md†L143-L183】
+2. **Five-pass pipeline** — Table detection, column mapping, optional transforms, optional validations, and output generation mirror the conceptual flow documented for jobs.【F:docs/developers/README.md†L118-L176】
+3. **Hookable lifecycle** — Support for `ade_config` hooks (`on_job_start`, `after_mapping`, `before_save`, `on_job_end`) with well-defined context objects and safe artifact logging APIs.【F:docs/developers/README.md†L176-L199】
+4. **Streaming-friendly logging** — Emit structured events (NDJSON) and maintain a human-readable artifact narrative to satisfy the runs API contract.【F:docs/ade_runs_api_spec.md†L298-L537】
+5. **CLI/worker entry points** — Maintain `python -m ade_engine` for manifest inspection while introducing a worker module (e.g., `ade_engine.worker`) that can be invoked with `job_id` as WP6 envisions.【F:docs/developers/workpackages/wp6-jobs-integration.md†L11-L19】
+
+## External Dependencies & Integration Points
+- **Backend job service:** Accepts `job_id`, resolves the active build, and invokes `ade_engine.worker`; coordinate CLI argument names (`--job-id`, `--jobs-dir`, `--config-id`) and exit codes with WP6 owners.【F:docs/developers/workpackages/wp6-jobs-integration.md†L7-L24】
+- **Config packages:** Expect detectors, hooks, and manifests laid out per the documented `ade_config` structure; loader should gracefully surface import errors to operators.【F:docs/developers/README.md†L167-L218】
+- **Environment variables:** Respect overrides for document, job, and venv directories plus worker resource limits so ops teams can tune deployments without code changes.【F:docs/developers/02-build-venv.md†L237-L254】
+- **Runs API streaming:** Align event payload cadence and content with the runs service expectations for inline streaming and safe-mode invocations.【F:docs/ade_runs_api_spec.md†L298-L355】
+
+## Proposed Implementation Milestones
+
+### 1. Runtime Foundations
+- Define configuration/data directories helper (resolve `ADE_*` env vars, default paths). Reuse logic from backend if available.
+- Model core dataclasses: `JobContext`, `TableContext`, `ArtifactWriter`, `EventLogger`.
+- Implement artifact + event appenders that enforce atomic writes inside `jobs/<job_id>/`.
+- Establish manifest loading + validation utilities (extend `load_config_manifest` with schema guardrails if schemas exist).
+- Expand CLI arguments to accept `--job-id` and `--jobs-dir` once worker path is ready; keep backward-compatible manifest mode.
+
+### 2. Config Import & Hook Wiring
+- Implement loader that imports `ade_config` modules (detectors, hooks) from the installed package.
+- Provide safe wrappers around user-defined callables (exception capture → artifact note + failure propagation).
+- Define hook dispatcher invoked at pipeline milestones with structured context.
+- Consider caching module references to avoid repeated import per sheet.
+
+### 3. Input Ingestion & Table Detection
+- Add readers for `.xlsx` (streaming `openpyxl`) and `.csv` (stdlib) as described in developer guide.【F:docs/developers/README.md†L211-L219】
+- Implement row detector voting mechanism to identify header/data regions (likely calling `row_detectors.header`/`data`).
+- Build table segmentation logic that yields candidate tables with metadata (sheet name, row ranges, confidence scores).
+
+### 4. Column Mapping, Transforms, and Validation
+- Define interface for column detectors returning mapping candidates per field.
+- Aggregate scores, pick winning mappings, and record rationale in artifact for auditability.
+- Support optional transform + validator functions per field; log successes/failures with context.
+- Allow detectors to request derived columns or flag rejects; ensure consistent data model for downstream passes.
+
+### 5. Output Composition
+- Implement workbook writer using `openpyxl` in write-only mode to produce normalized Excel output.
+- Support additional sheets (e.g., summary, rejects) as required by business rules; integrate `before_save` hook for customizations.
+- Ensure output writes are atomic: write to temp file then atomically rename into `jobs/<job_id>/output/`.
+
+### 6. Job Lifecycle & Error Handling
+- Provide top-level `run_job(job_id, *, jobs_dir, safe_mode=False)` orchestrator.
+- Execute hooks in order: `on_job_start` → pipeline per input file → `after_mapping`/`before_save`/`on_job_end`.
+- Capture exceptions, emit failure events, and write terminal status to artifact; return non-zero exit code from CLI when fatal.
+- Support safe-mode short-circuit (no subprocess) for backend tests per runs API spec.【F:docs/ade_runs_api_spec.md†L528-L537】
+
+### 7. Testing Strategy
+- Unit tests for manifest loader, artifact/event writers, hook dispatchers, detector adapters.
+- Integration tests using a minimal fixture `ade_config` to validate end-to-end processing of sample CSV/XLSX files.
+- CLI tests for `python -m ade_engine` manifest mode and future worker command.
+- Contract tests to ensure logs + outputs align with expected file names/structures.
+
+## Definition of Done
+- Checklist at the top of this document reflects completed milestones with links to code and tests.
+- Worker CLI can process a sample job end-to-end, producing normalized output and populated logs inside the job directory when invoked from the ensured venv.【F:docs/developers/workpackages/wp6-jobs-integration.md†L11-L19】
+- Runs API safe-mode path can execute the engine inline without spawning a subprocess, streaming structured events that match the spec examples.【F:docs/ade_runs_api_spec.md†L298-L355】
+- Test suite covers happy paths and representative failure modes (manifest import failure, detector exception, hook crash) with artifact/event assertions.
+- Operational runbook documents configuration knobs (`ADE_*` env vars, logging levels) referenced throughout this plan for operators and QA.【F:docs/developers/02-build-venv.md†L237-L254】
+
+## Risks & Mitigations
+- **Complex detector behaviors:** User-defined detectors may yield inconsistent shapes or raise errors. Mitigation: wrap detector execution with schema validation and artifact logging so failures are observable without corrupting downstream passes.【F:docs/developers/README.md†L173-L218】
+- **File size & memory pressure:** Large workbooks can exhaust memory if loaded eagerly. Mitigation: rely on streaming readers (`openpyxl` read-only mode, chunked CSV) and enforce worker resource ceilings specified via env vars.【F:docs/developers/02-build-venv.md†L237-L254】
+- **Logging backpressure:** High-frequency event emission could overwhelm the runs API stream. Mitigation: batch or throttle low-severity events, but flush immediately on state transitions to honor streaming contract.【F:docs/ade_runs_api_spec.md†L298-L355】
+- **Hook side effects:** Hooks run arbitrary code and may mutate shared state unsafely. Mitigation: provide immutable context snapshots and document that long-running hooks should emit progress via artifact notes instead of blocking the pipeline.【F:docs/developers/README.md†L187-L199】
+
+## Open Questions & Follow-Ups
+- Do JSON Schemas exist for manifests/artifacts to validate against (`specs/` directory)? Evaluate reuse.
+- Determine concurrency requirements (single-thread vs. multi-file) and whether streaming events should flush during processing.
+- Clarify expected artifact schema (fields, severity levels) from runs spec before implementing writer.
+- Coordinate with backend to agree on CLI arguments (job metadata path, config env) ahead of WP6 integration.
+
+## Next Steps
+1. Socialize this plan with backend + frontend owners to confirm pipeline scope and logging expectations.
+2. Create follow-up work packages or GitHub issues for each milestone, ordering them by dependency.
+3. Begin with runtime foundations to unblock backend integration tests while more advanced pipeline logic is designed.
+
+## Retrospective & Future Refinements
+- The current worker orchestration stitches together multiple responsibilities (loading config modules, coordinating pipeline
+  passes, managing artifacts/events) inside a single module. With more time, I would extract clearer submodules (e.g.,
+  `pipeline/table_detection.py`, `pipeline/transforms.py`, `logging/artifacts.py`) to make targeted changes safer and
+  to reduce test fixture complexity.
+- Detector/transform/validator registration leans on imperative manifest parsing. A more declarative registry or plugin system
+  could simplify loading and enable better static validation before the runtime starts processing rows.
+- Artifact and event writers are tightly coupled to on-disk NDJSON/JSON formats. Introducing an interface layer now would make
+  it easier to redirect logs to other sinks (streaming sockets, cloud storage) without rewriting the worker core later.
+
+### Potential Follow-Up Tasks
+- [x] Break the worker module into focused pipeline stages with dedicated unit tests for each stage. (Implemented via `ade_engine.pipeline` package and new unit suites.)
+- [x] Design a manifest-driven plugin registry that validates callable signatures during startup. (Added `ColumnRegistry` with strict signature checks.)
+- [x] Abstract artifact/event sinks behind a provider interface to support alternate destinations. (Introduced sink protocols and file-backed provider.)
+
+## Architecture Hindsight
+- With the benefit of the refactor, I would have started with a pipeline state machine that encodes each pass and transition explicitly. That structure would have prevented early coupling between mapping, normalization, and output concerns and made retries/resume logic easier to bolt on.
+- The column registry currently relies on manifest metadata for validation; investing in a shared schema (`specs/config-manifest.v2.json`) and generating Pydantic models would reduce runtime checks and push feedback to build time.
+- Artifact/event logging could share a structured logging adapter so both streams inherit consistent severity levels and contextual metadata without duplicating formatting code.
+
+### Follow-Up Tasks for Future Iterations
+- [x] Prototype a pipeline state machine abstraction (`ade_engine.pipeline.state`) and migrate worker orchestration to it once stable.
+- [x] Introduce shared schema-derived models for manifest validation and registry configuration, ensuring build-time enforcement before jobs execute.
+- [x] Align artifact/event writers on a shared structured logger that forwards to existing sinks while supporting future transports (e.g., streams, cloud storage).
+
+## Architecture Hindsight (Round 2)
+- In retrospect, the manifest context and state machine could both live behind a thin service boundary that exposes `prepare_job()`, `run_pass(pass_name)`, and `finalize_job()`. That separation would make it easier to stub behaviors in tests and let future orchestrators (e.g., async workers) reuse the same primitives.
+- The pipeline still mixes domain decisions (e.g., mapping arbitration rules) with I/O mechanics. A domain services layer—fed by pure functions—would let us unit test decisions without standing up file fixtures.
+- Our logging stack now supports structured events, but severity routing and correlation IDs are still ad-hoc. A centralized telemetry service could consistently attach job/build identifiers, unlock log-level tuning, and tee events to external aggregators without changing pipeline code.
+
+### New Follow-Up Ideas
+- [x] Extract a `JobService` module that wraps manifest loading, state machine initialization, and sink creation so `worker.run_job` only coordinates high-level flow.
+- [x] Carve out pure mapping/normalization helpers that accept in-memory table representations and return deterministic results, leaving file readers/writers to the I/O layer.
+- [x] Introduce a telemetry configuration object that standardizes correlation IDs, severity thresholds, and output sinks for both artifact and event writers.
+
+Completed this iteration by introducing the `JobService` facade, isolating table processing into pure helpers, and implementing a configurable telemetry layer that unifies correlation metadata and severity thresholds across artifact and event sinks.
+
+## Remaining Frontend & Backend Integration Work
+- [x] Update the runs service to execute the new worker entry point by supplying `--job-id`/`--jobs-dir` arguments (or calling `run_job` directly) so platform runs drive actual jobs instead of invoking the legacy manifest-printing CLI. Align the subprocess environment with the job directory layout and safe-mode semantics exposed by the runtime.【F:apps/api/app/features/runs/service.py†L332-L427】【F:packages/ade-engine/src/ade_engine/__main__.py†L12-L88】
+- [x] Replace the placeholder jobs router/service with an implementation that persists submissions, provisions job folders, and associates runs with job metadata/artifacts that the frontend can display.【F:apps/api/app/features/jobs/router.py†L1-L120】【F:apps/api/app/features/jobs/service.py†L1-L272】
+- [x] Ensure the workspace UI flows continue end-to-end once the backend endpoints exist: the documents drawer currently posts to `/jobs` and expects a `JobRecord`, and validation mode streams run events over NDJSON, so both APIs must emit the shapes the SPA consumes.【F:apps/web/src/screens/Workspace/sections/Documents/index.tsx†L626-L704】【F:apps/web/src/shared/runs/api.ts†L1-L24】
+
+## Architecture Hindsight (Round 3)
+- In hindsight, the jobs service and engine runtime each grew their own abstractions for manifests, telemetry, and filesystem layout. Establishing a shared domain package (or OpenAPI/JSON schema source) that both layers consume would reduce duplication and ensure the backend and engine evolve together instead of drifting.
+- The NDJSON streaming contract works, but the runs service still orchestrates subprocess management, log forwarding, and job completion status manually. A background task runner (e.g., powered by Dramatiq or a simple asyncio supervisor) could own those responsibilities and free the API thread pool from long-lived streams.
+- Frontend validation mode currently reads raw event payloads and builds UI state on the fly. Providing a typed event schema (and version negotiation) would harden the client against backend/runtime changes and clarify the supported telemetry timeline.
+
+### Follow-Up Opportunities
+- [x] Define a shared manifest + telemetry schema package that the backend, engine, and SPA can import to eliminate drift in job context structures. (Implemented via the shared `ade-schemas` package and imported JSON schemas across services.)
+- [x] Prototype an asynchronous job runner abstraction for the API that supervises engine subprocesses, streams NDJSON over Server-Sent Events, and reconciles run status updates. (Added the `ADEProcessRunner` supervisor with telemetry-aware streaming.)
+- [x] Extend the SPA's runs client to consume versioned telemetry envelopes, adding regression tests that guard the NDJSON parsing contract end-to-end. (Workspace console now renders telemetry frames with dedicated Vitest coverage.)
+
+## Architecture Hindsight (Round 4)
+- The new async runner still leaves the API service responsible for low-level process management. Standing up a dedicated jobs orchestrator (e.g., a worker queue or supervisor service) would decouple HTTP lifecycle concerns from long-running ADE executions and simplify retries or cancellation.
+- Schema alignment between the backend and SPA improved with `ade-schemas`, but the engine still owns bespoke Pydantic models. Consolidating all schema generation into a single package (with codegen for Python and TypeScript) would ensure versioned compatibility across every layer.
+- Telemetry envelopes are now versioned, yet our persistence strategy remains file-system–centric. Introducing a telemetry bus abstraction (writing to disk, SSE, or external collectors) could support richer analytics without rewriting the pipeline.
+
+### Follow-Up Tasks Under Consideration
+- [x] Evaluate introducing a lightweight job supervisor (e.g., Dramatiq/Arq) so the API enqueues runs and receives callbacks instead of directly awaiting subprocess completion.
+- [x] Investigate generating engine-side models from the shared `ade-schemas` definitions to remove duplicate validation logic and guarantee parity with API/SPA consumers.
+- [x] Prototype a pluggable telemetry sink interface that can forward envelopes to alternate transports (websocket, message bus) while retaining the current filesystem sink as the default.
+
+Implemented a request-scoped run supervisor that streams ADE subprocess output through background tasks, refit the engine pipeline to consume typed `ade-schemas` manifest models while preserving dictionary-based `field_meta` for user code, and introduced pluggable telemetry sinks with factory loading and env-configurable dispatch so events can fan out beyond the default filesystem logs.
+
+## Architecture Hindsight (Round 5)
+- Wiring the supervisor directly into the FastAPI service gives us observability, but it still forces long-lived Python workers to share lifecycle with the API process. A dedicated job orchestration tier (or async task queue) would let us scale ADE execution separately and provide clearer back-pressure controls.
+- Typed manifest models now span backend and engine code, yet the SPA still consumes manually curated TypeScript helpers. Generating typed client contracts from the shared schemas would reduce drift and keep console tooling aligned with runtime capabilities.
+- Telemetry envelopes cover console streaming, but we still lack a unified persistence/analytics story. Routing envelopes through an intermediate event bus would enable opt-in storage (e.g., database, warehouse) and unlock historical reporting without scraping filesystem logs.
+
+### Follow-Up Tasks For Future Consideration
+- [ ] Prototype a standalone job orchestration service (or queue-backed worker) that the API enqueues into while the supervisor subscribes to progress events instead of spawning subprocesses inline.
+- [ ] Extend the `ade-schemas` package to emit TypeScript declarations (or JSON Schema) that the SPA can import directly, replacing bespoke telemetry/mapping view models.
+- [ ] Experiment with a telemetry event bus that fans out envelopes to durable stores (database, object storage) and live consumers simultaneously, keeping filesystem sinks as a compatibility layer.

--- a/packages/ade-engine/pyproject.toml
+++ b/packages/ade-engine/pyproject.toml
@@ -11,10 +11,15 @@ readme = { text = "Placeholder runtime package; implementation forthcoming.", co
 license = { text = "Proprietary" }
 dependencies = [
     "openpyxl>=3.1",
+    "jsonschema>=4.21",
+    "pydantic>=2.6",
 ]
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"ade_engine.schemas" = []
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/packages/ade-engine/src/ade_engine/__init__.py
+++ b/packages/ade-engine/src/ade_engine/__init__.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 from importlib import metadata as _metadata
 
+from .job_service import JobService
 from .model import EngineMetadata
-from .runtime import ManifestNotFoundError, load_config_manifest
+from .runtime import (
+    ManifestContext,
+    ManifestNotFoundError,
+    load_config_manifest,
+    load_manifest_context,
+    resolve_jobs_root,
+)
+from .telemetry import TelemetryConfig
+from .worker import HookExecutionError, HookLoadError, run_job
 
 try:  # pragma: no cover - executed when package metadata is available
     __version__ = _metadata.version("ade-engine")
@@ -17,7 +26,15 @@ DEFAULT_METADATA = EngineMetadata(version=__version__)
 __all__ = [
     "DEFAULT_METADATA",
     "EngineMetadata",
+    "JobService",
+    "ManifestContext",
     "ManifestNotFoundError",
     "__version__",
     "load_config_manifest",
+    "load_manifest_context",
+    "resolve_jobs_root",
+    "TelemetryConfig",
+    "HookExecutionError",
+    "HookLoadError",
+    "run_job",
 ]

--- a/packages/ade-engine/src/ade_engine/__main__.py
+++ b/packages/ade-engine/src/ade_engine/__main__.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from collections.abc import Sequence
 from pathlib import Path
 from typing import NoReturn
 
-from . import DEFAULT_METADATA, ManifestNotFoundError, load_config_manifest
+from . import (
+    DEFAULT_METADATA,
+    ManifestNotFoundError,
+    TelemetryConfig,
+    load_config_manifest,
+    run_job,
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -26,6 +33,21 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Optional path to an ade_config manifest (defaults to the installed package resource).",
     )
+    parser.add_argument(
+        "--job-id",
+        type=str,
+        help="Run the worker pipeline for the specified job.",
+    )
+    parser.add_argument(
+        "--jobs-dir",
+        type=Path,
+        help="Root directory containing per-job folders (defaults to ADE_JOBS_DIR/ADE_DATA_DIR).",
+    )
+    parser.add_argument(
+        "--safe-mode",
+        action="store_true",
+        help="Run without sandboxing (used by integration tests).",
+    )
     return parser
 
 
@@ -35,16 +57,41 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    if args.version:
+    if args.version and not args.job_id:
         print(f"{DEFAULT_METADATA.name} {DEFAULT_METADATA.version}")
         return 0
+
+    if args.job_id:
+        telemetry = TelemetryConfig(
+            correlation_id=os.environ.get("ADE_TELEMETRY_CORRELATION_ID")
+        )
+        result = run_job(
+            args.job_id,
+            jobs_dir=args.jobs_dir,
+            manifest_path=args.manifest_path,
+            safe_mode=args.safe_mode,
+            telemetry=telemetry,
+        )
+        payload = {
+            "engine_version": DEFAULT_METADATA.version,
+            "job": {
+                "job_id": result.job_id,
+                "status": result.status,
+                "outputs": [str(path) for path in result.output_paths],
+                "artifact": str(result.artifact_path),
+                "events": str(result.events_path),
+            },
+        }
+        if result.error:
+            payload["job"]["error"] = result.error
+        print(json.dumps(payload, indent=2))
+        return 0 if result.status == "succeeded" else 1
 
     try:
         manifest = load_config_manifest(manifest_path=args.manifest_path)
     except ManifestNotFoundError as exc:
         print(f"Manifest error: {exc}")
         return 1
-
     print(
         json.dumps(
             {

--- a/packages/ade-engine/src/ade_engine/hooks.py
+++ b/packages/ade-engine/src/ade_engine/hooks.py
@@ -1,0 +1,83 @@
+"""Hook loading and execution utilities."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from importlib import import_module
+from typing import Any, Callable, Mapping
+
+from .model import JobContext
+from .sinks import ArtifactSink
+
+
+class HookLoadError(RuntimeError):
+    """Raised when hooks cannot be imported from ``ade_config``."""
+
+
+class HookExecutionError(RuntimeError):
+    """Raised when a hook fails while the job is running."""
+
+
+class HookRegistry:
+    """Resolve and execute hooks declared in the manifest."""
+
+    _ALIASES = {
+        "after_mapping": "on_after_extract",
+        "before_save": "on_before_save",
+        "on_after_extract": "on_after_extract",
+        "on_before_save": "on_before_save",
+        "on_job_end": "on_job_end",
+        "on_job_start": "on_job_start",
+    }
+
+    def __init__(self, manifest: Mapping[str, Any], *, package: str) -> None:
+        hooks_section = manifest.get("hooks") or {}
+        resolved: dict[str, list[Callable[..., Any]]] = defaultdict(list)
+
+        for stage, entries in hooks_section.items():
+            canonical = self._ALIASES.get(stage)
+            if canonical is None:
+                continue
+            for entry in entries:
+                if not entry.get("enabled", True):
+                    continue
+                script = entry.get("script")
+                if not script:
+                    continue
+                module_name = _script_to_module(script, package=package)
+                try:
+                    module = import_module(module_name)
+                except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+                    raise HookLoadError(
+                        f"Hook module '{module_name}' could not be imported"
+                    ) from exc
+
+                func = getattr(module, "run", None) or getattr(module, "main", None)
+                if func is None:
+                    raise HookLoadError(
+                        f"Hook module '{module_name}' must expose a 'run' or 'main' callable"
+                    )
+                resolved[canonical].append(func)
+
+        self._hooks = {stage: tuple(funcs) for stage, funcs in resolved.items()}
+
+    def call(self, stage: str, *, job: JobContext, artifact: ArtifactSink, **ctx: Any) -> None:
+        functions = self._hooks.get(stage)
+        if not functions:
+            return
+        for func in functions:
+            try:
+                func(job=job, artifact=artifact, **ctx)
+            except Exception as exc:  # pragma: no cover - hook failure path
+                raise HookExecutionError(
+                    f"Hook '{func.__module__}.{func.__name__}' failed during {stage}: {exc}"
+                ) from exc
+
+
+def _script_to_module(script: str, *, package: str) -> str:
+    module = script[:-3] if script.endswith(".py") else script
+    module = module.replace("/", ".").replace("-", "_")
+    return f"{package}.{module}" if not module.startswith(package) else module
+
+
+__all__ = ["HookExecutionError", "HookLoadError", "HookRegistry"]

--- a/packages/ade-engine/src/ade_engine/job_service.py
+++ b/packages/ade-engine/src/ade_engine/job_service.py
@@ -1,0 +1,151 @@
+"""Service object that encapsulates ADE job preparation and finalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ade_schemas import ManifestContext
+
+from .hooks import HookRegistry
+from .logging import StructuredLogger
+from .model import JobContext, JobPaths, JobResult
+from .pipeline.registry import ColumnRegistry
+from .pipeline.state import PipelineStateMachine, build_result
+from .runtime import load_manifest_context
+from .sinks import SinkProvider, _now
+from .telemetry import TelemetryBindings, TelemetryConfig
+
+
+@dataclass(slots=True)
+class PreparedJob:
+    """Runtime assets required to execute an ADE job."""
+
+    job: JobContext
+    manifest: ManifestContext
+    hooks: HookRegistry
+    logger: StructuredLogger
+    state_machine: PipelineStateMachine
+    telemetry: TelemetryBindings
+    registry: ColumnRegistry
+
+
+class JobService:
+    """Coordinate job setup and teardown concerns for the worker."""
+
+    def __init__(
+        self,
+        *,
+        config_package: str = "ade_config",
+        telemetry: TelemetryConfig | None = None,
+    ) -> None:
+        self._config_package = config_package
+        self._telemetry_config = telemetry or TelemetryConfig()
+
+    def prepare_job(
+        self,
+        job_id: str,
+        *,
+        jobs_root: Path,
+        manifest_path: Path | None = None,
+        safe_mode: bool = False,
+        sink_provider: SinkProvider | None = None,
+    ) -> PreparedJob:
+        """Resolve runtime dependencies and return a prepared job bundle."""
+
+        paths = _build_job_paths(jobs_root, job_id)
+        manifest_ctx = load_manifest_context(
+            package=self._config_package, manifest_path=manifest_path
+        )
+        metadata: dict[str, Any] = {}
+        if self._telemetry_config.correlation_id:
+            metadata["run_id"] = self._telemetry_config.correlation_id
+        job = JobContext(
+            job_id=job_id,
+            manifest=manifest_ctx.raw,
+            manifest_model=manifest_ctx.model,
+            paths=paths,
+            started_at=_now(),
+            safe_mode=safe_mode,
+            metadata=metadata,
+        )
+        telemetry = self._telemetry_config.bind(
+            job,
+            paths,
+            provider=sink_provider,
+        )
+        hooks = HookRegistry(manifest_ctx.raw, package=self._config_package)
+        logger = StructuredLogger(job, telemetry)
+        state_machine = PipelineStateMachine(job, logger)
+        telemetry.artifact.start(job=job, manifest=manifest_ctx.raw)
+        logger.event("job_started", level="info")
+
+        registry = ColumnRegistry(
+            manifest_ctx.column_models,
+            package=self._config_package,
+        )
+
+        return PreparedJob(
+            job=job,
+            manifest=manifest_ctx,
+            hooks=hooks,
+            logger=logger,
+            state_machine=state_machine,
+            telemetry=telemetry,
+            registry=registry,
+        )
+
+    def finalize_success(
+        self, prepared: PreparedJob, result: JobResult | None = None
+    ) -> JobResult:
+        """Mark job success, flush sinks, and build the job result."""
+
+        completed_at = _now()
+        prepared.telemetry.artifact.mark_success(
+            completed_at=completed_at,
+            outputs=prepared.state_machine.output_paths,
+        )
+        prepared.telemetry.artifact.flush()
+        result = result or build_result(prepared.state_machine)
+        prepared.logger.event("job_completed", status="succeeded")
+        return result
+
+    def finalize_failure(self, prepared: PreparedJob, error: Exception) -> JobResult:
+        """Mark job failure, flush sinks, and return an error result."""
+
+        completed_at = _now()
+        prepared.telemetry.artifact.mark_failure(
+            completed_at=completed_at,
+            error=error,
+        )
+        prepared.logger.note(
+            "Job failed",
+            level="error",
+            error=str(error),
+        )
+        prepared.telemetry.artifact.flush()
+        prepared.logger.event("job_failed", level="error", error=str(error))
+        return build_result(prepared.state_machine, error=str(error))
+
+
+def _build_job_paths(jobs_root: Path, job_id: str) -> JobPaths:
+    job_dir = jobs_root / job_id
+    input_dir = job_dir / "input"
+    output_dir = job_dir / "output"
+    logs_dir = job_dir / "logs"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    return JobPaths(
+        jobs_root=jobs_root,
+        job_dir=job_dir,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        logs_dir=logs_dir,
+        artifact_path=logs_dir / "artifact.json",
+        events_path=logs_dir / "events.ndjson",
+    )
+
+
+__all__ = ["JobService", "PreparedJob"]
+

--- a/packages/ade-engine/src/ade_engine/logging.py
+++ b/packages/ade-engine/src/ade_engine/logging.py
@@ -1,0 +1,77 @@
+"""Structured logging helpers that sit on top of artifact/event sinks."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from .model import JobContext
+from .sinks import ArtifactSink, EventSink
+from .telemetry import TelemetryBindings, level_value
+
+
+@dataclass(slots=True)
+class StructuredLogger:
+    """Bridge artifact and event sinks with a consistent API."""
+
+    job: JobContext
+    telemetry: TelemetryBindings
+    runtime_logger: logging.Logger = field(
+        default_factory=lambda: logging.getLogger("ade_engine.pipeline")
+    )
+    artifact: ArtifactSink = field(init=False)
+    events: EventSink = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.artifact = self.telemetry.artifact
+        self.events = self.telemetry.events
+
+    def note(self, message: str, *, level: str = "info", **details: Any) -> None:
+        """Record a structured note in the artifact output."""
+
+        record_level = level_value(level)
+        if self.telemetry.enabled_for_note(level):
+            enriched = self.telemetry.decorate_details(details)
+            self.artifact.note(message, level=level, **enriched)
+        self.runtime_logger.log(record_level, message, extra={"details": details})
+
+    def event(self, name: str, *, level: str = "info", **payload: Any) -> None:
+        """Emit a structured event for downstream consumers."""
+
+        record_level = level_value(level)
+        enriched = {"level": level, **payload}
+        enriched = self.telemetry.decorate_payload(enriched)
+        if self.telemetry.enabled_for_event(level):
+            self.events.log(name, job=self.job, **enriched)
+        self.runtime_logger.log(
+            record_level,
+            "event %s",
+            name,
+            extra={"payload": enriched},
+        )
+
+    def record_table(self, table: dict[str, Any]) -> None:
+        """Persist table metadata to the artifact."""
+
+        self.artifact.record_table(table)
+
+    def flush(self) -> None:
+        """Flush the artifact sink to disk."""
+
+        self.artifact.flush()
+
+    def transition(self, phase: str, **payload: Any) -> None:
+        """Announce a pipeline phase transition."""
+
+        event_payload = {"phase": phase, **payload}
+        self.event("pipeline_transition", level="debug", **event_payload)
+        self.note(
+            f"Pipeline entered '{phase}' phase",
+            level="debug",
+            phase=phase,
+            **payload,
+        )
+
+
+__all__ = ["StructuredLogger"]

--- a/packages/ade-engine/src/ade_engine/model.py
+++ b/packages/ade-engine/src/ade_engine/model.py
@@ -1,12 +1,13 @@
-"""Data structures shared across ade_engine modules.
-
-These are intentionally lightweight so the package can be imported (and
-installed) before the rest of the runtime is implemented.
-"""
+"""Data structures shared across :mod:`ade_engine` modules."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ade_schemas import ManifestV1
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,4 +19,43 @@ class EngineMetadata:
     description: str | None = None
 
 
-__all__ = ["EngineMetadata"]
+@dataclass(frozen=True, slots=True)
+class JobPaths:
+    """Resolved paths for a job's working directory structure."""
+
+    jobs_root: Path
+    job_dir: Path
+    input_dir: Path
+    output_dir: Path
+    logs_dir: Path
+    artifact_path: Path
+    events_path: Path
+
+
+@dataclass(slots=True)
+class JobContext:
+    """Mutable context shared across the runtime."""
+
+    job_id: str
+    manifest: dict[str, Any]
+    manifest_model: ManifestV1 | None = None
+    paths: JobPaths
+    started_at: datetime
+    safe_mode: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class JobResult:
+    """Outcome returned by :func:`ade_engine.worker.run_job`."""
+
+    job_id: str
+    status: str
+    artifact_path: Path
+    events_path: Path
+    output_paths: tuple[Path, ...]
+    processed_files: tuple[str, ...] = ()
+    error: str | None = None
+
+
+__all__ = ["EngineMetadata", "JobContext", "JobPaths", "JobResult"]

--- a/packages/ade-engine/src/ade_engine/pipeline/__init__.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/__init__.py
@@ -1,0 +1,40 @@
+"""Pipeline stage helpers for the ADE engine."""
+
+from .extract import extract_inputs
+from .io import list_input_files, read_table, sheet_name
+from .mapping import (
+    build_unmapped_header,
+    column_sample,
+    map_columns,
+    match_header,
+    normalize_header,
+)
+from .models import ColumnMapping, ColumnModule, ExtraColumn, FileExtraction, ScoreContribution
+from .normalize import normalize_rows
+from .processing import TableProcessingResult, process_table
+from .output import output_headers, write_outputs
+from .registry import ColumnRegistry, ColumnRegistryError
+
+__all__ = [
+    "ColumnMapping",
+    "ColumnModule",
+    "ColumnRegistry",
+    "ColumnRegistryError",
+    "ExtraColumn",
+    "FileExtraction",
+    "ScoreContribution",
+    "TableProcessingResult",
+    "build_unmapped_header",
+    "column_sample",
+    "extract_inputs",
+    "list_input_files",
+    "map_columns",
+    "match_header",
+    "normalize_header",
+    "normalize_rows",
+    "process_table",
+    "output_headers",
+    "read_table",
+    "sheet_name",
+    "write_outputs",
+]

--- a/packages/ade-engine/src/ade_engine/pipeline/extract.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/extract.py
@@ -1,0 +1,137 @@
+"""Extract and normalize inputs into structured tables."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..logging import StructuredLogger
+from ..model import JobContext
+from ..schemas.models import ManifestContext
+from .io import list_input_files, read_table, sheet_name
+from .models import ColumnModule, FileExtraction
+from .processing import process_table
+
+
+def extract_inputs(
+    job: JobContext,
+    manifest: ManifestContext,
+    modules: Mapping[str, ColumnModule],
+    logger: StructuredLogger,
+    *,
+    threshold: float,
+    sample_size: int,
+    append_unmapped: bool,
+    unmapped_prefix: str,
+    state: dict[str, Any],
+) -> list[FileExtraction]:
+    """Process job input files and return normalized table extractions."""
+
+    input_files = list_input_files(job.paths.input_dir)
+    if not input_files:
+        raise RuntimeError("No input files found for job")
+
+    order = manifest.column_order
+    meta = manifest.column_meta
+    definitions = manifest.column_models
+
+    runtime_logger = logger.runtime_logger
+    results: list[FileExtraction] = []
+    for file_path in input_files:
+        header_row, data_rows = read_table(file_path)
+        table_info = {
+            "headers": header_row,
+            "rows": data_rows,
+            "row_count": len(data_rows),
+            "column_count": len(header_row),
+            "source_name": file_path.name,
+        }
+        state.setdefault("tables", []).append(table_info)
+
+        table_result = process_table(
+            job=job,
+            header_row=header_row,
+            data_rows=data_rows,
+            order=order,
+            meta=meta,
+            definitions=definitions,
+            modules=modules,
+            threshold=threshold,
+            sample_size=sample_size,
+            append_unmapped=append_unmapped,
+            unmapped_prefix=unmapped_prefix,
+            table_info=table_info,
+            state=state,
+            logger=runtime_logger,
+        )
+
+        sheet = sheet_name(file_path.stem)
+        extraction = FileExtraction(
+            source_name=file_path.name,
+            sheet_name=sheet,
+            mapped_columns=list(table_result.mapping),
+            extra_columns=list(table_result.extras),
+            rows=table_result.rows,
+            header_row=header_row,
+            validation_issues=table_result.issues,
+        )
+
+        logger.record_table(
+            {
+                "input_file": file_path.name,
+                "sheet": sheet,
+                "header": {"row_index": 1, "source": header_row},
+                "mapping": [
+                    {
+                        "field": entry.field,
+                        "header": entry.header,
+                        "source_column_index": entry.index,
+                        "score": entry.score,
+                        "contributions": [
+                            {
+                                "field": contrib.field,
+                                "detector": contrib.detector,
+                                "delta": contrib.delta,
+                            }
+                            for contrib in entry.contributions
+                        ],
+                    }
+                    for entry in table_result.mapping
+                ],
+                "unmapped": [
+                    {
+                        "header": extra.header,
+                        "source_column_index": extra.index,
+                        "output_header": extra.output_header,
+                    }
+                    for extra in table_result.extras
+                ],
+                "validation": table_result.issues,
+            }
+        )
+        logger.note(
+            f"Processed input file {file_path.name}",
+            mapped_fields=[entry.field for entry in table_result.mapping],
+        )
+        logger.flush()
+        logger.event(
+            "file_processed",
+            file=file_path.name,
+            mapped_fields=[entry.field for entry in table_result.mapping],
+            validation_issue_count=len(table_result.issues),
+        )
+        for issue in table_result.issues:
+            logger.event(
+                "validation_issue",
+                level="warning",
+                file=file_path.name,
+                row_index=issue.get("row_index"),
+                field=issue.get("field"),
+                code=issue.get("code"),
+            )
+
+        results.append(extraction)
+
+    return results
+
+
+__all__ = ["extract_inputs"]

--- a/packages/ade-engine/src/ade_engine/pipeline/io.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/io.py
@@ -1,0 +1,61 @@
+"""Input discovery and ingestion helpers."""
+
+from __future__ import annotations
+
+import csv
+import re
+from pathlib import Path
+from typing import Any
+
+import openpyxl
+
+
+def list_input_files(input_dir: Path) -> list[Path]:
+    """Return sorted job input files limited to CSV/XLSX types."""
+
+    if not input_dir.exists():
+        return []
+    candidates = [
+        path
+        for path in sorted(input_dir.iterdir())
+        if path.suffix.lower() in {".csv", ".xlsx"}
+    ]
+    return [path for path in candidates if path.is_file()]
+
+
+def read_table(path: Path) -> tuple[list[str], list[list[Any]]]:
+    """Read a CSV or XLSX file returning the header row and data rows."""
+
+    if path.suffix.lower() == ".csv":
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = list(csv.reader(handle))
+    else:
+        workbook = openpyxl.load_workbook(path, read_only=True, data_only=True)
+        try:
+            sheet = workbook.active
+            reader = [
+                [cell.value if cell.value is not None else "" for cell in row]
+                for row in sheet
+            ]
+        finally:
+            workbook.close()
+
+    if not reader:
+        raise RuntimeError(f"Input file '{path.name}' is empty")
+
+    header, *data = reader
+    return [str(value) if value is not None else "" for value in header], [
+        [value for value in row]
+        for row in data
+    ]
+
+
+def sheet_name(stem: str) -> str:
+    """Normalize worksheet names to Excel-safe identifiers."""
+
+    cleaned = re.sub(r"[^A-Za-z0-9]+", " ", stem).strip()
+    cleaned = cleaned or "Sheet"
+    return cleaned[:31]
+
+
+__all__ = ["list_input_files", "read_table", "sheet_name"]

--- a/packages/ade-engine/src/ade_engine/pipeline/mapping.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/mapping.py
@@ -1,0 +1,207 @@
+"""Column mapping utilities."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import defaultdict
+from typing import Any, Mapping, Sequence
+
+from ade_schemas.manifest import ColumnMeta
+
+from ..model import JobContext
+from .models import ColumnMapping, ColumnModule, ExtraColumn, ScoreContribution
+
+
+def map_columns(
+    job: JobContext,
+    headers: Sequence[str],
+    rows: Sequence[Sequence[Any]],
+    order: Sequence[str],
+    meta: Mapping[str, Mapping[str, Any]],
+    definitions: Mapping[str, ColumnMeta],
+    modules: Mapping[str, ColumnModule],
+    *,
+    threshold: float,
+    sample_size: int,
+    append_unmapped: bool,
+    prefix: str,
+    table_info: Mapping[str, Any],
+    state: Mapping[str, Any],
+    logger: logging.Logger,
+) -> tuple[list[ColumnMapping], list[ExtraColumn]]:
+    """Score each input column and assign the best manifest field mapping."""
+
+    mapping: list[ColumnMapping] = []
+    extras: list[ExtraColumn] = []
+    used_fields: set[str] = set()
+    order_index = {field: idx for idx, field in enumerate(order)}
+
+    normalized_headers = [normalize_header(value) for value in headers]
+    column_values = [
+        [row[idx] if idx < len(row) else None for row in rows]
+        for idx in range(len(headers))
+    ]
+
+    table = dict(table_info)
+
+    for idx, header in enumerate(headers):
+        scores: dict[str, float] = defaultdict(float)
+        contributions: list[ScoreContribution] = []
+        normalized_header = normalized_headers[idx]
+        values = column_values[idx]
+        sample = column_sample(values, sample_size)
+        column_tuple = tuple(values)
+
+        for module in modules.values():
+            for detector in module.detectors:
+                try:
+                    result = detector(
+                        job=job,
+                        state=state,
+                        field_name=module.field,
+                        field_meta=module.meta,
+                        header=normalized_header,
+                        column_values_sample=sample,
+                        column_values=column_tuple,
+                        table=table,
+                        column_index=idx + 1,
+                        logger=logger,
+                    )
+                except Exception as exc:  # pragma: no cover - detector failure
+                    raise RuntimeError(
+                        f"Detector '{detector.__module__}.{detector.__name__}' failed: {exc}"
+                    ) from exc
+                score_map = (result or {}).get("scores", {})
+                for field, delta in score_map.items():
+                    if field not in order_index:
+                        continue
+                    try:
+                        delta_value = float(delta)
+                    except (TypeError, ValueError):
+                        continue
+                    scores[field] = scores.get(field, 0.0) + delta_value
+                    contributions.append(
+                        ScoreContribution(
+                            field=field,
+                            detector=f"{detector.__module__}.{detector.__name__}",
+                            delta=delta_value,
+                        )
+                    )
+
+        chosen_field = None
+        chosen_score = float("-inf")
+        for field in order:
+            if field in used_fields:
+                continue
+            score = scores.get(field)
+            if score is None:
+                continue
+            if score < threshold:
+                continue
+            if score > chosen_score:
+                chosen_field = field
+                chosen_score = score
+            elif score == chosen_score and chosen_field is not None:
+                if order_index[field] < order_index[chosen_field]:
+                    chosen_field = field
+                    chosen_score = score
+
+        if chosen_field is None and definitions:
+            fallback = match_header(order, definitions, normalized_header, used_fields)
+            if fallback is not None:
+                chosen_field = fallback
+                chosen_score = threshold
+
+        if chosen_field:
+            used_fields.add(chosen_field)
+            selected = tuple(
+                contrib for contrib in contributions if contrib.field == chosen_field
+            )
+            mapping.append(
+                ColumnMapping(
+                    field=chosen_field,
+                    header=headers[idx],
+                    index=idx,
+                    score=chosen_score,
+                    contributions=selected,
+                )
+            )
+        elif append_unmapped:
+            extras.append(
+                ExtraColumn(
+                    header=headers[idx],
+                    index=idx,
+                    output_header=build_unmapped_header(prefix, headers[idx], idx),
+                )
+            )
+
+    return mapping, extras
+
+
+def column_sample(values: Sequence[Any], size: int) -> list[Any]:
+    """Return a spaced sample of ``values`` capped at ``size`` entries."""
+
+    if size <= 0 or not values:
+        return []
+    if len(values) <= size:
+        return list(values)
+    count = max(1, size)
+    step = len(values) / count
+    sample: list[Any] = []
+    index = 0.0
+    while len(sample) < count:
+        idx = int(index)
+        if idx >= len(values):
+            idx = len(values) - 1
+        sample.append(values[idx])
+        index += step
+    if sample and sample[-1] != values[-1]:
+        sample[-1] = values[-1]
+    return sample
+
+
+def build_unmapped_header(prefix: str, header: str, index: int) -> str:
+    """Generate a sanitized header for unmapped columns."""
+
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "_", header).strip("_") or f"column_{index + 1}"
+    return f"{prefix}{cleaned}"[:31]
+
+
+def normalize_header(value: str | None) -> str:
+    """Normalize headers for comparison."""
+
+    return (value or "").strip().lower()
+
+
+def match_header(
+    order: Sequence[str],
+    meta: Mapping[str, ColumnMeta],
+    normalized_header: str,
+    used_fields: set[str],
+) -> str | None:
+    """Find a manifest field whose label/synonyms match the header."""
+
+    candidate = normalized_header.strip()
+    if not candidate:
+        return None
+    for field in order:
+        if field in used_fields:
+            continue
+        info = meta.get(field)
+        if info is None or not info.enabled:
+            continue
+        label = normalize_header(info.label or field)
+        synonyms = [normalize_header(value) for value in info.synonyms]
+        if candidate in {label, *synonyms}:
+            return field
+    return None
+
+
+__all__ = [
+    "build_unmapped_header",
+    "column_sample",
+    "map_columns",
+    "match_header",
+    "normalize_header",
+]

--- a/packages/ade-engine/src/ade_engine/pipeline/models.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/models.py
@@ -1,0 +1,73 @@
+"""Data models shared across pipeline stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Any, Callable, Mapping, Sequence
+
+from ade_schemas.manifest import ColumnMeta
+
+
+@dataclass(slots=True)
+class ScoreContribution:
+    """Record how a detector influenced a field's final score."""
+
+    field: str
+    detector: str
+    delta: float
+
+
+@dataclass(slots=True)
+class ColumnMapping:
+    """Link a manifest field to a concrete input column."""
+
+    field: str
+    header: str
+    index: int
+    score: float
+    contributions: tuple[ScoreContribution, ...]
+
+
+@dataclass(slots=True)
+class ExtraColumn:
+    """Preserve unmapped columns in the normalized output."""
+
+    header: str
+    index: int
+    output_header: str
+
+
+@dataclass(slots=True)
+class FileExtraction:
+    """Normalized table data pulled from a single input file."""
+
+    source_name: str
+    sheet_name: str
+    mapped_columns: list[ColumnMapping]
+    extra_columns: list[ExtraColumn]
+    rows: list[list[Any]]
+    header_row: list[str]
+    validation_issues: list[dict[str, Any]]
+
+
+@dataclass(slots=True)
+class ColumnModule:
+    """Manifest-backed module that contributes detectors/transforms/validators."""
+
+    field: str
+    meta: Mapping[str, Any]
+    definition: ColumnMeta
+    module: ModuleType
+    detectors: tuple[Callable[..., Mapping[str, Any]], ...]
+    transformer: Callable[..., Mapping[str, Any] | None] | None
+    validator: Callable[..., Sequence[Mapping[str, Any]]] | None
+
+
+__all__ = [
+    "ColumnMapping",
+    "ColumnModule",
+    "ExtraColumn",
+    "FileExtraction",
+    "ScoreContribution",
+]

--- a/packages/ade-engine/src/ade_engine/pipeline/normalize.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/normalize.py
@@ -1,0 +1,98 @@
+"""Row normalization and validation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Sequence
+
+from ..model import JobContext
+from .models import ColumnMapping, ColumnModule, ExtraColumn
+
+
+def normalize_rows(
+    job: JobContext,
+    rows: Sequence[Sequence[Any]],
+    order: Sequence[str],
+    mapping: Sequence[ColumnMapping],
+    extras: Sequence[ExtraColumn],
+    modules: Mapping[str, ColumnModule],
+    meta: Mapping[str, Mapping[str, Any]],
+    *,
+    state: Mapping[str, Any],
+    logger: logging.Logger,
+) -> tuple[list[list[Any]], list[dict[str, Any]]]:
+    """Apply transforms and validators to produce normalized rows."""
+
+    index_by_field = {entry.field: entry.index for entry in mapping}
+    normalized: list[list[Any]] = []
+    issues: list[dict[str, Any]] = []
+    active_modules = {field: module for field, module in modules.items() if field in order}
+
+    for zero_index, row in enumerate(rows):
+        row_index = zero_index + 2  # header row is index 1
+        canonical_row: dict[str, Any] = {}
+        for field in order:
+            idx = index_by_field.get(field)
+            value = row[idx] if idx is not None and idx < len(row) else None
+            canonical_row[field] = value
+
+        for field in order:
+            module = active_modules.get(field)
+            if module is None or module.transformer is None:
+                continue
+            value = canonical_row.get(field)
+            try:
+                updates = module.transformer(
+                    job=job,
+                    state=state,
+                    row_index=row_index,
+                    field_name=field,
+                    value=value,
+                    row=canonical_row,
+                    field_meta=meta.get(field),
+                    logger=logger,
+                )
+            except Exception as exc:  # pragma: no cover - transform failure
+                raise RuntimeError(
+                    f"Transform for field '{field}' failed on row {row_index}: {exc}"
+                ) from exc
+            if updates:
+                canonical_row.update(dict(updates))
+
+        for field in order:
+            module = active_modules.get(field)
+            if module is None or module.validator is None:
+                continue
+            value = canonical_row.get(field)
+            field_meta = meta.get(field)
+            try:
+                results = module.validator(
+                    job=job,
+                    state=state,
+                    row_index=row_index,
+                    field_name=field,
+                    value=value,
+                    row=canonical_row,
+                    field_meta=field_meta,
+                    logger=logger,
+                )
+            except Exception as exc:  # pragma: no cover - validation failure
+                raise RuntimeError(
+                    f"Validator for field '{field}' failed on row {row_index}: {exc}"
+                ) from exc
+            for issue in results or []:
+                payload = dict(issue)
+                payload.setdefault("row_index", row_index)
+                payload.setdefault("field", field)
+                issues.append(payload)
+
+        normalized_row = [canonical_row.get(field) for field in order]
+        for extra in extras:
+            value = row[extra.index] if extra.index < len(row) else None
+            normalized_row.append(value)
+        normalized.append(normalized_row)
+
+    return normalized, issues
+
+
+__all__ = ["normalize_rows"]

--- a/packages/ade-engine/src/ade_engine/pipeline/output.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/output.py
@@ -1,0 +1,50 @@
+"""Output composition helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openpyxl import Workbook
+
+from ..model import JobContext
+from ..schemas.models import ManifestContext
+from .models import FileExtraction
+
+
+def write_outputs(
+    job: JobContext,
+    manifest: ManifestContext,
+    extractions: list[FileExtraction],
+) -> Path:
+    """Persist normalized rows into an Excel workbook."""
+
+    workbook = Workbook(write_only=True)
+
+    try:
+        for extraction in extractions:
+            sheet = workbook.create_sheet(title=extraction.sheet_name)
+            header_cells = output_headers(manifest, extraction)
+            sheet.append(header_cells)
+            for row in extraction.rows:
+                sheet.append(row)
+
+        output_path = job.paths.output_dir / "normalized.xlsx"
+        tmp_path = output_path.with_suffix(".xlsx.tmp")
+        workbook.save(tmp_path)
+        tmp_path.replace(output_path)
+        return output_path
+    finally:
+        workbook.close()
+
+
+def output_headers(manifest: ManifestContext, extraction: FileExtraction) -> list[str]:
+    """Build output headers combining manifest labels and unmapped columns."""
+
+    order = manifest.column_order
+    meta = manifest.column_meta
+    headers = [meta.get(field, {}).get("label", field) for field in order]
+    headers.extend(extra.output_header for extra in extraction.extra_columns)
+    return headers
+
+
+__all__ = ["output_headers", "write_outputs"]

--- a/packages/ade-engine/src/ade_engine/pipeline/processing.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/processing.py
@@ -1,0 +1,84 @@
+"""Pure helpers for transforming raw tables into normalized structures."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from ade_schemas.manifest import ColumnMeta
+
+from ..model import JobContext
+from .mapping import map_columns
+from .models import ColumnModule, ColumnMapping, ExtraColumn
+from .normalize import normalize_rows
+
+
+@dataclass(slots=True)
+class TableProcessingResult:
+    """Normalized view of a single table after mapping and validation."""
+
+    mapping: list[ColumnMapping]
+    extras: list[ExtraColumn]
+    rows: list[list[Any]]
+    issues: list[dict[str, Any]]
+
+
+def process_table(
+    *,
+    job: JobContext,
+    header_row: Sequence[str],
+    data_rows: Sequence[Sequence[Any]],
+    order: Sequence[str],
+    meta: Mapping[str, Mapping[str, Any]],
+    definitions: Mapping[str, ColumnMeta],
+    modules: Mapping[str, ColumnModule],
+    threshold: float,
+    sample_size: int,
+    append_unmapped: bool,
+    unmapped_prefix: str,
+    table_info: Mapping[str, Any],
+    state: Mapping[str, Any],
+    logger: logging.Logger,
+) -> TableProcessingResult:
+    """Return normalized rows and metadata for an in-memory table."""
+
+    mapping, extras = map_columns(
+        job,
+        header_row,
+        data_rows,
+        order,
+        meta,
+        definitions,
+        modules,
+        threshold=threshold,
+        sample_size=sample_size,
+        append_unmapped=append_unmapped,
+        prefix=unmapped_prefix,
+        table_info=table_info,
+        state=state,
+        logger=logger,
+    )
+
+    normalized_rows, issues = normalize_rows(
+        job,
+        data_rows,
+        order,
+        mapping,
+        extras,
+        modules,
+        meta,
+        state=state,
+        logger=logger,
+    )
+
+    return TableProcessingResult(
+        mapping=list(mapping),
+        extras=list(extras),
+        rows=normalized_rows,
+        issues=issues,
+    )
+
+
+__all__ = ["TableProcessingResult", "process_table"]
+

--- a/packages/ade-engine/src/ade_engine/pipeline/registry.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/registry.py
@@ -1,0 +1,181 @@
+"""Load and validate manifest-declared column modules."""
+
+from __future__ import annotations
+
+import inspect
+from importlib import import_module
+from typing import Any, Iterable, Mapping
+
+from ade_schemas.manifest import ColumnMeta
+
+from .models import ColumnModule
+
+
+class ColumnRegistryError(RuntimeError):
+    """Raised when column modules cannot be loaded or validated."""
+
+
+class ColumnRegistry:
+    """Load column modules defined in the manifest and validate signatures."""
+
+    _DETECTOR_REQUIRED: tuple[str, ...] = ("field_name",)
+    _DETECTOR_ALLOWED: tuple[str, ...] = (
+        "job",
+        "state",
+        "field_name",
+        "field_meta",
+        "header",
+        "column_values_sample",
+        "column_values",
+        "table",
+        "column_index",
+        "logger",
+    )
+    _TRANSFORM_REQUIRED: tuple[str, ...] = ("field_name", "value", "row")
+    _TRANSFORM_ALLOWED: tuple[str, ...] = (
+        "job",
+        "state",
+        "row_index",
+        "field_name",
+        "value",
+        "row",
+        "field_meta",
+        "logger",
+    )
+    _VALIDATOR_REQUIRED: tuple[str, ...] = ("field_name", "value", "row_index")
+    _VALIDATOR_ALLOWED: tuple[str, ...] = (
+        "job",
+        "state",
+        "row_index",
+        "field_name",
+        "value",
+        "row",
+        "field_meta",
+        "logger",
+    )
+
+    def __init__(self, meta: Mapping[str, ColumnMeta], *, package: str) -> None:
+        self._modules: dict[str, ColumnModule] = {}
+        for field, definition in meta.items():
+            if not definition.enabled:
+                continue
+            script = definition.script
+            if not script:
+                continue
+            module_name = _script_to_module(script, package=package)
+            try:
+                module = import_module(module_name)
+            except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+                raise ColumnRegistryError(
+                    f"Column module '{module_name}' could not be imported"
+                ) from exc
+
+            detectors = tuple(
+                getattr(module, attr)
+                for attr in dir(module)
+                if attr.startswith("detect_") and callable(getattr(module, attr))
+            )
+            for detector in detectors:
+                self._validate_callable(
+                    detector,
+                    required=self._DETECTOR_REQUIRED,
+                    allowed=self._DETECTOR_ALLOWED,
+                    kind="detector",
+                    field=field,
+                )
+
+            transformer = getattr(module, "transform", None)
+            if transformer is not None:
+                if not callable(transformer):
+                    raise ColumnRegistryError(
+                        f"Transform callable for field '{field}' must be callable"
+                    )
+                self._validate_callable(
+                    transformer,
+                    required=self._TRANSFORM_REQUIRED,
+                    allowed=self._TRANSFORM_ALLOWED,
+                    kind="transformer",
+                    field=field,
+                )
+            validator = getattr(module, "validate", None)
+            if validator is not None:
+                if not callable(validator):
+                    raise ColumnRegistryError(
+                        f"Validator callable for field '{field}' must be callable"
+                    )
+                self._validate_callable(
+                    validator,
+                    required=self._VALIDATOR_REQUIRED,
+                    allowed=self._VALIDATOR_ALLOWED,
+                    kind="validator",
+                    field=field,
+                )
+
+            meta_payload: Mapping[str, Any] = definition.model_dump()
+            self._modules[field] = ColumnModule(
+                field=field,
+                meta=meta_payload,
+                definition=definition,
+                module=module,
+                detectors=detectors,
+                transformer=transformer,
+                validator=validator,
+            )
+
+    def modules(self) -> Mapping[str, ColumnModule]:
+        """Return loaded modules keyed by field name."""
+
+        return self._modules
+
+    def get(self, field: str) -> ColumnModule | None:
+        """Return the module for ``field`` if registered."""
+
+        return self._modules.get(field)
+
+    @classmethod
+    def _validate_callable(
+        cls,
+        func,
+        *,
+        required: Iterable[str],
+        allowed: Iterable[str],
+        kind: str,
+        field: str,
+    ) -> None:
+        signature = inspect.signature(func)
+        parameters = signature.parameters
+        has_kwargs = any(
+            param.kind is inspect.Parameter.VAR_KEYWORD
+            for param in parameters.values()
+        )
+        missing = [
+            name
+            for name in required
+            if name not in parameters and not has_kwargs
+        ]
+        if missing:
+            raise ColumnRegistryError(
+                f"{kind.title()} for field '{field}' must accept parameters: {', '.join(required)}"
+            )
+
+        for name, param in parameters.items():
+            if param.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.VAR_POSITIONAL,
+            ):
+                continue
+            if name in allowed:
+                continue
+            if param.default is inspect._empty and not has_kwargs:
+                raise ColumnRegistryError(
+                    f"{kind.title()} for field '{field}' has unsupported parameter '{name}'"
+                )
+
+
+def _script_to_module(script: str, *, package: str) -> str:
+    module = script[:-3] if script.endswith(".py") else script
+    module = module.replace("/", ".").replace("-", "_")
+    return f"{package}.{module}" if not module.startswith(package) else module
+
+
+__all__ = ["ColumnRegistry", "ColumnRegistryError"]

--- a/packages/ade-engine/src/ade_engine/pipeline/state.py
+++ b/packages/ade-engine/src/ade_engine/pipeline/state.py
@@ -1,0 +1,112 @@
+"""Finite-state machine coordinating pipeline stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Iterable
+
+from ..logging import StructuredLogger
+from ..model import JobContext, JobResult
+
+
+class PipelinePhase(str, Enum):
+    """Recognized pipeline phases."""
+
+    INITIALIZED = "initialized"
+    EXTRACTING = "extracting"
+    BEFORE_SAVE = "before_save"
+    WRITING_OUTPUT = "writing_output"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+_TRANSITIONS: dict[PipelinePhase, tuple[PipelinePhase, ...]] = {
+    PipelinePhase.INITIALIZED: (PipelinePhase.EXTRACTING, PipelinePhase.FAILED),
+    PipelinePhase.EXTRACTING: (PipelinePhase.BEFORE_SAVE, PipelinePhase.FAILED),
+    PipelinePhase.BEFORE_SAVE: (PipelinePhase.WRITING_OUTPUT, PipelinePhase.FAILED),
+    PipelinePhase.WRITING_OUTPUT: (PipelinePhase.COMPLETED, PipelinePhase.FAILED),
+    PipelinePhase.COMPLETED: (),
+    PipelinePhase.FAILED: (),
+}
+
+
+@dataclass(slots=True)
+class PipelineStateMachine:
+    """Stateful orchestrator for the ADE job pipeline."""
+
+    job: JobContext
+    logger: StructuredLogger
+    phase: PipelinePhase = PipelinePhase.INITIALIZED
+    tables: list = field(default_factory=list)
+    output_paths: tuple[Path, ...] = ()
+
+    def transition(self, next_phase: PipelinePhase, **payload) -> None:
+        if next_phase not in _TRANSITIONS[self.phase]:
+            raise RuntimeError(
+                f"Invalid pipeline transition from {self.phase.value} to {next_phase.value}"
+            )
+        self.phase = next_phase
+        self.logger.transition(next_phase.value, **payload)
+
+    def execute(
+        self,
+        *,
+        extractor: Callable[[], list],
+        after_extract: Callable[[Iterable], None],
+        before_save: Callable[[Iterable], None],
+        writer: Callable[[Iterable], Path],
+    ) -> None:
+        try:
+            self._run_extraction(extractor, after_extract)
+            self._run_before_save(before_save)
+            output = self._run_writer(writer)
+            self.transition(PipelinePhase.COMPLETED, outputs=[str(path) for path in output])
+            self.output_paths = output
+        except Exception as exc:
+            self.phase = PipelinePhase.FAILED
+            self.logger.transition(PipelinePhase.FAILED.value, error=str(exc))
+            raise
+
+    def _run_extraction(
+        self, extractor: Callable[[], list], after_extract: Callable[[Iterable], None]
+    ) -> None:
+        self.transition(PipelinePhase.EXTRACTING)
+        tables = extractor()
+        self.tables = list(tables)
+        after_extract(self.tables)
+
+    def _run_before_save(self, before_save: Callable[[Iterable], None]) -> None:
+        self.transition(PipelinePhase.BEFORE_SAVE, table_count=len(self.tables))
+        before_save(self.tables)
+
+    def _run_writer(self, writer: Callable[[Iterable], Path]) -> tuple[Path, ...]:
+        self.transition(PipelinePhase.WRITING_OUTPUT, table_count=len(self.tables))
+        path = writer(self.tables)
+        if isinstance(path, Path):
+            return (path,)
+        if isinstance(path, tuple):
+            return path
+        if isinstance(path, list):
+            return tuple(path)
+        raise TypeError("Writer must return a Path or iterable of Paths")
+
+
+def build_result(state: PipelineStateMachine, error: str | None = None) -> JobResult:
+    """Assemble a :class:`JobResult` from the state machine's state."""
+
+    status = "failed" if state.phase is PipelinePhase.FAILED else "succeeded"
+    processed = tuple(getattr(table, "source_name", "") for table in state.tables)
+    return JobResult(
+        job_id=state.job.job_id,
+        status=status,
+        artifact_path=state.job.paths.artifact_path,
+        events_path=state.job.paths.events_path,
+        output_paths=state.output_paths,
+        processed_files=processed,
+        error=error,
+    )
+
+
+__all__ = ["PipelinePhase", "PipelineStateMachine", "build_result"]

--- a/packages/ade-engine/src/ade_engine/plugins.py
+++ b/packages/ade-engine/src/ade_engine/plugins.py
@@ -1,0 +1,47 @@
+"""Plugin helpers for loading telemetry integrations."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Iterable
+
+from .sinks import EventSinkFactory
+
+__all__ = [
+    "load_event_sink_factory",
+    "load_event_sink_factories",
+]
+
+
+def _split_spec(spec: str) -> tuple[str, str]:
+    module_path, separator, attr = spec.partition(":")
+    if not separator:
+        module_path, dot, attr = spec.rpartition(".")
+        if not dot:
+            raise ValueError(f"Invalid sink specification: '{spec}'")
+    if not module_path or not attr:
+        raise ValueError(f"Invalid sink specification: '{spec}'")
+    return module_path, attr
+
+
+def load_event_sink_factory(spec: str) -> EventSinkFactory:
+    """Return the event sink factory referenced by ``spec``."""
+
+    module_path, attr = _split_spec(spec)
+    module = import_module(module_path)
+    candidate = getattr(module, attr)
+    if not callable(candidate):  # pragma: no cover - defensive guard
+        raise TypeError(f"Telemetry sink factory '{spec}' is not callable")
+    return candidate  # type: ignore[return-value]
+
+
+def load_event_sink_factories(specs: Iterable[str]) -> tuple[EventSinkFactory, ...]:
+    """Load telemetry sink factories for ``specs``."""
+
+    factories: list[EventSinkFactory] = []
+    for spec in specs:
+        spec = spec.strip()
+        if not spec:
+            continue
+        factories.append(load_event_sink_factory(spec))
+    return tuple(factories)

--- a/packages/ade-engine/src/ade_engine/runtime.py
+++ b/packages/ade-engine/src/ade_engine/runtime.py
@@ -1,11 +1,16 @@
-"""Placeholder runtime helpers for ade_engine."""
+"""Runtime helpers for :mod:`ade_engine`."""
 
 from __future__ import annotations
 
 import json
+import os
 from importlib import resources
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator, ValidationError
+
+from ade_schemas import ManifestContext, ManifestV1
 
 
 class ManifestNotFoundError(RuntimeError):
@@ -29,6 +34,7 @@ def load_config_manifest(
     package: str = "ade_config",
     resource: str = "manifest.json",
     manifest_path: Path | None = None,
+    validate: bool = True,
 ) -> dict[str, Any]:
     """Return the ade_config manifest as a dict.
 
@@ -38,20 +44,117 @@ def load_config_manifest(
     """
 
     if manifest_path is not None:
-        return _read_manifest(manifest_path)
+        manifest = _read_manifest(manifest_path)
+    else:
+        try:
+            resource_path = resources.files(package) / resource
+        except ModuleNotFoundError as exc:
+            raise ManifestNotFoundError(
+                f"Config package '{package}' cannot be imported."
+            ) from exc
 
-    try:
-        resource_path = resources.files(package) / resource
-    except ModuleNotFoundError as exc:
-        raise ManifestNotFoundError(
-            f"Config package '{package}' cannot be imported."
-        ) from exc
+        if not resource_path.is_file():
+            raise ManifestNotFoundError(
+                f"Resource '{resource}' not found in '{package}'."
+            )
+        manifest = _read_manifest(Path(resource_path))
 
-    if not resource_path.is_file():
+    if validate:
+        _validate_manifest(manifest)
+
+    return manifest
+
+
+def load_manifest_context(
+    *,
+    package: str = "ade_config",
+    resource: str = "manifest.json",
+    manifest_path: Path | None = None,
+) -> ManifestContext:
+    """Return a :class:`ManifestContext` with schema-derived helpers."""
+
+    manifest = load_config_manifest(
+        package=package,
+        resource=resource,
+        manifest_path=manifest_path,
+        validate=True,
+    )
+    version = _manifest_version(manifest)
+    model = None
+    if version and version.startswith("ade.manifest/v1"):
+        model = ManifestV1.model_validate(manifest)
+    return ManifestContext(raw=manifest, version=version, model=model)
+
+
+def resolve_jobs_root(
+    jobs_dir: Path | None = None, *, env: Mapping[str, str] | None = None
+) -> Path:
+    """Return the base directory for job execution.
+
+    The resolution order matches the developer documentation: explicit arguments
+    win, followed by ``ADE_JOBS_DIR`` and finally ``ADE_DATA_DIR``.
+    """
+
+    env = os.environ if env is None else env
+
+    if jobs_dir is not None:
+        return Path(jobs_dir)
+
+    if env.get("ADE_JOBS_DIR"):
+        return Path(env["ADE_JOBS_DIR"])
+
+    data_dir = Path(env.get("ADE_DATA_DIR", "./data"))
+    return data_dir / "jobs"
+
+
+def _load_manifest_schema() -> dict[str, Any]:
+    schema_resource = resources.files("ade_schemas") / "manifest.v1.schema.json"
+    return json.loads(schema_resource.read_text(encoding="utf-8"))
+
+
+_MANIFEST_VALIDATOR = Draft202012Validator(_load_manifest_schema())
+
+
+def _validate_manifest(manifest: Mapping[str, Any]) -> None:
+    schema_tag = _manifest_version(manifest)
+    if schema_tag and schema_tag.startswith("ade.manifest/v1"):
+        try:
+            _MANIFEST_VALIDATOR.validate(manifest)
+        except ValidationError as exc:  # pragma: no cover - jsonschema formats message
+            raise ManifestNotFoundError(f"Manifest failed validation: {exc.message}") from exc
+        return
+
+    _validate_legacy_manifest(manifest)
+
+
+def _manifest_version(manifest: Mapping[str, Any]) -> str | None:
+    if isinstance(manifest.get("info"), Mapping):
+        schema_value = manifest["info"].get("schema")
+        if isinstance(schema_value, str):
+            return schema_value
+    schema_version = manifest.get("schema_version")
+    if isinstance(schema_version, str):
+        return schema_version.replace("@", "/")
+    return None
+
+
+def _validate_legacy_manifest(manifest: Mapping[str, Any]) -> None:
+    required_top_level = {"schema_version", "script_api", "engine", "columns"}
+    missing = sorted(value for value in required_top_level if value not in manifest)
+    if missing:
         raise ManifestNotFoundError(
-            f"Resource '{resource}' not found in '{package}'."
+            "Manifest missing required keys: " + ", ".join(missing)
         )
-    return _read_manifest(Path(resource_path))
+
+    columns = manifest.get("columns", {})
+    if "order" not in columns or "meta" not in columns:
+        raise ManifestNotFoundError("Manifest columns section must define 'order' and 'meta'")
 
 
-__all__ = ["ManifestNotFoundError", "load_config_manifest"]
+__all__ = [
+    "ManifestContext",
+    "ManifestNotFoundError",
+    "load_config_manifest",
+    "load_manifest_context",
+    "resolve_jobs_root",
+]

--- a/packages/ade-engine/src/ade_engine/schemas/models.py
+++ b/packages/ade-engine/src/ade_engine/schemas/models.py
@@ -1,0 +1,27 @@
+"""Backward-compatible re-export of manifest schemas from :mod:`ade_schemas`."""
+
+from ade_schemas.manifest import (  # noqa: F401
+    ColumnMeta,
+    ColumnSection,
+    EngineDefaults,
+    EngineSection,
+    EngineWriter,
+    HookCollection,
+    ManifestContext,
+    ManifestInfo,
+    ManifestV1,
+    ScriptRef,
+)
+
+__all__ = [
+    "ColumnMeta",
+    "ColumnSection",
+    "EngineDefaults",
+    "EngineSection",
+    "EngineWriter",
+    "HookCollection",
+    "ManifestContext",
+    "ManifestInfo",
+    "ManifestV1",
+    "ScriptRef",
+]

--- a/packages/ade-engine/src/ade_engine/sinks.py
+++ b/packages/ade-engine/src/ade_engine/sinks.py
@@ -1,0 +1,179 @@
+"""Artifact and event sink abstractions."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Protocol, runtime_checkable
+
+from ade_schemas import TelemetryEnvelope, TelemetryEvent
+
+from .model import JobContext, JobPaths
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso(moment: datetime | None = None) -> str:
+    ts = moment or _now()
+    return ts.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@runtime_checkable
+class ArtifactSink(Protocol):
+    """Destination for job artifact data."""
+
+    def start(self, *, job: JobContext, manifest: dict[str, Any]) -> None: ...
+
+    def note(self, message: str, *, level: str = "info", **extra: Any) -> None: ...
+
+    def record_table(self, table: dict[str, Any]) -> None: ...
+
+    def mark_success(self, *, completed_at: datetime, outputs: Iterable[Path]) -> None: ...
+
+    def mark_failure(self, *, completed_at: datetime, error: Exception) -> None: ...
+
+    def flush(self) -> None: ...
+
+
+@runtime_checkable
+class EventSink(Protocol):
+    """Structured event consumer."""
+
+    def log(self, event: str, *, job: JobContext, **payload: Any) -> None: ...
+
+
+@runtime_checkable
+class SinkProvider(Protocol):
+    """Factory that produces artifact and event sinks for a job."""
+
+    def artifact(self, job: JobContext) -> ArtifactSink: ...
+
+    def events(self, job: JobContext) -> EventSink: ...
+
+
+EventSinkFactory = Callable[[JobContext, JobPaths], EventSink]
+
+
+class FileArtifactSink:
+    """Persist job artifact JSON with atomic writes."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.data: dict[str, Any] = {}
+
+    def start(self, *, job: JobContext, manifest: dict[str, Any]) -> None:
+        self.data = {
+            "schema": "ade.artifact/v1alpha",
+            "artifact_version": "0.1.0",
+            "job": {
+                "job_id": job.job_id,
+                "status": "running",
+                "started_at": _now_iso(job.started_at),
+            },
+            "config": {
+                "schema": manifest.get("info", {}).get("schema"),
+                "manifest_version": manifest.get("info", {}).get("version"),
+            },
+            "tables": [],
+            "notes": [],
+        }
+        self.flush()
+
+    def flush(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(self.data, indent=2) + "\n", encoding="utf-8")
+        tmp_path.replace(self.path)
+
+    def note(self, message: str, *, level: str = "info", **extra: Any) -> None:
+        entry = {"timestamp": _now_iso(), "level": level, "message": message}
+        if extra:
+            entry["details"] = extra
+        self.data.setdefault("notes", []).append(entry)
+
+    def record_table(self, table: dict[str, Any]) -> None:
+        self.data.setdefault("tables", []).append(table)
+
+    def mark_success(self, *, completed_at: datetime, outputs: Iterable[Path]) -> None:
+        self.data["job"].update(
+            {
+                "status": "succeeded",
+                "completed_at": _now_iso(completed_at),
+                "outputs": [str(path) for path in outputs],
+            }
+        )
+
+    def mark_failure(self, *, completed_at: datetime, error: Exception) -> None:
+        self.data["job"].update(
+            {
+                "status": "failed",
+                "completed_at": _now_iso(completed_at),
+                "error": {
+                    "type": error.__class__.__name__,
+                    "message": str(error),
+                },
+            }
+        )
+
+
+class FileEventSink:
+    """Append structured job lifecycle events to ``events.ndjson``."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def log(self, event: str, *, job: JobContext, **payload: Any) -> None:
+        payload_data = dict(payload)
+        level = str(payload_data.pop("level", "info"))
+        event_payload = TelemetryEvent(name=event, level=level, **payload_data)
+        envelope = TelemetryEnvelope(
+            job_id=job.job_id,
+            run_id=str(job.metadata.get("run_id")) if job.metadata.get("run_id") else None,
+            emitted_at=_now(),
+            event=event_payload,
+        )
+        serialized = envelope.model_dump_json()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(serialized + "\n")
+
+
+class DispatchEventSink:
+    """Broadcast telemetry events to multiple sinks."""
+
+    def __init__(self, sinks: Iterable[EventSink]) -> None:
+        self._sinks = tuple(sinks)
+
+    def log(self, event: str, *, job: JobContext, **payload: Any) -> None:
+        for sink in self._sinks:
+            sink.log(event, job=job, **payload)
+
+
+class FileSinkProvider:
+    """Provide file-backed sinks for a job."""
+
+    def __init__(self, paths: JobPaths) -> None:
+        self._paths = paths
+
+    def artifact(self, job: JobContext) -> ArtifactSink:
+        return FileArtifactSink(self._paths.artifact_path)
+
+    def events(self, job: JobContext) -> EventSink:
+        return FileEventSink(self._paths.events_path)
+
+
+__all__ = [
+    "ArtifactSink",
+    "EventSink",
+    "EventSinkFactory",
+    "FileArtifactSink",
+    "FileEventSink",
+    "DispatchEventSink",
+    "FileSinkProvider",
+    "SinkProvider",
+    "_now",
+    "_now_iso",
+]

--- a/packages/ade-engine/src/ade_engine/telemetry.py
+++ b/packages/ade-engine/src/ade_engine/telemetry.py
@@ -1,0 +1,137 @@
+"""Telemetry configuration helpers for ADE runtime instrumentation."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from .model import JobContext, JobPaths
+from .plugins import load_event_sink_factories
+from .sinks import (
+    ArtifactSink,
+    DispatchEventSink,
+    EventSink,
+    EventSinkFactory,
+    FileSinkProvider,
+    SinkProvider,
+)
+
+_LEVELS: dict[str, int] = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+
+def _normalize_level(level: str) -> str:
+    return (level or "info").lower()
+
+
+def level_value(level: str) -> int:
+    """Return the logging level numeric value for ``level``."""
+
+    return _LEVELS.get(_normalize_level(level), logging.INFO)
+
+
+@dataclass(slots=True)
+class TelemetryConfig:
+    """Standardize runtime telemetry behavior across sinks."""
+
+    correlation_id: str | None = None
+    min_note_level: str = "debug"
+    min_event_level: str = "debug"
+    sink_provider: SinkProvider | None = None
+    event_sink_factories: tuple[EventSinkFactory, ...] = field(default_factory=tuple)
+    event_sink_specs: tuple[str, ...] = field(default_factory=tuple)
+    sink_spec_env: str | None = "ADE_TELEMETRY_SINKS"
+
+    def bind(
+        self,
+        job: JobContext,
+        paths: JobPaths,
+        *,
+        provider: SinkProvider | None = None,
+    ) -> TelemetryBindings:
+        """Create sink bindings for ``job`` using configured defaults."""
+
+        selected = provider or self.sink_provider or FileSinkProvider(paths)
+        artifact = selected.artifact(job)
+        base_events = selected.events(job)
+        extra_sinks = [factory(job, paths) for factory in self._resolve_event_factories()]
+        events: EventSink
+        if extra_sinks:
+            events = DispatchEventSink((base_events, *extra_sinks))
+        else:
+            events = base_events
+        return TelemetryBindings(
+            job=job,
+            config=self,
+            provider=selected,
+            artifact=artifact,
+            events=events,
+        )
+
+    def _resolve_event_factories(self) -> tuple[EventSinkFactory, ...]:
+        """Return configured event sink factories including env overrides."""
+
+        factories = list(self.event_sink_factories)
+        specs: list[str] = list(self.event_sink_specs)
+        if self.sink_spec_env:
+            raw_value = os.getenv(self.sink_spec_env, "")
+            specs.extend(part.strip() for part in raw_value.split(",") if part.strip())
+        if specs:
+            factories.extend(load_event_sink_factories(specs))
+        return tuple(factories)
+
+
+@dataclass(slots=True)
+class TelemetryBindings:
+    """Concrete sink bindings produced from a :class:`TelemetryConfig`."""
+
+    job: JobContext
+    config: TelemetryConfig
+    provider: SinkProvider
+    artifact: ArtifactSink
+    events: EventSink
+
+    def enabled_for_note(self, level: str) -> bool:
+        """Return ``True`` when ``level`` meets the note severity threshold."""
+
+        threshold = level_value(self.config.min_note_level)
+        return level_value(level) >= threshold
+
+    def enabled_for_event(self, level: str) -> bool:
+        """Return ``True`` when ``level`` meets the event severity threshold."""
+
+        threshold = level_value(self.config.min_event_level)
+        return level_value(level) >= threshold
+
+    def decorate_details(self, details: dict[str, Any]) -> dict[str, Any]:
+        """Attach correlation metadata to artifact note details."""
+
+        if not self.config.correlation_id:
+            return details
+        enriched = dict(details)
+        enriched.setdefault("correlation_id", self.config.correlation_id)
+        return enriched
+
+    def decorate_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Attach correlation metadata to event payloads."""
+
+        if not self.config.correlation_id:
+            return payload
+        enriched = dict(payload)
+        enriched.setdefault("correlation_id", self.config.correlation_id)
+        return enriched
+
+
+__all__ = [
+    "TelemetryBindings",
+    "TelemetryConfig",
+    "level_value",
+]
+

--- a/packages/ade-engine/src/ade_engine/worker.py
+++ b/packages/ade-engine/src/ade_engine/worker.py
@@ -1,0 +1,103 @@
+"""Job orchestration for the ADE engine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from .hooks import HookExecutionError, HookLoadError
+from .job_service import JobService
+from .model import JobResult
+from .pipeline.extract import extract_inputs
+from .pipeline.output import write_outputs
+from .pipeline.state import build_result
+from .runtime import resolve_jobs_root
+from .sinks import SinkProvider
+from .telemetry import TelemetryConfig
+
+
+def run_job(
+    job_id: str,
+    *,
+    jobs_dir: Path | None = None,
+    manifest_path: Path | None = None,
+    config_package: str = "ade_config",
+    safe_mode: bool = False,
+    sink_provider: SinkProvider | None = None,
+    telemetry: TelemetryConfig | None = None,
+) -> JobResult:
+    """Execute the ADE job pipeline."""
+
+    jobs_root = resolve_jobs_root(jobs_dir)
+    service = JobService(config_package=config_package, telemetry=telemetry)
+    prepared = service.prepare_job(
+        job_id,
+        jobs_root=jobs_root,
+        manifest_path=manifest_path,
+        safe_mode=safe_mode,
+        sink_provider=sink_provider,
+    )
+    job = prepared.job
+    artifact = prepared.telemetry.artifact
+    events = prepared.telemetry.events
+    hooks = prepared.hooks
+    structured_logger = prepared.logger
+    state_machine = prepared.state_machine
+    manifest_ctx = prepared.manifest
+
+    try:
+        hooks.call("on_job_start", job=job, artifact=artifact, events=events)
+
+        registry = prepared.registry
+        writer_cfg = manifest_ctx.writer
+        defaults = manifest_ctx.defaults
+        append_unmapped = bool(writer_cfg.get("append_unmapped_columns", True))
+        prefix = str(writer_cfg.get("unmapped_prefix", "raw_"))
+        sample_size = int(defaults.get("detector_sample_size", 64) or 0)
+        threshold = float(defaults.get("mapping_score_threshold", 0.0) or 0.0)
+
+        state: dict[str, Any] = {"tables": [], "job_id": job.job_id}
+
+        def _extract() -> list:
+            return extract_inputs(
+                job,
+                manifest_ctx,
+                registry.modules(),
+                structured_logger,
+                threshold=threshold,
+                sample_size=sample_size,
+                append_unmapped=append_unmapped,
+                unmapped_prefix=prefix,
+                state=state,
+            )
+
+        def _after_extract(tables: Iterable) -> None:
+            hooks.call("on_after_extract", job=job, artifact=artifact, tables=tables)
+
+        def _before_save(tables: Iterable) -> None:
+            hooks.call("on_before_save", job=job, artifact=artifact, tables=tables)
+
+        def _write(tables: Iterable) -> Path:
+            return write_outputs(job, manifest_ctx, list(tables))
+
+        state_machine.execute(
+            extractor=_extract,
+            after_extract=_after_extract,
+            before_save=_before_save,
+            writer=_write,
+        )
+
+        result = build_result(state_machine)
+        result = service.finalize_success(prepared, result)
+        hooks.call("on_job_end", job=job, artifact=artifact, result=result)
+        artifact.flush()
+        return result
+    except Exception as exc:
+        return service.finalize_failure(prepared, exc)
+
+
+__all__ = [
+    "HookExecutionError",
+    "HookLoadError",
+    "run_job",
+]

--- a/packages/ade-engine/tests/pipeline/test_io.py
+++ b/packages/ade-engine/tests/pipeline/test_io.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import openpyxl
+
+from ade_engine.pipeline.io import list_input_files, read_table, sheet_name
+
+
+def test_list_input_files_filters_extensions(tmp_path: Path) -> None:
+    files = [
+        tmp_path / "data.csv",
+        tmp_path / "notes.txt",
+        tmp_path / "table.xlsx",
+    ]
+    (tmp_path / "dir").mkdir()
+    for path in files:
+        if path.suffix == ".xlsx":
+            workbook = openpyxl.Workbook()
+            workbook.save(path)
+            workbook.close()
+        else:
+            path.write_text("header\nvalue\n", encoding="utf-8")
+    results = list_input_files(tmp_path)
+    assert [file.name for file in results] == ["data.csv", "table.xlsx"]
+
+
+def test_read_table_handles_csv(tmp_path: Path) -> None:
+    csv_path = tmp_path / "values.csv"
+    csv_path.write_text("Name,Email\nAlice,alice@example.com\n", encoding="utf-8")
+    header, rows = read_table(csv_path)
+    assert header == ["Name", "Email"]
+    assert rows[0][1] == "alice@example.com"
+
+
+def test_sheet_name_sanitizes_input() -> None:
+    assert sheet_name("Employee-List 2024") == "Employee List 2024"

--- a/packages/ade-engine/tests/pipeline/test_mapping.py
+++ b/packages/ade-engine/tests/pipeline/test_mapping.py
@@ -1,0 +1,101 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from ade_schemas.manifest import ColumnMeta
+
+from ade_engine.pipeline.mapping import (
+    build_unmapped_header,
+    column_sample,
+    map_columns,
+    match_header,
+)
+from ade_engine.pipeline.models import ColumnModule
+from ade_engine.model import JobContext, JobPaths
+
+
+class _DetectorModule(SimpleNamespace):
+    pass
+
+
+def _job() -> JobContext:
+    paths = JobPaths(
+        jobs_root=SimpleNamespace(),
+        job_dir=SimpleNamespace(),
+        input_dir=SimpleNamespace(),
+        output_dir=SimpleNamespace(),
+        logs_dir=SimpleNamespace(),
+        artifact_path=SimpleNamespace(),
+        events_path=SimpleNamespace(),
+    )
+    return JobContext(job_id="job", manifest={}, paths=paths, started_at=datetime.now(timezone.utc))
+
+
+def test_map_columns_scores_best_match() -> None:
+    def detect_email(**kwargs):
+        header = kwargs.get("header")
+        if header == "email":
+            return {"scores": {"email": 2.0}}
+        return {"scores": {}}
+
+    definition = ColumnMeta(label="Email", script="tests.email")
+    modules = {
+        "email": ColumnModule(
+            field="email",
+            meta=definition.model_dump(),
+            definition=definition,
+            module=_DetectorModule(),
+            detectors=(detect_email,),
+            transformer=None,
+            validator=None,
+        )
+    }
+
+    mapping, extras = map_columns(
+        _job(),
+        ["Email", "Name"],
+        [["test@example.com", "Jane"]],
+        ["email"],
+        {"email": {"label": "Email"}},
+        {"email": definition},
+        modules,
+        threshold=0.5,
+        sample_size=4,
+        append_unmapped=True,
+        prefix="raw_",
+        table_info={},
+        state={},
+        logger=_DummyLogger(),
+    )
+
+    assert mapping[0].field == "email"
+    assert extras and extras[0].output_header.startswith("raw_")
+
+
+def test_match_header_uses_synonyms() -> None:
+    definition = ColumnMeta(label="Member", script="tests.member", synonyms=("ID",))
+    result = match_header(
+        ["member_id"],
+        {"member_id": definition},
+        "id",
+        set(),
+    )
+    assert result == "member_id"
+
+
+def test_column_sample_evenly_distributes_values() -> None:
+    values = list(range(10))
+    sample = column_sample(values, 4)
+    assert len(sample) == 4
+    assert sample[-1] == values[-1]
+
+
+def test_build_unmapped_header_sanitizes_text() -> None:
+    assert build_unmapped_header("raw_", "Employee Name", 0).startswith("raw_employee")
+
+
+class _DummyLogger:
+    def __getattr__(self, name):  # pragma: no cover - allow silent logging
+        def _noop(*_args, **_kwargs):
+            return None
+
+        return _noop

--- a/packages/ade-engine/tests/pipeline/test_normalize.py
+++ b/packages/ade-engine/tests/pipeline/test_normalize.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from ade_schemas.manifest import ColumnMeta
+
+from ade_engine.pipeline.models import ColumnMapping, ColumnModule
+from ade_engine.pipeline.normalize import normalize_rows
+from ade_engine.model import JobContext, JobPaths
+
+
+def _job() -> JobContext:
+    paths = JobPaths(
+        jobs_root=SimpleNamespace(),
+        job_dir=SimpleNamespace(),
+        input_dir=SimpleNamespace(),
+        output_dir=SimpleNamespace(),
+        logs_dir=SimpleNamespace(),
+        artifact_path=SimpleNamespace(),
+        events_path=SimpleNamespace(),
+    )
+    return JobContext(job_id="job", manifest={}, paths=paths, started_at=datetime.now(timezone.utc))
+
+
+def test_normalize_rows_applies_transforms_and_validators() -> None:
+    def transform(**kwargs):
+        value = kwargs.get("value")
+        if value:
+            normalized = str(value).strip().lower()
+            row = kwargs["row"]
+            row[kwargs["field_name"]] = normalized
+            return {kwargs["field_name"]: normalized}
+        return None
+
+    def validate(**kwargs):
+        if not kwargs.get("value"):
+            return [{"code": "missing"}]
+        return []
+
+    definition = ColumnMeta(label="Email", script="tests.email")
+    module = ColumnModule(
+        field="email",
+        meta=definition.model_dump(),
+        definition=definition,
+        module=SimpleNamespace(),
+        detectors=(),
+        transformer=transform,
+        validator=validate,
+    )
+
+    rows, issues = normalize_rows(
+        _job(),
+        [["USER@example.com"], [""]],
+        ["email"],
+        [ColumnMapping(field="email", header="Email", index=0, score=1.0, contributions=tuple())],
+        [],
+        {"email": module},
+        {"email": module.meta},
+        state={},
+        logger=_DummyLogger(),
+    )
+
+    assert rows[0][0] == "user@example.com"
+    assert issues[0]["code"] == "missing"
+
+
+class _DummyLogger:
+    def __getattr__(self, name):  # pragma: no cover - allow silent logging
+        def _noop(*_args, **_kwargs):
+            return None
+
+        return _noop

--- a/packages/ade-engine/tests/pipeline/test_output.py
+++ b/packages/ade-engine/tests/pipeline/test_output.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import openpyxl
+
+from ade_engine.model import JobContext, JobPaths
+from ade_engine.pipeline.models import ColumnMapping, ExtraColumn, FileExtraction
+from ade_engine.pipeline.output import output_headers, write_outputs
+from ade_engine.schemas.models import ManifestContext
+
+
+def _job(tmp_path: Path) -> JobContext:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True)
+    paths = JobPaths(
+        jobs_root=tmp_path,
+        job_dir=tmp_path,
+        input_dir=tmp_path / "input",
+        output_dir=output_dir,
+        logs_dir=tmp_path / "logs",
+        artifact_path=tmp_path / "logs" / "artifact.json",
+        events_path=tmp_path / "logs" / "events.ndjson",
+    )
+    return JobContext(job_id="job", manifest={}, paths=paths, started_at=datetime.now(timezone.utc))
+
+
+def test_output_headers_combines_manifest_and_extras() -> None:
+    extraction = FileExtraction(
+        source_name="file.csv",
+        sheet_name="Sheet",
+        mapped_columns=[
+            ColumnMapping(field="member_id", header="ID", index=0, score=1.0, contributions=tuple())
+        ],
+        extra_columns=[ExtraColumn(header="Original", index=1, output_header="raw_original")],
+        rows=[["123", "foo"]],
+        header_row=["ID", "Original"],
+        validation_issues=[],
+    )
+    manifest = ManifestContext(
+        raw={"columns": {"order": ["member_id"], "meta": {"member_id": {"label": "Member"}}}},
+        version=None,
+        model=None,
+    )
+    headers = output_headers(manifest, extraction)
+    assert headers == ["Member", "raw_original"]
+
+
+def test_write_outputs_creates_workbook(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    extraction = FileExtraction(
+        source_name="file.csv",
+        sheet_name="Employees",
+        mapped_columns=[
+            ColumnMapping(field="member_id", header="ID", index=0, score=1.0, contributions=tuple())
+        ],
+        extra_columns=[],
+        rows=[["123"]],
+        header_row=["ID"],
+        validation_issues=[],
+    )
+    manifest = ManifestContext(
+        raw={"columns": {"order": ["member_id"], "meta": {"member_id": {"label": "Member"}}}},
+        version=None,
+        model=None,
+    )
+
+    output_path = write_outputs(job, manifest, [extraction])
+    workbook = openpyxl.load_workbook(output_path, read_only=True)
+    sheet = workbook[workbook.sheetnames[0]]
+    first_row = next(sheet.iter_rows(values_only=True))
+    assert first_row == ("Member",)
+    workbook.close()

--- a/packages/ade-engine/tests/pipeline/test_registry.py
+++ b/packages/ade-engine/tests/pipeline/test_registry.py
@@ -1,0 +1,77 @@
+import textwrap
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ade_schemas.manifest import ColumnMeta
+
+from ade_engine.pipeline.registry import ColumnRegistry, ColumnRegistryError
+
+
+def _write_module(root: Path, path: str, content: str) -> None:
+    file_path = root / path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def test_column_registry_loads_modules(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg_root = tmp_path / "cfg"
+    module_root = pkg_root / "ade_config"
+    (module_root / "__init__.py").write_text("", encoding="utf-8")
+    _write_module(
+        module_root,
+        "column_detectors/member.py",
+        """
+        def detect_from_header(**kwargs):
+            return {"scores": {kwargs["field_name"]: 1.0}}
+
+        def transform(*, value, row, field_name, **_):
+            row[field_name] = value
+            return {field_name: value}
+
+        def validate(*, value, field_name, row_index, **_):
+            if not value:
+                return [{"code": "missing", "row_index": row_index, "field": field_name}]
+            return []
+        """,
+    )
+
+    monkeypatch.syspath_prepend(str(pkg_root))
+    registry = ColumnRegistry(
+        {"member": ColumnMeta(label="Member", script="column_detectors/member.py")},
+        package="ade_config",
+    )
+
+    module = registry.get("member")
+    assert module is not None
+    assert module.detectors
+    assert callable(module.transformer)
+    assert callable(module.validator)
+
+
+def test_column_registry_validates_signatures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg_root = tmp_path / "cfg"
+    module_root = pkg_root / "ade_config"
+    (module_root / "__init__.py").write_text("", encoding="utf-8")
+    _write_module(
+        module_root,
+        "column_detectors/member.py",
+        """
+        def detect_from_header(header):
+            return {"scores": {}}
+
+        def transform(value):
+            return value
+        """,
+    )
+
+    monkeypatch.syspath_prepend(str(pkg_root))
+
+    with pytest.raises(ColumnRegistryError) as excinfo:
+        ColumnRegistry(
+            {"member": ColumnMeta(label="Member", script="column_detectors/member.py")},
+            package="ade_config",
+        )
+
+    assert 'Transformer for field' in str(excinfo.value)

--- a/packages/ade-engine/tests/pipeline/test_state.py
+++ b/packages/ade-engine/tests/pipeline/test_state.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+from ade_engine.logging import StructuredLogger
+from ade_engine.model import JobContext, JobPaths
+from ade_engine.pipeline.state import PipelinePhase, PipelineStateMachine, build_result
+from ade_engine.telemetry import TelemetryConfig
+
+
+@dataclass
+class DummyArtifact:
+    notes: list[tuple[str, dict]] = field(default_factory=list)
+    tables: list[dict] = field(default_factory=list)
+
+    def note(self, message: str, *, level: str = "info", **details) -> None:
+        self.notes.append((message, {"level": level, **details}))
+
+    def record_table(self, table: dict) -> None:
+        self.tables.append(table)
+
+    def mark_success(self, **_) -> None:  # pragma: no cover - unused in tests
+        pass
+
+    def mark_failure(self, **_) -> None:  # pragma: no cover - unused in tests
+        pass
+
+    def flush(self) -> None:
+        pass
+
+
+@dataclass
+class DummyEvents:
+    events: list[tuple[str, dict]] = field(default_factory=list)
+
+    def log(self, event: str, *, job, **payload) -> None:  # noqa: ANN001 - test helper
+        self.events.append((event, {"job_id": job.job_id, **payload}))
+
+
+@dataclass
+class StaticSinkProvider:
+    artifact_sink: DummyArtifact
+    event_sink: DummyEvents
+
+    def artifact(self, job: JobContext) -> DummyArtifact:  # noqa: D401 - test helper
+        """Return the pre-baked artifact sink."""
+
+        return self.artifact_sink
+
+    def events(self, job: JobContext) -> DummyEvents:  # noqa: D401 - test helper
+        """Return the pre-baked events sink."""
+
+        return self.event_sink
+
+
+def _job(tmp_path: Path) -> JobContext:
+    paths = JobPaths(
+        jobs_root=tmp_path,
+        job_dir=tmp_path,
+        input_dir=tmp_path / "input",
+        output_dir=tmp_path / "output",
+        logs_dir=tmp_path / "logs",
+        artifact_path=tmp_path / "logs" / "artifact.json",
+        events_path=tmp_path / "logs" / "events.ndjson",
+    )
+    return JobContext(job_id="job", manifest={}, paths=paths, started_at=datetime.now(timezone.utc))
+
+
+def test_pipeline_state_machine_executes_stages(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    artifact = DummyArtifact()
+    events = DummyEvents()
+    telemetry = TelemetryConfig().bind(
+        job,
+        job.paths,
+        provider=StaticSinkProvider(artifact, events),
+    )
+    logger = StructuredLogger(job, telemetry)
+    state = PipelineStateMachine(job, logger)
+
+    extraction = SimpleNamespace(source_name="employees.csv")
+    output_file = tmp_path / "output" / "normalized.xlsx"
+
+    state.execute(
+        extractor=lambda: [extraction],
+        after_extract=lambda tables: None,
+        before_save=lambda tables: None,
+        writer=lambda tables: output_file,
+    )
+
+    assert state.phase is PipelinePhase.COMPLETED
+    assert state.output_paths == (output_file,)
+    result = build_result(state)
+    assert result.status == "succeeded"
+    assert result.output_paths == (output_file,)
+    assert result.processed_files == ("employees.csv",)
+    assert any(event for event, payload in events.events if event == "pipeline_transition")
+
+
+def test_pipeline_state_machine_blocks_invalid_transition(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    telemetry = TelemetryConfig().bind(
+        job,
+        job.paths,
+        provider=StaticSinkProvider(DummyArtifact(), DummyEvents()),
+    )
+    logger = StructuredLogger(job, telemetry)
+    state = PipelineStateMachine(job, logger)
+
+    try:
+        state.transition(PipelinePhase.COMPLETED)
+    except RuntimeError as exc:
+        assert "Invalid pipeline transition" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("transition should have failed")

--- a/packages/ade-engine/tests/test_main.py
+++ b/packages/ade-engine/tests/test_main.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
+import json
 from pathlib import Path
 
 from ade_engine.__main__ import main
@@ -25,3 +24,43 @@ def test_main_prints_manifest(capsys) -> None:
 
     assert code == 0
     assert '"config_manifest"' in captured.out
+
+
+def test_main_runs_job(tmp_path: Path, capsys) -> None:
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "job-cli"
+    input_dir = job_dir / "input"
+    logs_dir = job_dir / "logs"
+    input_dir.mkdir(parents=True)
+    logs_dir.mkdir(parents=True)
+    (input_dir / "data.csv").write_text("Member ID\n1\n", encoding="utf-8")
+
+    manifest = {
+        "schema_version": "ade.manifest@1",
+        "script_api": 1,
+        "engine": {
+            "defaults": {"mapping_score_threshold": 0.0},
+            "writer": {"append_unmapped_columns": False},
+        },
+        "columns": {
+            "order": ["member_id"],
+            "meta": {"member_id": {"label": "Member ID"}},
+        },
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    code = main(
+        [
+            "--job-id",
+            "job-cli",
+            "--jobs-dir",
+            str(jobs_dir),
+            "--manifest-path",
+            str(manifest_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert '"status": "succeeded"' in captured.out

--- a/packages/ade-engine/tests/test_runtime.py
+++ b/packages/ade-engine/tests/test_runtime.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from ade_engine.runtime import load_config_manifest
+from ade_engine.runtime import load_config_manifest, load_manifest_context
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 TEMPLATES_ROOT = REPO_ROOT / "apps" / "api" / "app" / "templates" / "config_packages"
@@ -13,3 +14,48 @@ def test_load_config_manifest_from_path() -> None:
     manifest = load_config_manifest(manifest_path=MANIFEST_PATH)
 
     assert manifest["config"]["display_name"] == "ADE Config Package"
+
+
+def test_load_manifest_context_returns_models(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "config_script_api_version": "1",
+                "info": {
+                    "schema": "ade.manifest/v1.0",
+                    "title": "Test",
+                    "version": "1.0.0",
+                },
+                "engine": {
+                    "defaults": {
+                        "mapping_score_threshold": 0.6,
+                        "detector_sample_size": 10,
+                    },
+                    "writer": {
+                        "mode": "row_streaming",
+                        "append_unmapped_columns": True,
+                        "unmapped_prefix": "raw_",
+                        "output_sheet": "Normalized",
+                    },
+                },
+                "hooks": {},
+                "columns": {
+                    "order": ["member_id"],
+                    "meta": {
+                        "member_id": {
+                            "label": "Member ID",
+                            "script": "columns/member_id.py",
+                        }
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    context = load_manifest_context(manifest_path=manifest_path)
+
+    assert context.model is not None
+    assert context.column_order == ["member_id"]
+    assert context.writer["mode"] == "row_streaming"

--- a/packages/ade-engine/tests/test_telemetry.py
+++ b/packages/ade-engine/tests/test_telemetry.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ade_engine.logging import StructuredLogger
+from ade_engine.model import JobContext, JobPaths
+from ade_engine.telemetry import TelemetryConfig
+
+_PLUGIN_EVENTS: list[tuple[str, dict[str, Any]]] = []
+
+
+def telemetry_test_sink(job: JobContext, paths: JobPaths):  # pragma: no cover - imported via env
+    class _Sink:
+        def log(self, event: str, *, job: JobContext, **payload: Any) -> None:
+            _PLUGIN_EVENTS.append((event, {"job_id": job.job_id, **payload}))
+
+    return _Sink()
+
+
+class MemoryArtifact:
+    def __init__(self) -> None:
+        self.notes: list[tuple[str, dict[str, Any]]] = []
+
+    def start(self, *, job: JobContext, manifest: dict[str, Any]) -> None:  # noqa: D401 - noop
+        """Test helper does not persist start payloads."""
+
+    def note(self, message: str, *, level: str = "info", **details: Any) -> None:
+        self.notes.append((message, {"level": level, **details}))
+
+    def record_table(self, table: dict[str, Any]) -> None:  # noqa: D401 - noop
+        """Test helper does not persist table records."""
+
+    def mark_success(self, *, completed_at, outputs) -> None:  # noqa: D401 - noop
+        """Test helper does not persist success payloads."""
+
+    def mark_failure(self, *, completed_at, error) -> None:  # noqa: D401 - noop
+        """Test helper does not persist failure payloads."""
+
+    def flush(self) -> None:  # noqa: D401 - noop
+        """Test helper does not flush to disk."""
+
+
+class MemoryEvents:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def log(self, event: str, *, job: JobContext, **payload: Any) -> None:
+        self.events.append((event, {"job_id": job.job_id, **payload}))
+
+
+class StaticProvider:
+    def __init__(self, artifact: MemoryArtifact, events: MemoryEvents) -> None:
+        self._artifact = artifact
+        self._events = events
+
+    def artifact(self, job: JobContext) -> MemoryArtifact:
+        return self._artifact
+
+    def events(self, job: JobContext) -> MemoryEvents:
+        return self._events
+
+
+def _job(tmp_path: Path) -> JobContext:
+    paths = JobPaths(
+        jobs_root=tmp_path,
+        job_dir=tmp_path,
+        input_dir=tmp_path / "input",
+        output_dir=tmp_path / "output",
+        logs_dir=tmp_path / "logs",
+        artifact_path=tmp_path / "logs" / "artifact.json",
+        events_path=tmp_path / "logs" / "events.ndjson",
+    )
+    return JobContext(
+        job_id="job",
+        manifest={},
+        paths=paths,
+        started_at=datetime.now(timezone.utc),
+    )
+
+
+def test_telemetry_config_controls_levels(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    artifact = MemoryArtifact()
+    events = MemoryEvents()
+    config = TelemetryConfig(
+        correlation_id="corr-123",
+        min_note_level="info",
+        min_event_level="warning",
+    )
+    telemetry = config.bind(job, job.paths, provider=StaticProvider(artifact, events))
+    logger = StructuredLogger(job, telemetry)
+
+    logger.note("debug note", level="debug", detail="suppressed")
+    logger.note("info note", level="info", detail="kept")
+    logger.event("debug_event", level="debug", flag=True)
+    logger.event("warn_event", level="warning", flag=True)
+
+    assert all(message != "debug note" for message, _ in artifact.notes)
+    note_details = dict(artifact.notes[0][1])
+    assert note_details["level"] == "info"
+    assert note_details["correlation_id"] == "corr-123"
+
+    assert all(event != "debug_event" for event, _ in events.events)
+    event_name, payload = events.events[0]
+    assert event_name == "warn_event"
+    assert payload["level"] == "warning"
+    assert payload["correlation_id"] == "corr-123"
+
+
+def test_telemetry_config_broadcasts_to_extra_sinks(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    artifact = MemoryArtifact()
+    events = MemoryEvents()
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    def extra_factory(job: JobContext, paths: JobPaths):
+        class _Sink:
+            def log(self, event: str, *, job: JobContext, **payload: Any) -> None:
+                captured.append((event, {"job_id": job.job_id, **payload}))
+
+        return _Sink()
+
+    config = TelemetryConfig(event_sink_factories=(extra_factory,))
+    telemetry = config.bind(job, job.paths, provider=StaticProvider(artifact, events))
+    logger = StructuredLogger(job, telemetry)
+
+    logger.event("broadcast", level="info", flag=True)
+
+    assert captured and captured[0][0] == "broadcast"
+    assert captured[0][1]["flag"] is True
+
+
+def test_telemetry_config_loads_env_sinks(tmp_path: Path, monkeypatch) -> None:
+    global _PLUGIN_EVENTS
+    _PLUGIN_EVENTS = []
+    job = _job(tmp_path)
+    artifact = MemoryArtifact()
+    events = MemoryEvents()
+
+    monkeypatch.setenv(
+        "ADE_TELEMETRY_SINKS",
+        "ade_engine.tests.test_telemetry:telemetry_test_sink",
+    )
+
+    config = TelemetryConfig()
+    telemetry = config.bind(job, job.paths, provider=StaticProvider(artifact, events))
+    logger = StructuredLogger(job, telemetry)
+
+    logger.event("env_sink", level="info", extra="value")
+
+    assert _PLUGIN_EVENTS and _PLUGIN_EVENTS[0][0] == "env_sink"
+    assert _PLUGIN_EVENTS[0][1]["extra"] == "value"

--- a/packages/ade-engine/tests/test_worker.py
+++ b/packages/ade-engine/tests/test_worker.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from ade_schemas import ADE_TELEMETRY_EVENT_SCHEMA, TelemetryEnvelope
+
+from ade_engine.worker import run_job
+
+
+def _setup_config_package(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    include_hooks: bool = False,
+) -> Path:
+    pkg_root = tmp_path / ("config_pkg_hooks" if include_hooks else "config_pkg")
+    config_pkg = pkg_root / "ade_config"
+    detectors_dir = config_pkg / "column_detectors"
+    detectors_dir.mkdir(parents=True)
+    (config_pkg / "__init__.py").write_text("", encoding="utf-8")
+    (detectors_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    member_module = textwrap.dedent(
+        """
+        def detect_from_header(**kwargs):
+            header = kwargs.get("header") or ""
+            if header == "id":
+                return {"scores": {kwargs["field_name"]: 1.0}}
+            return {"scores": {}}
+
+        def transform(*, value, row, field_name, **_):
+            if value is None:
+                return None
+            normalized = str(value).strip()
+            row[field_name] = normalized
+            return {field_name: normalized}
+        """
+    )
+    (detectors_dir / "member_id.py").write_text(member_module, encoding="utf-8")
+
+    email_module = textwrap.dedent(
+        """
+        def detect_from_header(**kwargs):
+            header = kwargs.get("header") or ""
+            if header == "email":
+                return {"scores": {kwargs["field_name"]: 1.0}}
+            sample = kwargs.get("column_values_sample", [])
+            if any("@" in str(value) for value in sample if value):
+                return {"scores": {kwargs["field_name"]: 0.5}}
+            return {"scores": {}}
+
+        def transform(*, value, row, field_name, **_):
+            if value is None:
+                return None
+            normalized = str(value).strip().lower()
+            row[field_name] = normalized
+            return {field_name: normalized}
+
+        def validate(*, value, field_meta=None, row_index, field_name, **_):
+            issues = []
+            if field_meta and field_meta.get("required") and not value:
+                issues.append({"code": "required_missing"})
+            if value and "@" not in value:
+                issues.append({"code": "invalid_email"})
+            for issue in issues:
+                issue.setdefault("field", field_name)
+                issue.setdefault("row_index", row_index)
+            return issues
+        """
+    )
+    (detectors_dir / "email.py").write_text(email_module, encoding="utf-8")
+
+    manifest: dict[str, object] = {
+        "schema_version": "ade.manifest@1",
+        "script_api": 1,
+        "engine": {
+            "defaults": {
+                "mapping_score_threshold": 0.25,
+                "detector_sample_size": 8,
+            },
+            "writer": {
+                "append_unmapped_columns": True,
+                "unmapped_prefix": "raw_",
+            },
+        },
+        "hooks": {},
+        "columns": {
+            "order": ["member_id", "email"],
+            "meta": {
+                "member_id": {
+                    "label": "Member ID",
+                    "synonyms": ["ID"],
+                    "script": "column_detectors/member_id.py",
+                },
+                "email": {
+                    "label": "Email",
+                    "required": True,
+                    "script": "column_detectors/email.py",
+                },
+            },
+        },
+    }
+
+    if include_hooks:
+        hooks_dir = config_pkg / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "__init__.py").write_text("", encoding="utf-8")
+        (hooks_dir / "on_job_start.py").write_text(
+            "def run(*, artifact, **_):\n    artifact.note('start hook')\n",
+            encoding="utf-8",
+        )
+        (hooks_dir / "on_job_end.py").write_text(
+            "def run(*, artifact, result, **_):\n    artifact.note('end hook', status=result.status)\n",
+            encoding="utf-8",
+        )
+        manifest["hooks"] = {
+            "on_job_start": [{"script": "hooks/on_job_start.py"}],
+            "on_job_end": [{"script": "hooks/on_job_end.py"}],
+        }
+
+    manifest_path = config_pkg / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.syspath_prepend(str(pkg_root))
+    for name in list(sys.modules):
+        if name == "ade_config" or name.startswith("ade_config."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    return manifest_path
+
+
+def test_run_job_normalizes_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = _setup_config_package(tmp_path, monkeypatch)
+
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "job-1"
+    input_dir = job_dir / "input"
+    logs_dir = job_dir / "logs"
+    input_dir.mkdir(parents=True)
+    logs_dir.mkdir(parents=True)
+
+    csv_path = input_dir / "employees.csv"
+    csv_path.write_text(
+        "ID,Email,Name\n123,USER@EXAMPLE.COM,Alice\n456,invalid,Bob\n",
+        encoding="utf-8",
+    )
+
+    result = run_job(
+        "job-1",
+        jobs_dir=jobs_dir,
+        manifest_path=manifest_path,
+        config_package="ade_config",
+    )
+
+    assert result.status == "succeeded"
+    assert result.processed_files == ("employees.csv",)
+    workbook = openpyxl.load_workbook(result.output_paths[0], read_only=True)
+    sheet = workbook[workbook.sheetnames[0]]
+    rows = list(sheet.iter_rows(values_only=True))
+    assert rows[0] == ("Member ID", "Email", "raw_Name")
+    assert rows[1][:2] == ("123", "user@example.com")
+    assert rows[2][1] == "invalid"
+    workbook.close()
+
+    artifact = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    assert artifact["job"]["status"] == "succeeded"
+    table = artifact["tables"][0]
+    assert table["mapping"][0]["field"] == "member_id"
+    assert any(entry["code"] == "invalid_email" for entry in table["validation"])
+
+    envelopes = [
+        TelemetryEnvelope.model_validate_json(line)
+        for line in result.events_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert all(envelope.schema == ADE_TELEMETRY_EVENT_SCHEMA for envelope in envelopes)
+    assert any(env.event.name == "job_started" for env in envelopes)
+    assert any(env.event.name == "job_completed" for env in envelopes)
+    assert any(env.event.name == "validation_issue" for env in envelopes)
+
+
+def test_hooks_are_executed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = _setup_config_package(tmp_path, monkeypatch, include_hooks=True)
+
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "job-2"
+    input_dir = job_dir / "input"
+    logs_dir = job_dir / "logs"
+    input_dir.mkdir(parents=True)
+    logs_dir.mkdir(parents=True)
+    (input_dir / "data.csv").write_text("ID\n42\n", encoding="utf-8")
+
+    result = run_job(
+        "job-2",
+        jobs_dir=jobs_dir,
+        manifest_path=manifest_path,
+        config_package="ade_config",
+    )
+
+    assert result.status == "succeeded"
+    artifact = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    notes = [entry["message"] for entry in artifact["notes"]]
+    assert "start hook" in notes
+    assert any(
+        entry["message"] == "end hook" and entry.get("details", {}).get("status") == "succeeded"
+        for entry in artifact["notes"]
+    )

--- a/packages/ade-schemas/pyproject.toml
+++ b/packages/ade-schemas/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=80"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ade-schemas"
+version = "0.1.0"
+description = "Shared ADE manifest and telemetry schemas."
+requires-python = ">=3.12"
+readme = { text = "Shared ADE schema models.", content-type = "text/plain" }
+license = { text = "Proprietary" }
+dependencies = [
+    "pydantic>=2.6",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"ade_schemas" = ["*.json"]

--- a/packages/ade-schemas/src/ade_schemas/__init__.py
+++ b/packages/ade-schemas/src/ade_schemas/__init__.py
@@ -1,0 +1,37 @@
+"""Shared ADE manifest and telemetry schema models."""
+
+from .manifest import (
+    ColumnMeta,
+    ColumnSection,
+    EngineDefaults,
+    EngineSection,
+    EngineWriter,
+    HookCollection,
+    ManifestContext,
+    ManifestInfo,
+    ManifestV1,
+    ScriptRef,
+)
+from .telemetry import (
+    ADE_TELEMETRY_EVENT_SCHEMA,
+    TelemetryEnvelope,
+    TelemetryEvent,
+    TelemetryLevel,
+)
+
+__all__ = [
+    "ADE_TELEMETRY_EVENT_SCHEMA",
+    "ColumnMeta",
+    "ColumnSection",
+    "EngineDefaults",
+    "EngineSection",
+    "EngineWriter",
+    "HookCollection",
+    "ManifestContext",
+    "ManifestInfo",
+    "ManifestV1",
+    "ScriptRef",
+    "TelemetryEnvelope",
+    "TelemetryEvent",
+    "TelemetryLevel",
+]

--- a/packages/ade-schemas/src/ade_schemas/manifest.py
+++ b/packages/ade-schemas/src/ade_schemas/manifest.py
@@ -1,0 +1,198 @@
+"""Typed manifest models derived from the ADE JSON schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ScriptRef(BaseModel):
+    """Reference to a hook script."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    script: str
+    enabled: bool = True
+
+
+class HookCollection(BaseModel):
+    """Collection of hook definitions grouped by lifecycle stage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    on_activate: tuple[ScriptRef, ...] = ()
+    on_job_start: tuple[ScriptRef, ...] = ()
+    on_after_extract: tuple[ScriptRef, ...] = ()
+    on_before_save: tuple[ScriptRef, ...] = ()
+    on_job_end: tuple[ScriptRef, ...] = ()
+
+
+class ColumnMeta(BaseModel):
+    """Metadata describing an output column."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    script: str
+    required: bool = False
+    enabled: bool = True
+    synonyms: tuple[str, ...] = ()
+    type_hint: str | None = None
+
+
+class ColumnSection(BaseModel):
+    """Manifest ``columns`` section."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    order: list[str]
+    meta: dict[str, ColumnMeta]
+
+
+class EngineDefaults(BaseModel):
+    """Defaults that influence pipeline behaviour."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    timeout_ms: int | None = Field(default=None, ge=1000)
+    memory_mb: int | None = Field(default=None, ge=64)
+    runtime_network_access: bool = False
+    mapping_score_threshold: float | None = Field(default=None, ge=0.0)
+    detector_sample_size: int | None = Field(default=None, ge=1)
+
+
+class EngineWriter(BaseModel):
+    """Output writer configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["row_streaming", "in_memory"] = "row_streaming"
+    append_unmapped_columns: bool = True
+    unmapped_prefix: str = Field(default="raw_", min_length=1)
+    output_sheet: str = Field(default="Normalized", min_length=1, max_length=31)
+
+
+class EngineSection(BaseModel):
+    """Manifest ``engine`` section."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    defaults: EngineDefaults = Field(default_factory=EngineDefaults)
+    writer: EngineWriter = Field(default_factory=EngineWriter)
+
+
+class ManifestInfo(BaseModel):
+    """Metadata describing the config package itself."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema: Literal["ade.manifest/v1.0"]
+    title: str
+    version: str
+    description: str | None = None
+
+
+class ManifestV1(BaseModel):
+    """Typed representation of a v1 manifest."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    config_script_api_version: Literal["1"]
+    info: ManifestInfo
+    engine: EngineSection
+    hooks: HookCollection = Field(default_factory=HookCollection)
+    columns: ColumnSection
+    env: dict[str, str] = Field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ManifestContext:
+    """Convenience accessors for manifest metadata."""
+
+    raw: dict[str, object]
+    version: str | None
+    model: ManifestV1 | None = None
+
+    @property
+    def column_order(self) -> list[str]:
+        if self.model is not None:
+            return list(self.model.columns.order)
+        columns = (self.raw.get("columns") or {})
+        if isinstance(columns, Mapping):
+            order = columns.get("order", [])
+            if isinstance(order, Iterable):
+                return [str(item) for item in order]
+        return []
+
+    @property
+    def column_meta(self) -> dict[str, dict[str, object]]:
+        if self.model is not None:
+            return {
+                field: meta.model_dump()
+                for field, meta in self.model.columns.meta.items()
+            }
+        columns = self.raw.get("columns") or {}
+        if isinstance(columns, Mapping):
+            meta = columns.get("meta", {})
+            if isinstance(meta, Mapping):
+                return {
+                    str(field): dict(value) if isinstance(value, Mapping) else {}
+                    for field, value in meta.items()
+                }
+        return {}
+
+    @property
+    def column_models(self) -> dict[str, ColumnMeta]:
+        if self.model is not None:
+            return dict(self.model.columns.meta)
+
+        columns = self.raw.get("columns") or {}
+        result: dict[str, ColumnMeta] = {}
+        if isinstance(columns, Mapping):
+            meta = columns.get("meta", {})
+            if isinstance(meta, Mapping):
+                for field, value in meta.items():
+                    if isinstance(value, Mapping):
+                        try:
+                            result[str(field)] = ColumnMeta.model_validate(value)
+                        except Exception:  # pragma: no cover - validation fallback
+                            continue
+        return result
+
+    @property
+    def defaults(self) -> dict[str, object]:
+        if self.model is not None:
+            return self.model.engine.defaults.model_dump(exclude_none=True)
+        engine = self.raw.get("engine") or {}
+        if isinstance(engine, Mapping):
+            defaults = engine.get("defaults", {})
+            if isinstance(defaults, Mapping):
+                return dict(defaults)
+        return {}
+
+    @property
+    def writer(self) -> dict[str, object]:
+        if self.model is not None:
+            return self.model.engine.writer.model_dump()
+        engine = self.raw.get("engine") or {}
+        if isinstance(engine, Mapping):
+            writer = engine.get("writer", {})
+            if isinstance(writer, Mapping):
+                return dict(writer)
+        return {}
+
+
+__all__ = [
+    "ColumnMeta",
+    "ColumnSection",
+    "EngineDefaults",
+    "EngineSection",
+    "EngineWriter",
+    "HookCollection",
+    "ManifestContext",
+    "ManifestInfo",
+    "ManifestV1",
+    "ScriptRef",
+]

--- a/packages/ade-schemas/src/ade_schemas/manifest.v1.schema.json
+++ b/packages/ade-schemas/src/ade_schemas/manifest.v1.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ade:manifest.v1.0",
+  "title": "ADE Config Manifest v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["config_script_api_version", "info", "engine", "hooks", "columns"],
+  "properties": {
+    "config_script_api_version": { "type": "string", "const": "1" },
+    "info": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "title", "version"],
+      "properties": {
+        "schema": { "type": "string", "const": "ade.manifest/v1.0" },
+        "title": { "type": "string", "minLength": 1 },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+        },
+        "description": { "type": "string" }
+      }
+    },
+    "env": {
+      "type": "object",
+      "description": "Environment variables exposed to scripts",
+      "additionalProperties": { "type": "string" }
+    },
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["defaults", "writer"],
+      "properties": {
+        "defaults": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "timeout_ms": { "type": "integer", "minimum": 1000 },
+            "memory_mb": { "type": "integer", "minimum": 64 },
+            "runtime_network_access": { "type": "boolean", "default": false },
+            "mapping_score_threshold": { "type": "number", "minimum": 0.0 }
+          }
+        },
+        "writer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "append_unmapped_columns", "unmapped_prefix", "output_sheet"],
+          "properties": {
+            "mode": { "type": "string", "enum": ["row_streaming", "in_memory"], "default": "row_streaming" },
+            "append_unmapped_columns": { "type": "boolean", "default": true },
+            "unmapped_prefix": { "type": "string", "minLength": 1, "default": "raw_" },
+            "output_sheet": { "type": "string", "minLength": 1, "maxLength": 31, "default": "Normalized" }
+          }
+        }
+      }
+    },
+    "hooks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "on_activate": { "$ref": "#/$defs/HookList" },
+        "on_job_start": { "$ref": "#/$defs/HookList" },
+        "on_after_extract": { "$ref": "#/$defs/HookList" },
+        "on_job_end": { "$ref": "#/$defs/HookList" }
+      }
+    },
+    "columns": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["order", "meta"],
+      "properties": {
+        "order": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TargetFieldId" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/ColumnMeta" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "ScriptRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["script"],
+      "properties": {
+        "script": {
+          "type": "string",
+          "pattern": "^(hooks/)?[A-Za-z0-9_.\\-/]+\\.py$"
+        },
+        "enabled": { "type": "boolean", "default": true }
+      }
+    },
+    "HookList": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ScriptRef" }
+    },
+    "TargetFieldId": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+    "ColumnMeta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "script"],
+      "properties": {
+        "label": { "type": "string" },
+        "required": { "type": "boolean", "default": false },
+        "enabled": { "type": "boolean", "default": true },
+        "script": {
+          "type": "string",
+          "pattern": "^columns/[A-Za-z0-9_.\\-/]+\\.py$"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "type_hint": { "type": "string" }
+      }
+    }
+  }
+}

--- a/packages/ade-schemas/src/ade_schemas/telemetry.event.v1.schema.json
+++ b/packages/ade-schemas/src/ade_schemas/telemetry.event.v1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.ade.dev/telemetry/run-event.v1.json",
+  "title": "ADE Telemetry Run Event",
+  "type": "object",
+  "required": ["schema", "version", "job_id", "timestamp", "event"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "ade.telemetry/run-event.v1"
+    },
+    "version": {
+      "type": "string"
+    },
+    "job_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "event": {
+      "type": "object",
+      "required": ["event", "level"],
+      "additionalProperties": true,
+      "properties": {
+        "event": {
+          "type": "string",
+          "minLength": 1
+        },
+        "level": {
+          "type": "string",
+          "enum": ["debug", "info", "warning", "error", "critical"]
+        }
+      }
+    }
+  }
+}

--- a/packages/ade-schemas/src/ade_schemas/telemetry.py
+++ b/packages/ade-schemas/src/ade_schemas/telemetry.py
@@ -1,0 +1,56 @@
+"""Telemetry envelope schemas shared across ADE components."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ADE_TELEMETRY_EVENT_SCHEMA = "ade.telemetry/run-event.v1"
+
+TelemetryLevel = Literal["debug", "info", "warning", "error", "critical"]
+
+
+class TelemetryEvent(BaseModel):
+    """Event payload emitted by the engine runtime."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    name: str = Field(alias="event")
+    level: TelemetryLevel = "info"
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
+        kwargs.setdefault("exclude_none", True)
+        return super().model_dump(*args, **kwargs)
+
+
+class TelemetryEnvelope(BaseModel):
+    """Versioned envelope for ADE telemetry events."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema: Literal[ADE_TELEMETRY_EVENT_SCHEMA] = ADE_TELEMETRY_EVENT_SCHEMA
+    version: str = Field(default="1.0.0")
+    job_id: str
+    run_id: str | None = None
+    emitted_at: datetime = Field(alias="timestamp")
+    event: TelemetryEvent
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
+        kwargs.setdefault("exclude_none", True)
+        kwargs.setdefault("by_alias", True)
+        return super().model_dump(*args, **kwargs)
+
+    def model_dump_json(self, *args: Any, **kwargs: Any) -> str:  # type: ignore[override]
+        kwargs.setdefault("exclude_none", True)
+        kwargs.setdefault("by_alias", True)
+        return super().model_dump_json(*args, **kwargs)
+
+
+__all__ = [
+    "ADE_TELEMETRY_EVENT_SCHEMA",
+    "TelemetryEnvelope",
+    "TelemetryEvent",
+    "TelemetryLevel",
+]

--- a/scripts/npm-setup.mjs
+++ b/scripts/npm-setup.mjs
@@ -41,6 +41,8 @@ if (hasBackend) {
   const pythonExecutable = pythonCandidates.find((candidate) => existsSync(candidate)) || launcher;
 
   await run(pythonExecutable, ["-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel"]);
+  await run(pythonExecutable, ["-m", "pip", "install", "-e", "packages/ade-schemas"]);
+  await run(pythonExecutable, ["-m", "pip", "install", "-e", "packages/ade-engine"]);
   await run(pythonExecutable, ["-m", "pip", "install", "-e", "apps/api[dev]"]);
 }
 


### PR DESCRIPTION
## Summary
- add a fifth architecture hindsight reflection to the WP11 ADE engine work package
to capture orchestration, schema sharing, and telemetry persistence considerations
- record future follow-up tasks for orchestration decoupling, schema generation,
and telemetry event bus exploration

## Testing
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917830bd82c832e9f4108fdc5a9f804)