### PR TITLE
refactor: remove unused describeSheetSelection function from Workbench

### DIFF
--- a/apps/ade-web/src/screens/Workspace/sections/ConfigBuilder/workbench/Workbench.tsx
+++ b/apps/ade-web/src/screens/Workspace/sections/ConfigBuilder/workbench/Workbench.tsx
@@ -2050,16 +2050,6 @@ function ChromeIconButton({
   );
 }
 
-function describeSheetSelection(sheetNames?: readonly string[] | null): string | null {
-  if (!sheetNames) {
-    return null;
-  }
-  if (sheetNames.length === 0) {
-    return "All worksheets";
-  }
-  return sheetNames.join(", ");
-}
-
 function formatRunDurationLabel(durationMs?: number | null): string | null {
   if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 0) {
     return null;


### PR DESCRIPTION
This pull request makes a small change by removing the unused `describeSheetSelection` function from `Workbench.tsx`. This helps clean up the codebase by eliminating dead code.