### PR TITLE
fix: reset document rename state on workspace switch

### DIFF
--- a/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableView.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableView.tsx
@@ -185,6 +185,8 @@ export function DocumentsTableView({
 
   useEffect(() => {
     setDeleteTarget(null);
+    setRenameTarget(null);
+    setRenameError(null);
     setPendingMutations({});
     setUpdatesAvailable(false);
     handledUploadsRef.current.clear();


### PR DESCRIPTION
## Summary
- clear rename target + rename error when workspace changes
- prevent stale rename dialog state from leaking across workspaces

## Validation
- cd backend && uv run ade web lint
- cd backend && uv run ade web test