### PR TITLE
chore: specify Dockerfile path in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: infra/docker/api.Dockerfile
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: infra/docker/api.Dockerfile
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.versions.outputs.version }}


### PR DESCRIPTION
This pull request updates the Docker build configuration in both the CI and release GitHub Actions workflows to explicitly specify the `infra/docker/api.Dockerfile` file. This ensures that the correct Dockerfile is used during image builds in both workflows.

**Workflow configuration updates:**

* CI workflow (`.github/workflows/ci.yml`): Sets the `file` parameter to `infra/docker/api.Dockerfile` in the Docker build step, ensuring the correct Dockerfile is used for CI builds.
* Release workflow (`.github/workflows/release.yml`): Also sets the `file` parameter to `infra/docker/api.Dockerfile` in the Docker build step, aligning the release process with the CI process.