### PR TITLE
fix: restore loading state in document activity feed

### DIFF
--- a/frontend/src/pages/Workspace/sections/Documents/detail/tabs/activity/hooks/useDocumentActivityFeed.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/tabs/activity/hooks/useDocumentActivityFeed.ts
@@ -88,7 +88,7 @@ export function useDocumentActivityFeed({
     counts,
     hasNextPage: Boolean(commentsModel.hasNextPage),
     isFetchingNextPage: commentsModel.isFetchingNextPage,
-    isLoading: (runsQuery.isLoading || commentsModel.isLoading) && allItems.length === 0,
+    isLoading: runsQuery.isLoading || commentsModel.isLoading,
     hasError: Boolean(runsQuery.error || commentsModel.error),
     submitError: commentsModel.submitError,
     isSubmitting: commentsModel.isSubmitting,


### PR DESCRIPTION
## Summary
- restore activity tab loading state while runs/comments are fetching
- avoid suppressing skeleton state due to synthetic uploaded event row

## Validation
- cd backend && uv run ade web lint
- cd backend && uv run ade web test