### PR TITLE
Enhance run completion payloads and summaries

### DIFF
--- a/.workpackages/ade-event-system-refactor/010-WORK-PACKAGE.md
+++ b/.workpackages/ade-event-system-refactor/010-WORK-PACKAGE.md
@@ -21,11 +21,11 @@ Architecture & spec
 
 Implementation
 
-- [ ] Implement canonical `AdeEvent` envelope, `console.line`, and new payload models in ade-api + ade-engine.
-- [ ] Implement central event dispatcher in ade-api (ID/sequence assignment, NDJSON sink, SSE fan-out).
-- [ ] Replace existing v1 run & build routes with new behavior (no `/v2`; new semantics are the default).
-- [ ] Integrate build + run orchestration with new events, including subprocess console streaming.
-- [ ] Implement `RunSummaryBuilder` and canonical `run.completed`, updating DB and UI.
+- [x] Implement canonical `AdeEvent` envelope, `console.line`, and new payload models in ade-api + ade-engine. (Introduced typed payload classes and nested payload usage across engine + API.)
+- [x] Implement central event dispatcher in ade-api (ID/sequence assignment, NDJSON sink, SSE fan-out). Added `RunEventDispatcher` + storage/log reader scaffolding.
+- [x] Replace existing v1 run & build routes with new behavior (no `/v2`; new semantics are the default). Updated run/build endpoints to stream via SSE and run event retrieval to use dispatcher-backed logs.
+- [x] Integrate build + run orchestration with new events, including subprocess console streaming. (Wired console.line payloads and dispatcher-backed build/run emissions.)
+- [x] Implement `RunSummaryBuilder` and canonical `run.completed`, updating DB and UI. (Summary builder now consumes validation summaries/run errors; run.completed payloads carry execution, artifacts, and failure context.)
 - [ ] Update ade-web to consume unified run event stream and render build + run logs consistently.
 - [ ] Remove all v1 event types, streaming codepaths, and docs (ensure no stale references remain).
 

--- a/apps/ade-api/src/ade_api/features/builds/service.py
+++ b/apps/ade-api/src/ade_api/features/builds/service.py
@@ -14,7 +14,13 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from ade_engine.schemas import AdeEvent
+from ade_engine.schemas import (
+    AdeEvent,
+    BuildCompletedPayload,
+    BuildPhaseStartedPayload,
+    BuildStartedPayload,
+    ConsoleLinePayload,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ade_api.features.builds.fingerprint import compute_build_fingerprint
@@ -358,10 +364,7 @@ class BuildsService:
         yield self._ade_event(
             build=build,
             type_="build.started",
-            payload={
-                "status": "building",
-                "reason": reason,
-            },
+            payload=BuildStartedPayload(status="building", reason=reason),
         )
 
         artifacts: BuildArtifacts | None = None
@@ -384,26 +387,26 @@ class BuildsService:
                     yield self._ade_event(
                         build=build,
                         type_="build.phase.started",
-                        payload={
-                            "phase": event.step.value,
-                            "message": event.message,
-                        },
+                        payload=BuildPhaseStartedPayload(
+                            phase=event.step.value,
+                            message=event.message,
+                        ),
                     )
                 elif isinstance(event, BuilderLogEvent):
-                    log = await self._append_log(
+                    await self._append_log(
                         build_id=build.id,
                         message=event.message,
                         stream=event.stream,
                     )
                     yield self._ade_event(
                         build=build,
-                        type_="build.console",
-                        payload={
-                            "stream": event.stream,
-                            "level": "warning" if event.stream == "stderr" else "info",
-                            "message": event.message,
-                            "created": self._epoch_seconds(log.created_at),
-                        },
+                        type_="console.line",
+                        payload=ConsoleLinePayload(
+                            scope="build",
+                            stream=event.stream,
+                            level="warning" if event.stream == "stderr" else "info",
+                            message=event.message,
+                        ),
                     )
                 elif isinstance(event, BuilderArtifactsEvent):
                     artifacts = event.artifacts
@@ -426,12 +429,14 @@ class BuildsService:
             yield self._ade_event(
                 build=build,
                 type_="build.completed",
-                payload={
-                    "status": self._status_literal(build.status),
-                    "exit_code": build.exit_code,
-                    "summary": build.summary,
-                    "error": {"message": build.error_message} if build.error_message else None,
-                },
+                payload=BuildCompletedPayload(
+                    status=self._status_literal(build.status),
+                    exit_code=build.exit_code,
+                    summary=build.summary,
+                    error={"message": build.error_message}
+                    if build.error_message
+                    else None,
+                ),
             )
             return
 
@@ -453,12 +458,14 @@ class BuildsService:
             yield self._ade_event(
                 build=build,
                 type_="build.completed",
-                payload={
-                    "status": self._status_literal(build.status),
-                    "exit_code": build.exit_code,
-                    "summary": build.summary,
-                    "error": {"message": build.error_message} if build.error_message else None,
-                },
+                payload=BuildCompletedPayload(
+                    status=self._status_literal(build.status),
+                    exit_code=build.exit_code,
+                    summary=build.summary,
+                    error={"message": build.error_message}
+                    if build.error_message
+                    else None,
+                ),
             )
             return
 
@@ -680,11 +687,12 @@ class BuildsService:
         return AdeEvent(
             type=type_,
             created_at=utc_now(),
+            source="api.builds",
             workspace_id=build.workspace_id,
             configuration_id=build.configuration_id,
             run_id=None,
             build_id=build.id,
-            **(payload or {}),
+            payload=payload or {},
         )
 
     # ------------------------------------------------------------------

--- a/apps/ade-api/src/ade_api/features/runs/event_dispatcher.py
+++ b/apps/ade-api/src/ade_api/features/runs/event_dispatcher.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable, Iterable
+
+from ade_engine.schemas import AdeEvent, AdeEventPayload
+from pydantic import BaseModel
+
+from ade_api.settings import Settings
+from ade_api.shared.core.ids import generate_ulid
+from ade_api.shared.core.time import utc_now
+from ade_api.storage_layout import workspace_run_root
+
+__all__ = [
+    "RunEventDispatcher",
+    "RunEventLogReader",
+    "RunEventStorage",
+    "RunEventSubscription",
+]
+
+
+@dataclass(slots=True)
+class RunEventSubscription:
+    """Live stream handle for a run's event stream."""
+
+    run_id: str
+    _queue: asyncio.Queue[AdeEvent | None]
+    _on_close: Callable[[str, asyncio.Queue[AdeEvent | None]], None]
+    _closed: bool = False
+
+    def __aiter__(self) -> AsyncIterator[AdeEvent]:
+        return self
+
+    async def __anext__(self) -> AdeEvent:
+        item = await self._queue.get()
+        if item is None:
+            raise StopAsyncIteration
+        return item
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._on_close(self.run_id, self._queue)
+        await self._queue.put(None)
+
+
+class RunEventStorage:
+    """Persist AdeEvents to NDJSON files per run and replay them."""
+
+    def __init__(self, *, settings: Settings) -> None:
+        self._settings = settings
+
+    def events_path(self, *, workspace_id: str, run_id: str, create: bool = True) -> Path:
+        run_dir = workspace_run_root(self._settings, workspace_id, run_id)
+        logs_dir = run_dir / "logs"
+        if create:
+            logs_dir.mkdir(parents=True, exist_ok=True)
+        return logs_dir / "events.ndjson"
+
+    async def append(self, event: AdeEvent) -> AdeEvent:
+        if not event.workspace_id or not event.run_id:
+            raise ValueError("workspace_id and run_id are required to append events")
+
+        path = self.events_path(workspace_id=event.workspace_id, run_id=event.run_id)
+        serialized = event.model_dump_json()
+        await asyncio.to_thread(self._append_line, path, serialized)
+        return event
+
+    def iter_events(
+        self,
+        *,
+        workspace_id: str,
+        run_id: str,
+        after_sequence: int | None = None,
+    ) -> Iterable[AdeEvent]:
+        path = self.events_path(workspace_id=workspace_id, run_id=run_id, create=False)
+        if not path.exists():
+            return []
+
+        def _iter() -> Iterable[AdeEvent]:
+            with path.open("r", encoding="utf-8") as handle:
+                for raw in handle:
+                    if not raw.strip():
+                        continue
+                    event = AdeEvent.model_validate_json(raw)
+                    if after_sequence is not None and event.sequence is not None:
+                        if event.sequence <= after_sequence:
+                            continue
+                    yield event
+
+        return _iter()
+
+    def last_sequence(self, *, workspace_id: str, run_id: str) -> int:
+        last_seen = 0
+        for event in self.iter_events(workspace_id=workspace_id, run_id=run_id):
+            if event.sequence:
+                last_seen = max(last_seen, event.sequence)
+        return last_seen
+
+    @staticmethod
+    def _append_line(path: Path, line: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+            handle.write("\n")
+
+
+class RunEventDispatcher:
+    """Assign event IDs/sequences, persist to NDJSON, and fan-out to subscribers."""
+
+    def __init__(
+        self,
+        *,
+        storage: RunEventStorage,
+        id_factory: Callable[[], str] = generate_ulid,
+    ) -> None:
+        self._storage = storage
+        self._id_factory = id_factory
+        self._sequence_by_run: dict[str, int] = {}
+        self._subscribers: dict[str, set[asyncio.Queue[AdeEvent | None]]] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    async def emit(
+        self,
+        *,
+        type: str,
+        workspace_id: str,
+        configuration_id: str,
+        run_id: str,
+        payload: AdeEventPayload | dict[str, Any] | None = None,
+        source: str = "api",
+        build_id: str | None = None,
+    ) -> AdeEvent:
+        if isinstance(payload, BaseModel):
+            payload = payload.model_dump()
+        sequence = await self._next_sequence(workspace_id=workspace_id, run_id=run_id)
+        event = AdeEvent(
+            type=type,
+            event_id=f"evt_{self._id_factory()}",
+            created_at=utc_now(),
+            sequence=sequence,
+            source=source,
+            workspace_id=workspace_id,
+            configuration_id=configuration_id,
+            run_id=run_id,
+            build_id=build_id,
+            payload=payload,
+        )
+        await self._storage.append(event)
+        await self._publish(event)
+        return event
+
+    @asynccontextmanager
+    async def subscribe(self, run_id: str) -> AsyncIterator[RunEventSubscription]:
+        queue: asyncio.Queue[AdeEvent | None] = asyncio.Queue()
+        if run_id not in self._subscribers:
+            self._subscribers[run_id] = set()
+        self._subscribers[run_id].add(queue)
+        subscription = RunEventSubscription(run_id, queue, self._remove_subscriber)
+        try:
+            yield subscription
+        finally:
+            await subscription.close()
+
+    async def _publish(self, event: AdeEvent) -> None:
+        for queue in list(self._subscribers.get(event.run_id or "", [])):
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                continue
+
+    def _remove_subscriber(
+        self, run_id: str, queue: asyncio.Queue[AdeEvent | None]
+    ) -> None:
+        subscribers = self._subscribers.get(run_id)
+        if not subscribers:
+            return
+        subscribers.discard(queue)
+        if not subscribers:
+            self._subscribers.pop(run_id, None)
+
+    async def _next_sequence(self, *, workspace_id: str, run_id: str) -> int:
+        lock = self._locks.setdefault(run_id, asyncio.Lock())
+        async with lock:
+            if run_id not in self._sequence_by_run:
+                self._sequence_by_run[run_id] = await asyncio.to_thread(
+                    self._storage.last_sequence,
+                    workspace_id=workspace_id,
+                    run_id=run_id,
+                )
+            self._sequence_by_run[run_id] += 1
+            return self._sequence_by_run[run_id]
+
+
+class RunEventLogReader:
+    """Streaming iterator for a run's persisted events."""
+
+    def __init__(self, *, storage: RunEventStorage, workspace_id: str, run_id: str) -> None:
+        self._storage = storage
+        self._workspace_id = workspace_id
+        self._run_id = run_id
+
+    def iter(self, *, after_sequence: int | None = None) -> Iterable[AdeEvent]:
+        return self._storage.iter_events(
+            workspace_id=self._workspace_id,
+            run_id=self._run_id,
+            after_sequence=after_sequence,
+        )
+
+    def last_sequence(self) -> int:
+        return self._storage.last_sequence(
+            workspace_id=self._workspace_id,
+            run_id=self._run_id,
+        )

--- a/apps/ade-api/tests/integration/builds/test_builds_router.py
+++ b/apps/ade-api/tests/integration/builds/test_builds_router.py
@@ -150,7 +150,8 @@ async def test_stream_build_emits_events_and_logs(
         async for line in response.aiter_lines():
             if not line:
                 continue
-            events.append(json.loads(line))
+            if line.startswith("data: "):
+                events.append(json.loads(line.removeprefix("data: ")))
 
     assert events, "expected streaming events"
     assert events[0]["type"] == "build.created"

--- a/apps/ade-api/tests/integration/runs/test_runs_router.py
+++ b/apps/ade-api/tests/integration/runs/test_runs_router.py
@@ -633,7 +633,8 @@ async def test_stream_run_safe_mode(
         async for line in response.aiter_lines():
             if not line:
                 continue
-            events.append(json.loads(line))
+            if line.startswith("data: "):
+                events.append(json.loads(line.removeprefix("data: ")))
 
     assert events, "expected streaming events"
     assert events[0]["type"] == "run.queued"
@@ -718,7 +719,8 @@ async def test_stream_run_respects_persisted_safe_mode_override(
         async for line in response.aiter_lines():
             if not line:
                 continue
-            events.append(json.loads(line))
+            if line.startswith("data: "):
+                events.append(json.loads(line.removeprefix("data: ")))
 
     assert events, "expected streaming events"
     assert events[-1]["type"] == "run.completed"
@@ -798,11 +800,12 @@ async def test_stream_run_processes_real_documents(
         async for line in response.aiter_lines():
             if not line:
                 continue
-            events.append(json.loads(line))
+            if line.startswith("data: "):
+                events.append(json.loads(line.removeprefix("data: ")))
 
     assert events and events[0]["type"] == "run.queued"
     assert events[-1]["type"] == "run.completed"
-    assert events[-1]["status"] == "succeeded"
+    assert events[-1].get("payload", {}).get("status") == "succeeded"
     run_id = events[0]["run_id"]
 
     run_response = await async_client.get(f"/api/v1/runs/{run_id}")
@@ -934,11 +937,12 @@ async def test_stream_run_processes_all_worksheets_when_unspecified(
         async for line in response.aiter_lines():
             if not line:
                 continue
-            events.append(json.loads(line))
+            if line.startswith("data: "):
+                events.append(json.loads(line.removeprefix("data: ")))
 
     assert events and events[0]["type"] == "run.queued"
     assert events[-1]["type"] == "run.completed"
-    assert events[-1]["status"] == "succeeded"
+    assert events[-1].get("payload", {}).get("status") == "succeeded"
     run_id = events[0]["run_id"]
 
     outputs_response = await async_client.get(f"/api/v1/runs/{run_id}/outputs")
@@ -1015,11 +1019,12 @@ async def test_stream_run_sheet_selection_variants(
             async for line in response.aiter_lines():
                 if not line:
                     continue
-                events.append(json.loads(line))
+                if line.startswith("data: "):
+                    events.append(json.loads(line.removeprefix("data: ")))
 
-        assert events and events[0]["type"] == "run.queued"
-        assert events[-1]["type"] == "run.completed"
-        assert events[-1]["status"] == "succeeded"
+            assert events and events[0]["type"] == "run.queued"
+            assert events[-1]["type"] == "run.completed"
+            assert events[-1].get("payload", {}).get("status") == "succeeded"
         run_id = events[0]["run_id"]
 
         outputs_response = await async_client.get(f"/api/v1/runs/{run_id}/outputs")

--- a/apps/ade-api/tests/unit/features/runs/test_event_dispatcher.py
+++ b/apps/ade-api/tests/unit/features/runs/test_event_dispatcher.py
@@ -1,0 +1,167 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+from ade_engine.schemas import AdeEvent
+
+from ade_api.features.runs.event_dispatcher import (
+    RunEventDispatcher,
+    RunEventLogReader,
+    RunEventStorage,
+)
+from ade_api.settings import Settings
+from ade_api.shared.core.time import utc_now
+
+
+pytestmark = pytest.mark.asyncio()
+
+
+@pytest.fixture()
+def settings(tmp_path: Path) -> Settings:
+    workspaces = tmp_path / "workspaces"
+    return Settings(
+        workspaces_dir=workspaces,
+        configs_dir=workspaces,
+        documents_dir=workspaces,
+        runs_dir=workspaces,
+    )
+
+
+@pytest.fixture()
+def storage(settings: Settings) -> RunEventStorage:
+    return RunEventStorage(settings=settings)
+
+
+@pytest.fixture()
+def dispatcher(storage: RunEventStorage) -> RunEventDispatcher:
+    return RunEventDispatcher(storage=storage)
+
+
+async def test_emit_assigns_event_id_and_sequence(
+    dispatcher: RunEventDispatcher, settings: Settings
+) -> None:
+    event = await dispatcher.emit(
+        type="run.queued",
+        workspace_id="ws_123",
+        configuration_id="cfg_123",
+        run_id="run_123",
+        payload={"status": "queued", "mode": "execute", "options": {}},
+    )
+
+    assert event.event_id is not None
+    assert event.event_id.startswith("evt_")
+    assert event.sequence == 1
+
+    path = RunEventStorage(settings=settings).events_path(
+        workspace_id="ws_123", run_id="run_123"
+    )
+    saved = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(saved) == 1
+
+    parsed = AdeEvent.model_validate_json(saved[0])
+    assert parsed.sequence == 1
+    assert parsed.event_id == event.event_id
+
+
+async def test_sequences_increment_per_run(dispatcher: RunEventDispatcher) -> None:
+    first = await dispatcher.emit(
+        type="run.queued",
+        workspace_id="ws_1",
+        configuration_id="cfg_1",
+        run_id="run_a",
+        payload={"status": "queued", "mode": "execute", "options": {}},
+    )
+    second = await dispatcher.emit(
+        type="run.started",
+        workspace_id="ws_1",
+        configuration_id="cfg_1",
+        run_id="run_a",
+        payload={"status": "in_progress", "mode": "execute"},
+    )
+    other_run = await dispatcher.emit(
+        type="run.queued",
+        workspace_id="ws_2",
+        configuration_id="cfg_2",
+        run_id="run_b",
+        payload={"status": "queued", "mode": "execute", "options": {}},
+    )
+
+    assert (first.sequence, second.sequence) == (1, 2)
+    assert other_run.sequence == 1
+
+
+async def test_sequences_resume_from_disk(
+    storage: RunEventStorage, dispatcher: RunEventDispatcher
+) -> None:
+    existing = AdeEvent(
+        type="run.queued",
+        event_id="evt_existing",
+        created_at=utc_now(),
+        sequence=3,
+        workspace_id="ws_resume",
+        configuration_id="cfg_resume",
+        run_id="run_resume",
+        payload={"status": "queued", "mode": "execute", "options": {}},
+    )
+    await storage.append(existing)
+
+    resumed = await dispatcher.emit(
+        type="run.started",
+        workspace_id="ws_resume",
+        configuration_id="cfg_resume",
+        run_id="run_resume",
+        payload={"status": "in_progress", "mode": "execute"},
+    )
+
+    assert resumed.sequence == 4
+
+
+async def test_subscribers_receive_events(dispatcher: RunEventDispatcher) -> None:
+    async with dispatcher.subscribe("run_sub") as subscription:
+        emitted = await dispatcher.emit(
+            type="run.queued",
+            workspace_id="ws_sub",
+            configuration_id="cfg_sub",
+            run_id="run_sub",
+            payload={"status": "queued", "mode": "execute", "options": {}},
+        )
+
+        received = await asyncio.wait_for(subscription.__anext__(), timeout=1)
+
+    assert received.event_id == emitted.event_id
+    assert received.sequence == emitted.sequence
+
+
+async def test_log_reader_filters_by_sequence(storage: RunEventStorage) -> None:
+    await storage.append(
+        AdeEvent(
+            type="run.queued",
+            event_id="evt_first",
+            created_at=utc_now(),
+            sequence=1,
+            workspace_id="ws_read",
+            configuration_id="cfg_read",
+            run_id="run_read",
+            payload={"status": "queued", "mode": "execute", "options": {}},
+        )
+    )
+    await storage.append(
+        AdeEvent(
+            type="run.started",
+            event_id="evt_second",
+            created_at=utc_now(),
+            sequence=2,
+            workspace_id="ws_read",
+            configuration_id="cfg_read",
+            run_id="run_read",
+            payload={"status": "in_progress", "mode": "execute"},
+        )
+    )
+
+    reader = RunEventLogReader(
+        storage=storage, workspace_id="ws_read", run_id="run_read"
+    )
+
+    events = list(reader.iter(after_sequence=1))
+    assert len(events) == 1
+    assert events[0].sequence == 2

--- a/apps/ade-api/tests/unit/features/runs/test_runner.py
+++ b/apps/ade-api/tests/unit/features/runs/test_runner.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from ade_engine.schemas import ADE_EVENT_SCHEMA, AdeEvent
+from ade_engine.schemas import AdeEvent
 
 from ade_api.features.runs.runner import EngineSubprocessRunner, StdoutFrame
 
@@ -21,13 +21,10 @@ async def test_runner_streams_stdout_and_telemetry(tmp_path: Path) -> None:
         "events.parent.mkdir(parents=True, exist_ok=True)\n"
         "print('engine ready', flush=True)\n"
         "payload = {\n"
-        "    'schema': 'ade.event/v1',\n"
-        "    'version': '1.0.0',\n"
         "    'run_id': 'run-1',\n"
         "    'created_at': '2024-01-01T00:00:00Z',\n"
-        "    'object': 'ade.event',\n"
-        "    'phase': 'mapping',\n"
         "    'type': 'run.phase.started',\n"
+        "    'payload': {'phase': 'mapping'},\n"
         "}\n"
         "time.sleep(0.05)\n"
         "events.write_text(json.dumps(payload) + '\\n', encoding='utf-8')\n",
@@ -45,6 +42,5 @@ async def test_runner_streams_stdout_and_telemetry(tmp_path: Path) -> None:
     assert stdout_frames, "expected stdout frames"
     telemetry = next(frame for frame in frames if not isinstance(frame, StdoutFrame))
     assert isinstance(telemetry, AdeEvent)
-    assert telemetry.schema_id == ADE_EVENT_SCHEMA
     assert telemetry.type == "run.phase.started"
-    assert telemetry.model_extra["phase"] == "mapping"
+    assert telemetry.payload_dict()["phase"] == "mapping"

--- a/apps/ade-engine/src/ade_engine/infra/telemetry.py
+++ b/apps/ade-engine/src/ade_engine/infra/telemetry.py
@@ -28,13 +28,13 @@ def _now() -> datetime:
 def _event_level(event: AdeEvent) -> str:
     """Best-effort level extraction for filtering."""
 
-    extras = getattr(event, "model_extra", {}) or {}
-    level = extras.get("level")
+    payload = event.payload_dict()
+    level = payload.get("level")
     if isinstance(level, str):
         return level
 
     # Fall back to stderr implying warning when stream is present.
-    stream = extras.get("stream")
+    stream = payload.get("stream")
     if stream == "stderr":
         return "warning"
     return "info"
@@ -52,7 +52,6 @@ def _make_event(
     payload: dict[str, Any] | None = None,
     sequence: int | None = None,
     source: str | None = None,
-    details: dict[str, Any] | None = None,
 ) -> AdeEvent:
     """Construct a typed AdeEvent with the common envelope fields populated."""
 
@@ -67,8 +66,7 @@ def _make_event(
         configuration_id=configuration_id,
         run_id=run.run_id,
         source=source,
-        details=details,
-        **payload,
+        payload=payload,
     )
 
 
@@ -156,33 +154,12 @@ class PipelineLogger:
 
         payload = dict(payload or {})
 
-        # Pull any event-specific details off the payload so we can merge them
-        # with cross-cutting envelope details (emitter_version, correlation_id).
-        event_details = payload.pop("details", None)
-
-        base_details: dict[str, Any] = {}
-        if self.emitter or self.emitter_version:
-            name = self.emitter or "ade-engine"
-            if self.emitter_version:
-                base_details["emitter_version"] = f"{name}@{self.emitter_version}"
-            else:
-                base_details["emitter"] = name
-
-        if self.correlation_id:
-            base_details["correlation_id"] = self.correlation_id
-
-        if base_details and event_details:
-            merged_details: dict[str, Any] | None = {**base_details, **event_details}
-        else:
-            merged_details = event_details or base_details or None
-
         event = _make_event(
             run=self.run,
             type_=type_,
             payload=payload,
             sequence=self._next_sequence(),
             source=self.source,
-            details=merged_details,
         )
         self.event_sink.emit(event)
 
@@ -191,12 +168,17 @@ class PipelineLogger:
     # --------------------------------------------------------------------- #
 
     def note(self, message: str, *, level: str = "info", stream: str = "stdout", **details: Any) -> None:
-        """Emit a standardized run.console event (stdout/stderr line)."""
+        """Emit a standardized console.line event."""
 
-        payload: dict[str, Any] = {"message": message, "level": level, "stream": stream}
+        payload: dict[str, Any] = {
+            "scope": "run",
+            "message": message,
+            "level": level,
+            "stream": stream,
+        }
         if details:
             payload["details"] = details
-        self._emit("run.console", payload=payload)
+        self._emit("console.line", payload=payload)
 
     def event(self, type_suffix: str, *, level: str | None = "info", **payload: Any) -> None:
         """Emit a run.* lifecycle/metadata event."""

--- a/apps/ade-engine/src/ade_engine/schemas/__init__.py
+++ b/apps/ade-engine/src/ade_engine/schemas/__init__.py
@@ -1,14 +1,49 @@
 from ade_engine.schemas.artifact import ArtifactV1
 from ade_engine.schemas.manifest import ManifestV1
 from ade_engine.schemas.run_summary import RunSummaryV1
-from ade_engine.schemas.telemetry import ADE_EVENT_SCHEMA, AdeEvent, TelemetryEnvelope, TelemetryEvent
+from ade_engine.schemas.telemetry import (
+    AdeEvent,
+    AdeEventPayload,
+    BuildCompletedPayload,
+    BuildCreatedPayload,
+    BuildPhaseCompletedPayload,
+    BuildPhaseStartedPayload,
+    BuildStartedPayload,
+    ConsoleLinePayload,
+    RunCompletedPayload,
+    RunErrorPayload,
+    RunPhaseCompletedPayload,
+    RunPhaseStartedPayload,
+    RunQueuedPayload,
+    RunStartedPayload,
+    RunTableSummaryPayload,
+    RunValidationIssuePayload,
+    RunValidationSummaryPayload,
+    TelemetryEnvelope,
+    TelemetryEvent,
+)
 
 __all__ = [
-    "ADE_EVENT_SCHEMA",
     "AdeEvent",
+    "AdeEventPayload",
     "ArtifactV1",
+    "BuildCompletedPayload",
+    "BuildCreatedPayload",
+    "BuildPhaseCompletedPayload",
+    "BuildPhaseStartedPayload",
+    "BuildStartedPayload",
+    "ConsoleLinePayload",
     "ManifestV1",
+    "RunCompletedPayload",
+    "RunErrorPayload",
+    "RunPhaseCompletedPayload",
+    "RunPhaseStartedPayload",
+    "RunQueuedPayload",
+    "RunStartedPayload",
     "RunSummaryV1",
+    "RunTableSummaryPayload",
+    "RunValidationIssuePayload",
+    "RunValidationSummaryPayload",
     "TelemetryEnvelope",
     "TelemetryEvent",
 ]

--- a/apps/ade-engine/tests/test_engine_runtime.py
+++ b/apps/ade-engine/tests/test_engine_runtime.py
@@ -52,9 +52,9 @@ def test_engine_run_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     events_path = Path(result.logs_dir) / "events.ndjson"
     events = _parse_events(events_path)
 
-    assert any(evt.type == "run.completed" and evt.model_extra.get("status") == "succeeded" for evt in events)
+    assert any(evt.type == "run.completed" and evt.payload_dict().get("status") == "succeeded" for evt in events)
     table_event = next(evt for evt in events if evt.type == "run.table.summary")
-    table = table_event.model_extra
+    table = table_event.payload_dict()
     assert table["row_count"] == 2
 
 
@@ -75,7 +75,7 @@ def test_engine_run_hook_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     events_path = Path(result.logs_dir) / "events.ndjson"
     events = _parse_events(events_path)
     completion = next(evt for evt in events if evt.type == "run.completed")
-    assert completion.model_extra.get("status") == "failed"
+    assert completion.payload_dict().get("status") == "failed"
 
 
 def test_engine_mapping_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -92,7 +92,7 @@ def test_engine_mapping_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     events_path = Path(result.logs_dir) / "events.ndjson"
     events = _parse_events(events_path)
     table_event = next(evt for evt in events if evt.type == "run.table.summary")
-    table = table_event.model_extra
+    table = table_event.payload_dict()
 
     mapped_fields = [
         {key: field.get(key) for key in ("field", "header", "score", "source_column_index")}

--- a/apps/ade-engine/tests/test_schemas_telemetry.py
+++ b/apps/ade-engine/tests/test_schemas_telemetry.py
@@ -10,12 +10,10 @@ def test_telemetry_envelope_defaults():
         run_id="run-uuid",
         workspace_id="ws-1",
         configuration_id="cfg-1",
-        engine_version="0.2.0",
+        payload={"engine_version": "0.2.0"},
     )
 
-    assert envelope.schema == "ade.event/v1"
-    assert envelope.version == "1.0.0"
-    assert envelope.model_extra["engine_version"] == "0.2.0"
+    assert envelope.payload_dict()["engine_version"] == "0.2.0"
     assert envelope.workspace_id == "ws-1"
     assert envelope.configuration_id == "cfg-1"
 
@@ -25,10 +23,9 @@ def test_telemetry_serialization_round_trip():
         type="run.phase.started",
         created_at=datetime(2024, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
         run_id="run-uuid",
-        phase="extracting",
-        level="debug",
+        payload={"phase": "extracting", "level": "debug"},
     )
 
     data = envelope.model_dump()
     assert data["type"] == "run.phase.started"
-    assert data["phase"] == "extracting"
+    assert data["payload"]["phase"] == "extracting"


### PR DESCRIPTION
## Summary
- expand run completion emission to include execution timings, artifacts, and structured failure context across happy/safe-mode/cancel/error paths
- enrich RunSummaryBuilder with validation summary and run.error aggregation while updating tests for the new event payload expectations
- update the work package checklist to reflect the completed summary builder milestone

## Testing
- `pytest apps/ade-api/tests/unit/features/runs/test_summary_builder.py apps/ade-api/tests/unit/features/runs/test_runs_service.py -q`
- `ade test` *(terminated after extended runtime; see notes in conversation)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a425b6ed4832e8070ae64b482a6d9)