### PR TITLE
fix: remove unnecessary COPY commands for packages in Dockerfile

### DIFF
--- a/infra/docker/api.Dockerfile
+++ b/infra/docker/api.Dockerfile
@@ -7,7 +7,6 @@ RUN npm ci --prefix apps/ade-web --no-audit --no-fund
 
 # Build the SPA (requires telemetry JSON during bundling)
 COPY apps/ade-web apps/ade-web
-COPY packages packages
 RUN npm run build --prefix apps/ade-web
 
 FROM python:3.12-slim AS backend-build
@@ -21,9 +20,8 @@ RUN apt-get update \
 COPY README.md ./
 COPY apps/ade-api/pyproject.toml apps/ade-api/
 COPY apps ./apps
-COPY packages ./packages
 RUN python -m pip install -U pip \
- && pip install --no-cache-dir --prefix=/install ./apps/ade-engine ./apps/ade-api
+ && pip install --no-cache-dir --prefix=/install ./apps/ade-cli ./apps/ade-engine ./apps/ade-api
 
 FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -32,7 +30,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 COPY --from=backend-build /install /usr/local
 COPY apps ./apps
-COPY packages ./packages
 COPY --from=web-build /app/apps/ade-web/dist ./apps/ade-api/src/ade_api/web/static
 RUN mkdir -p /app/data/db /app/data/documents
 VOLUME ["/app/data"]


### PR DESCRIPTION
This pull request updates the Docker build process for the API by removing unnecessary copying of the `packages` directory and ensuring the CLI component is included during Python dependency installation. These changes streamline the Docker image and ensure all required dependencies are present.

**Docker build optimization:**

* Removed all `COPY packages` instructions from the Dockerfile, reducing image size and preventing unused files from being included. [[1]](diffhunk://#diff-1b04dbcdb6ed568f76271d42662747c5c43c0e94f7674ea470f768ca5623ec33L10) [[2]](diffhunk://#diff-1b04dbcdb6ed568f76271d42662747c5c43c0e94f7674ea470f768ca5623ec33L24-R24) [[3]](diffhunk://#diff-1b04dbcdb6ed568f76271d42662747c5c43c0e94f7674ea470f768ca5623ec33L35)

**Dependency installation improvements:**

* Updated the Python dependency installation command to include the `ade-cli` package, ensuring CLI tools are available in the final image.