### PR TITLE
fix: remove unnecessary dependency on ade-schemas in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
             apps/ade-cli/pyproject.toml
             apps/ade-api/pyproject.toml
             apps/ade-engine/pyproject.toml
-            packages/ade-schemas/pyproject.toml
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -44,7 +43,7 @@ jobs:
       - name: Install ade CLI
         run: |
           python -m pip install -U pip
-          python -m pip install -e apps/ade-cli -e packages/ade-schemas -e apps/ade-engine -e apps/ade-api
+          python -m pip install -e apps/ade-cli -e apps/ade-engine -e apps/ade-api
 
       - name: Run repo CI (lint, test, build)
         run: ade ci


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration by removing references to the `packages/ade-schemas` package from both the dependency list and the Python installation step. This streamlines the CI process by ensuring only the necessary packages are included.

- **CI Workflow Simplification:**
  * Removed `packages/ade-schemas/pyproject.toml` from the list of Python projects considered in the CI workflow.
  * Excluded `packages/ade-schemas` from the `pip install` step, so it is no longer installed in the CI environment.