### PR TITLE
fix(Dockerfile): update Microsoft package installation commands for c…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ WORKDIR /app
 # System deps for building Python packages (kept out of final image)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
-    && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft-prod.gpg \
-    && echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/microsoft-prod.gpg] https://packages.microsoft.com/config/debian/12/prod.list" > /etc/apt/sources.list.d/microsoft-prod.list \
+    && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
+    && curl -sSL https://packages.microsoft.com/config/debian/12/prod.list -o /etc/apt/sources.list.d/microsoft-prod.list \
     && apt-get update \
     && ACCEPT_EULA=Y apt-get install -y --no-install-recommends build-essential git unixodbc unixodbc-dev msodbcsql18 \
     && rm -rf /var/lib/apt/lists/*
@@ -77,8 +77,8 @@ WORKDIR /app
 # System deps for pyodbc / Azure SQL connectivity (runtime only)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
-    && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft-prod.gpg \
-    && echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/microsoft-prod.gpg] https://packages.microsoft.com/config/debian/12/prod.list" > /etc/apt/sources.list.d/microsoft-prod.list \
+    && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
+    && curl -sSL https://packages.microsoft.com/config/debian/12/prod.list -o /etc/apt/sources.list.d/microsoft-prod.list \
     && apt-get update \
     && ACCEPT_EULA=Y apt-get install -y --no-install-recommends unixodbc msodbcsql18 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request updates the way Microsoft's package signing key and repository list are added in the `Dockerfile` for both the build and runtime environments. The changes improve compatibility and follow best practices for keyring management.

Dependency installation improvements:

* The Microsoft GPG key is now stored in `/usr/share/keyrings/microsoft-prod.gpg` instead of `/etc/apt/trusted.gpg.d/`, aligning with newer Debian recommendations. (`Dockerfile`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L40-R41) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L80-R81)
* The Microsoft package repository list is now downloaded directly to `/etc/apt/sources.list.d/microsoft-prod.list` rather than being echoed, reducing the risk of formatting issues. (`Dockerfile`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L40-R41) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L80-R81)…ompatibility