### PR TITLE
feat: revamp workspace theme mode controls and transitions

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,6 +12,55 @@ body,
   overflow-x: hidden;
 }
 
+:root[data-mode-transition^="reveal"]::view-transition-old(root),
+:root[data-mode-transition^="reveal"]::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+:root[data-mode-transition] {
+  isolation: isolate;
+}
+
+:root[data-mode-transition="reveal-expand"]::view-transition-old(root),
+:root[data-mode-transition="reveal-collapse"]::view-transition-new(root) {
+  z-index: 1;
+}
+
+:root[data-mode-transition="reveal-expand"]::view-transition-new(root),
+:root[data-mode-transition="reveal-collapse"]::view-transition-old(root) {
+  z-index: 2;
+}
+
+:root[data-mode-transition^="fallback"]::view-transition-old(root),
+:root[data-mode-transition^="fallback"]::view-transition-new(root) {
+  animation: none;
+}
+
+@keyframes theme-toggle-press {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(0.96);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes theme-icon-drift {
+  0% {
+    transform: translateY(0);
+  }
+  35% {
+    transform: translateY(-0.5px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
 /*
   shadcn/ui theme tokens
   - Theme: document.documentElement.dataset.theme =

--- a/frontend/src/pages/Workspace/components/__tests__/WorkspaceTopbarControls.test.tsx
+++ b/frontend/src/pages/Workspace/components/__tests__/WorkspaceTopbarControls.test.tsx
@@ -1,0 +1,186 @@
+import userEvent from "@testing-library/user-event";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { WorkspaceTopbarControls } from "@/pages/Workspace/components/WorkspaceTopbarControls";
+
+const mockSetModePreference = vi.fn();
+const mockSetPreviewTheme = vi.fn();
+const mockSetTheme = vi.fn();
+const mockUseTheme = vi.fn();
+
+vi.mock("@/providers/auth/SessionContext", () => ({
+  useSession: () => ({
+    user: {
+      display_name: "Test User",
+      email: "test@example.com",
+    },
+  }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+vi.mock("@/providers/theme", () => ({
+  BUILTIN_THEMES: [{ id: "default", label: "Default", description: "Default theme" }],
+  MODE_OPTIONS: [
+    { value: "system", label: "System", description: "Match your device" },
+    { value: "light", label: "Light", description: "Bright and clear" },
+    { value: "dark", label: "Dark", description: "Low-light friendly" },
+  ],
+  WORKSPACE_THEME_MODE_ANCHOR: "workspace-topbar-mode-toggle",
+  useTheme: () => mockUseTheme(),
+}));
+
+vi.mock("@/providers/theme/modeTransition", () => ({
+  MOTION_PROFILE: {
+    buttonPress: {
+      durationMs: 120,
+      leadInMs: 40,
+    },
+  },
+}));
+
+vi.mock("@/hooks/system", () => ({
+  useSystemVersions: () => ({
+    data: { backend: "1.0.0", engine: "1.0.0", web: "1.0.0" },
+    isPending: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+describe("WorkspaceTopbarControls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTheme.mockReturnValue({
+      theme: "default",
+      modePreference: "light",
+      resolvedMode: "light",
+      setModePreference: mockSetModePreference,
+      setPreviewTheme: mockSetPreviewTheme,
+      setTheme: mockSetTheme,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("toggles between light and dark from the primary mode button", async () => {
+    vi.useFakeTimers();
+    render(<WorkspaceTopbarControls />);
+
+    const toggleButton = screen.getByRole("button", { name: "Switch to dark mode" });
+    vi.spyOn(toggleButton, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 30,
+      height: 40,
+      right: 40,
+      bottom: 60,
+      x: 10,
+      y: 20,
+      toJSON: () => "",
+    } as DOMRect);
+
+    fireEvent.click(toggleButton);
+    const iconDrift = toggleButton.querySelector<HTMLElement>("[data-mode-icon-drift]");
+
+    expect(toggleButton).toHaveAttribute("data-pressing", "true");
+    expect(iconDrift).toHaveAttribute("data-drift", "to-dark");
+    expect(mockSetModePreference).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(39);
+    });
+    expect(mockSetModePreference).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(mockSetModePreference).toHaveBeenCalledWith(
+      "dark",
+      expect.objectContaining({
+        animate: true,
+        source: "user",
+        origin: { x: 25, y: 40 },
+      }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(80);
+    });
+    expect(toggleButton).toHaveAttribute("data-pressing", "false");
+    expect(iconDrift).toHaveAttribute("data-drift", "idle");
+  });
+
+  it("exposes Light, Dark, and System options in the mode menu", async () => {
+    const user = userEvent.setup();
+    render(<WorkspaceTopbarControls />);
+
+    await user.click(screen.getByRole("button", { name: "Select color mode" }));
+
+    expect(screen.getByText("System")).toBeInTheDocument();
+    expect(screen.getByText("Light")).toBeInTheDocument();
+    expect(screen.getByText("Dark")).toBeInTheDocument();
+    expect(screen.getByText("Match your device")).toBeInTheDocument();
+    expect(screen.getByText("Bright and clear")).toBeInTheDocument();
+    expect(screen.getByText("Low-light friendly")).toBeInTheDocument();
+  });
+
+  it("maps icon drift direction for dark and light transitions", async () => {
+    const user = userEvent.setup();
+    mockUseTheme.mockReturnValueOnce({
+      theme: "default",
+      modePreference: "dark",
+      resolvedMode: "dark",
+      setModePreference: mockSetModePreference,
+      setPreviewTheme: mockSetPreviewTheme,
+      setTheme: mockSetTheme,
+    });
+
+    render(<WorkspaceTopbarControls />);
+    const toggleButton = screen.getByRole("button", { name: "Switch to light mode" });
+    await user.click(toggleButton);
+    const iconDrift = toggleButton.querySelector<HTMLElement>("[data-mode-icon-drift]");
+
+    expect(iconDrift).toHaveAttribute("data-drift", "to-light");
+  });
+
+  it("sends animated mode options with origin coordinates when selecting from menu", async () => {
+    const user = userEvent.setup();
+    render(<WorkspaceTopbarControls />);
+
+    const toggleButton = screen.getByRole("button", { name: "Switch to dark mode" });
+    vi.spyOn(toggleButton, "getBoundingClientRect").mockReturnValue({
+      left: 30,
+      top: 40,
+      width: 20,
+      height: 30,
+      right: 50,
+      bottom: 70,
+      x: 30,
+      y: 40,
+      toJSON: () => "",
+    } as DOMRect);
+
+    await user.click(screen.getByRole("button", { name: "Select color mode" }));
+    await user.click(screen.getByRole("menuitem", { name: /System/i }));
+
+    expect(mockSetModePreference).toHaveBeenCalledWith(
+      "system",
+      expect.objectContaining({
+        animate: true,
+        source: "user",
+        origin: { x: 40, y: 55 },
+      }),
+    );
+  });
+});

--- a/frontend/src/providers/theme/__tests__/ThemeProvider.modeTransition.test.tsx
+++ b/frontend/src/providers/theme/__tests__/ThemeProvider.modeTransition.test.tsx
@@ -1,0 +1,133 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "../ThemeProvider";
+import { useTheme } from "../useTheme";
+import { MODE_STORAGE_KEY } from "../themeStorage";
+import { runModeTransition } from "../modeTransition";
+
+const DARK_MODE_QUERY = "(prefers-color-scheme: dark)";
+
+vi.mock("../modeTransition", async () => {
+  const actual = await vi.importActual<typeof import("../modeTransition")>("../modeTransition");
+  return {
+    ...actual,
+    runModeTransition: vi.fn(async (options: { apply: () => void }) => {
+      options.apply();
+    }),
+    findModeTransitionOrigin: vi.fn(() => ({ x: 120, y: 80 })),
+  };
+});
+
+function installMatchMedia(initialDarkMode = false) {
+  let prefersDark = initialDarkMode;
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string): MediaQueryList => ({
+      matches: query === DARK_MODE_QUERY ? prefersDark : false,
+      media: query,
+      onchange: null,
+      addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (query !== DARK_MODE_QUERY || type !== "change") {
+          return;
+        }
+        const callback = listener as (event: MediaQueryListEvent) => void;
+        listeners.add(callback);
+      },
+      removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (query !== DARK_MODE_QUERY || type !== "change") {
+          return;
+        }
+        const callback = listener as (event: MediaQueryListEvent) => void;
+        listeners.delete(callback);
+      },
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+
+  return {
+    setDarkMode(next: boolean) {
+      prefersDark = next;
+      for (const listener of listeners) {
+        listener({ matches: next, media: DARK_MODE_QUERY } as MediaQueryListEvent);
+      }
+    },
+  };
+}
+
+function ThemeProbe() {
+  const { modePreference, resolvedMode } = useTheme();
+  return (
+    <div>
+      <span data-testid="mode-preference">{modePreference}</span>
+      <span data-testid="resolved-mode">{resolvedMode}</span>
+    </div>
+  );
+}
+
+describe("ThemeProvider mode transitions", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("defaults to light mode when storage is empty", () => {
+    installMatchMedia(false);
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("mode-preference")).toHaveTextContent("light");
+    expect(screen.getByTestId("resolved-mode")).toHaveTextContent("light");
+  });
+
+  it("preserves existing mode preference from storage", () => {
+    installMatchMedia(false);
+    localStorage.setItem(MODE_STORAGE_KEY, JSON.stringify("dark"));
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("mode-preference")).toHaveTextContent("dark");
+    expect(screen.getByTestId("resolved-mode")).toHaveTextContent("dark");
+  });
+
+  it("animates system-mode OS changes through runModeTransition", async () => {
+    const media = installMatchMedia(false);
+    localStorage.setItem(MODE_STORAGE_KEY, JSON.stringify("system"));
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    act(() => {
+      media.setDarkMode(true);
+    });
+
+    await waitFor(() => {
+      expect(runModeTransition).toHaveBeenCalledTimes(1);
+    });
+
+    expect(runModeTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "light",
+        to: "dark",
+        animate: true,
+      }),
+    );
+    expect(screen.getByTestId("resolved-mode")).toHaveTextContent("dark");
+  });
+});

--- a/frontend/src/providers/theme/__tests__/modeTransition.test.ts
+++ b/frontend/src/providers/theme/__tests__/modeTransition.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MOTION_PROFILE,
+  THEME_MODE_ANCHOR_ATTR,
+  WORKSPACE_THEME_MODE_ANCHOR,
+  findModeTransitionOrigin,
+  runModeTransition,
+} from "../modeTransition";
+
+function mockAnimate() {
+  const animate = vi.fn(() => ({ finished: Promise.resolve() } as unknown as Animation));
+  Object.defineProperty(document.documentElement, "animate", {
+    configurable: true,
+    writable: true,
+    value: animate,
+  });
+  return animate;
+}
+
+function mockMatchMedia(prefersReducedMotion: boolean) {
+  const implementation = vi.fn((query: string): MediaQueryList => ({
+    matches: query === "(prefers-reduced-motion: reduce)" ? prefersReducedMotion : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: implementation,
+  });
+}
+
+function installRafController() {
+  let now = 0;
+  let nextId = 0;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const requestSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback: FrameRequestCallback) => {
+    const id = ++nextId;
+    callbacks.set(id, callback);
+    return id;
+  });
+  const cancelSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id: number) => {
+    callbacks.delete(id);
+  });
+  const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => now);
+
+  const step = (ms: number) => {
+    now += ms;
+    const pending = Array.from(callbacks.entries());
+    callbacks.clear();
+    pending.forEach(([, callback]) => callback(now));
+  };
+
+  const flush = (durationMs: number, frameMs = 16) => {
+    const steps = Math.ceil(durationMs / frameMs) + 2;
+    for (let index = 0; index < steps; index += 1) {
+      step(frameMs);
+      if (callbacks.size === 0) {
+        break;
+      }
+    }
+  };
+
+  return {
+    step,
+    flush,
+    cancelSpy,
+    restore() {
+      requestSpy.mockRestore();
+      cancelSpy.mockRestore();
+      nowSpy.mockRestore();
+    },
+  };
+}
+
+function mockStartViewTransition(callbackImpl?: (callback: () => void) => void) {
+  const startViewTransition = vi.fn((callback: () => void): ViewTransition => {
+    if (callbackImpl) {
+      callbackImpl(callback);
+    } else {
+      callback();
+    }
+
+    return {
+      ready: Promise.resolve(),
+      finished: Promise.resolve(),
+      updateCallbackDone: Promise.resolve(),
+    };
+  });
+
+  Object.defineProperty(document, "startViewTransition", {
+    configurable: true,
+    writable: true,
+    value: startViewTransition,
+  });
+
+  return startViewTransition;
+}
+
+describe("modeTransition", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.removeAttribute("data-mode-transition");
+    document.documentElement.style.removeProperty("--mode-transition-origin-x");
+    document.documentElement.style.removeProperty("--mode-transition-origin-y");
+    document.documentElement.style.removeProperty("--mode-transition-radius");
+    mockMatchMedia(false);
+  });
+
+  it("uses view transition reveal when supported and entering dark mode", async () => {
+    const apply = vi.fn();
+    const startViewTransition = mockStartViewTransition();
+    const animate = mockAnimate();
+
+    await runModeTransition({
+      from: "light",
+      to: "dark",
+      apply,
+      animate: true,
+      origin: { x: 120, y: 80 },
+    });
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(animate).toHaveBeenCalledTimes(1);
+    const [frames, options] = animate.mock.calls[0] as [
+      Array<{ clipPath: string }>,
+      KeyframeAnimationOptions,
+    ];
+    expect(frames[0].clipPath).toContain(`circle(${MOTION_PROFILE.revealExpand.startRadiusPx}px at 120px 80px)`);
+    expect(frames[0].filter).toContain("drop-shadow");
+    expect(options.pseudoElement).toBe("::view-transition-new(root)");
+    expect(options.duration).toBe(MOTION_PROFILE.revealExpand.durationMs);
+    expect(options.easing).toBe(MOTION_PROFILE.revealExpand.easing);
+    expect(document.documentElement).not.toHaveAttribute("data-mode-transition");
+  });
+
+  it("uses collapse direction when exiting dark mode", async () => {
+    const apply = vi.fn();
+    mockStartViewTransition();
+    const animate = mockAnimate();
+
+    await runModeTransition({
+      from: "dark",
+      to: "light",
+      apply,
+      animate: true,
+      origin: { x: 12, y: 18 },
+    });
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    const [frames, options] = animate.mock.calls[0] as [
+      Array<{ clipPath: string }>,
+      KeyframeAnimationOptions,
+    ];
+    expect(frames[1].clipPath).toContain(`circle(${MOTION_PROFILE.revealCollapse.endRadiusPx}px at 12px 18px)`);
+    expect(options.pseudoElement).toBe("::view-transition-old(root)");
+    expect(options.duration).toBe(MOTION_PROFILE.revealCollapse.durationMs);
+    expect(options.easing).toBe(MOTION_PROFILE.revealCollapse.easing);
+  });
+
+  it("uses directional fallback mask when view transitions are unavailable", async () => {
+    const apply = vi.fn();
+    const raf = installRafController();
+    Object.defineProperty(document, "startViewTransition", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const transition = runModeTransition({
+      from: "light",
+      to: "dark",
+      apply,
+      animate: true,
+      origin: { x: 30, y: 40 },
+    });
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    const overlay = document.querySelector<HTMLElement>("[data-mode-transition-overlay]");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.style.maskImage).toContain("30px 40px");
+
+    raf.flush(MOTION_PROFILE.fallbackDirectional.durationMs);
+    await transition;
+    raf.restore();
+
+    expect(document.querySelector("[data-mode-transition-overlay]")).toBeNull();
+    expect(document.documentElement).not.toHaveAttribute("data-mode-transition");
+  });
+
+  it("skips animation when reduced motion is enabled", async () => {
+    const apply = vi.fn();
+    const startViewTransition = mockStartViewTransition();
+    mockAnimate();
+    mockMatchMedia(true);
+
+    await runModeTransition({
+      from: "light",
+      to: "dark",
+      apply,
+      animate: true,
+      origin: { x: 10, y: 20 },
+    });
+
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to immediate apply when view transition throws", async () => {
+    const apply = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    Object.defineProperty(document, "startViewTransition", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => {
+        throw new Error("boom");
+      }),
+    });
+    const animate = mockAnimate();
+
+    await runModeTransition({
+      from: "light",
+      to: "dark",
+      apply,
+      animate: true,
+      origin: { x: 10, y: 20 },
+    });
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(animate).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("cancels in-flight fallback transitions when a new toggle occurs", async () => {
+    const raf = installRafController();
+    Object.defineProperty(document, "startViewTransition", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    const firstApply = vi.fn();
+    const secondApply = vi.fn();
+
+    const firstTransition = runModeTransition({
+      from: "light",
+      to: "dark",
+      apply: firstApply,
+      animate: true,
+      origin: { x: 10, y: 20 },
+    });
+    raf.step(100);
+
+    const secondTransition = runModeTransition({
+      from: "dark",
+      to: "light",
+      apply: secondApply,
+      animate: true,
+      origin: { x: 20, y: 30 },
+    });
+    raf.flush(MOTION_PROFILE.fallbackDirectional.durationMs);
+
+    await Promise.all([firstTransition, secondTransition]);
+    raf.restore();
+
+    expect(firstApply).toHaveBeenCalledTimes(1);
+    expect(secondApply).toHaveBeenCalledTimes(1);
+    expect(document.querySelectorAll("[data-mode-transition-overlay]").length).toBe(0);
+  });
+
+  it("skips animation when tab visibility is hidden", async () => {
+    const apply = vi.fn();
+    const startViewTransition = mockStartViewTransition();
+    const visibilitySpy = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+
+    await runModeTransition({
+      from: "light",
+      to: "dark",
+      apply,
+      animate: true,
+      origin: { x: 10, y: 20 },
+    });
+
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(apply).toHaveBeenCalledTimes(1);
+    visibilitySpy.mockRestore();
+  });
+
+  it("resolves transition origin from the mode toggle anchor", () => {
+    const anchor = document.createElement("button");
+    anchor.setAttribute(THEME_MODE_ANCHOR_ATTR, WORKSPACE_THEME_MODE_ANCHOR);
+    anchor.getBoundingClientRect = () =>
+      ({
+        left: 40,
+        top: 20,
+        width: 30,
+        height: 10,
+      }) as DOMRect;
+    document.body.appendChild(anchor);
+
+    const origin = findModeTransitionOrigin();
+    expect(origin).toEqual({ x: 55, y: 25 });
+
+    anchor.remove();
+  });
+});

--- a/frontend/src/providers/theme/index.ts
+++ b/frontend/src/providers/theme/index.ts
@@ -6,11 +6,13 @@ import {
   type ThemeId,
 } from "./themes";
 import type { ModePreference } from "./themeStorage";
+import type { SetModePreferenceOptions } from "./modeTransition";
 
 export type ResolvedMode = "light" | "dark";
 
 export type { ModePreference };
 export type { ThemeId };
+export type { SetModePreferenceOptions };
 
 export const DEFAULT_THEME_ID: ThemeId = "default";
 export const BUILTIN_THEME_IDS = THEME_IDS satisfies readonly ThemeId[];
@@ -64,3 +66,8 @@ export function applyThemeToDocument(theme: ThemeId, mode: ResolvedMode): void {
 
 export { ThemeProvider } from "./ThemeProvider";
 export { useTheme } from "./useTheme";
+export {
+  DEFAULT_MODE_TRANSITION_DURATION_MS,
+  THEME_MODE_ANCHOR_ATTR,
+  WORKSPACE_THEME_MODE_ANCHOR,
+} from "./modeTransition";

--- a/frontend/src/providers/theme/modeTransition.ts
+++ b/frontend/src/providers/theme/modeTransition.ts
@@ -1,0 +1,451 @@
+import type { ResolvedMode } from "./index";
+
+export type ModeTransitionSource = "user" | "system";
+
+export type TransitionOrigin = {
+  x: number;
+  y: number;
+};
+
+export type SetModePreferenceOptions = {
+  animate?: boolean;
+  origin?: TransitionOrigin;
+  source?: ModeTransitionSource;
+};
+
+type RunModeTransitionOptions = {
+  from: ResolvedMode;
+  to: ResolvedMode;
+  apply: () => void;
+  animate: boolean;
+  origin?: TransitionOrigin;
+  durationMs?: number;
+};
+
+export const THEME_MODE_ANCHOR_ATTR = "data-theme-mode-anchor";
+export const WORKSPACE_THEME_MODE_ANCHOR = "workspace-topbar-mode-toggle";
+export const MOTION_PROFILE = {
+  revealExpand: {
+    durationMs: 760,
+    easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    featherPx: 12,
+    startRadiusPx: 6,
+  },
+  revealCollapse: {
+    durationMs: 520,
+    easing: "cubic-bezier(0.4, 0, 0.2, 1)",
+    featherPx: 10,
+    endRadiusPx: 4,
+  },
+  buttonPress: {
+    durationMs: 120,
+    leadInMs: 40,
+  },
+  fallbackDirectional: {
+    durationMs: 420,
+    easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+    bezier: [0.22, 1, 0.36, 1] as const,
+    featherPx: 14,
+  },
+} as const;
+
+export const DEFAULT_MODE_TRANSITION_DURATION_MS = MOTION_PROFILE.revealExpand.durationMs;
+
+const MODE_TRANSITION_ATTR = "data-mode-transition";
+const MODE_TRANSITION_ORIGIN_X = "--mode-transition-origin-x";
+const MODE_TRANSITION_ORIGIN_Y = "--mode-transition-origin-y";
+const MODE_TRANSITION_RADIUS = "--mode-transition-radius";
+const MODE_TRANSITION_FEATHER = "--mode-transition-feather";
+const FALLBACK_OVERLAY_ATTR = "data-mode-transition-overlay";
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+type TransitionState =
+  | "reveal-expand"
+  | "reveal-collapse"
+  | "fallback-expand"
+  | "fallback-collapse";
+
+type ActiveTransition = {
+  cancel: () => void;
+};
+
+let activeTransition: ActiveTransition | null = null;
+
+function supportsViewTransition(): boolean {
+  return typeof document !== "undefined" && typeof document.startViewTransition === "function";
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function shouldSkipAnimation(): boolean {
+  if (typeof document === "undefined") {
+    return true;
+  }
+  if (document.visibilityState !== "visible") {
+    return true;
+  }
+  return false;
+}
+
+function getViewportCenter(): TransitionOrigin {
+  if (typeof window === "undefined") {
+    return { x: 0, y: 0 };
+  }
+  return {
+    x: window.innerWidth / 2,
+    y: window.innerHeight / 2,
+  };
+}
+
+function distanceToFarthestCorner(origin: TransitionOrigin): number {
+  if (typeof window === "undefined") {
+    return 0;
+  }
+  const corners: Array<[number, number]> = [
+    [0, 0],
+    [window.innerWidth, 0],
+    [0, window.innerHeight],
+    [window.innerWidth, window.innerHeight],
+  ];
+
+  return corners.reduce((max, [x, y]) => {
+    const dx = x - origin.x;
+    const dy = y - origin.y;
+    const distance = Math.hypot(dx, dy);
+    return Math.max(max, distance);
+  }, 0);
+}
+
+function setTransitionAttributes(state: TransitionState, origin: TransitionOrigin, radius: number): void {
+  const root = document.documentElement;
+  const feather =
+    state === "reveal-expand"
+      ? MOTION_PROFILE.revealExpand.featherPx
+      : state === "reveal-collapse"
+        ? MOTION_PROFILE.revealCollapse.featherPx
+        : MOTION_PROFILE.fallbackDirectional.featherPx;
+  root.setAttribute(MODE_TRANSITION_ATTR, state);
+  root.style.setProperty(MODE_TRANSITION_ORIGIN_X, `${origin.x}px`);
+  root.style.setProperty(MODE_TRANSITION_ORIGIN_Y, `${origin.y}px`);
+  root.style.setProperty(MODE_TRANSITION_RADIUS, `${radius}px`);
+  root.style.setProperty(MODE_TRANSITION_FEATHER, `${feather}px`);
+}
+
+function clearTransitionAttributes(): void {
+  const root = document.documentElement;
+  root.removeAttribute(MODE_TRANSITION_ATTR);
+  root.style.removeProperty(MODE_TRANSITION_ORIGIN_X);
+  root.style.removeProperty(MODE_TRANSITION_ORIGIN_Y);
+  root.style.removeProperty(MODE_TRANSITION_RADIUS);
+  root.style.removeProperty(MODE_TRANSITION_FEATHER);
+}
+
+function buildClipPath(radius: number, origin: TransitionOrigin): string {
+  return `circle(${radius}px at ${origin.x}px ${origin.y}px)`;
+}
+
+function removeFallbackOverlays(): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const overlays = document.querySelectorAll(`[${FALLBACK_OVERLAY_ATTR}]`);
+  overlays.forEach((overlay) => overlay.remove());
+}
+
+function cancelInFlightTransition(): void {
+  if (activeTransition) {
+    activeTransition.cancel();
+    activeTransition = null;
+  }
+  clearTransitionAttributes();
+  removeFallbackOverlays();
+}
+
+function setActiveTransition(next: ActiveTransition): void {
+  cancelInFlightTransition();
+  activeTransition = next;
+}
+
+function clearActiveTransition(next: ActiveTransition): void {
+  if (activeTransition === next) {
+    activeTransition = null;
+  }
+}
+
+function sampleCurve(t: number, p0: number, p1: number, p2: number, p3: number): number {
+  const invT = 1 - t;
+  return invT ** 3 * p0 + 3 * invT ** 2 * t * p1 + 3 * invT * t ** 2 * p2 + t ** 3 * p3;
+}
+
+function sampleCurveDerivative(t: number, p0: number, p1: number, p2: number, p3: number): number {
+  const invT = 1 - t;
+  return 3 * invT ** 2 * (p1 - p0) + 6 * invT * t * (p2 - p1) + 3 * t ** 2 * (p3 - p2);
+}
+
+function cubicBezierProgress(progress: number, bezier: [number, number, number, number]): number {
+  if (progress <= 0 || progress >= 1) {
+    return progress;
+  }
+
+  const [x1, y1, x2, y2] = bezier;
+  let t = progress;
+  for (let index = 0; index < 5; index += 1) {
+    const estimate = sampleCurve(t, 0, x1, x2, 1) - progress;
+    const derivative = sampleCurveDerivative(t, 0, x1, x2, 1);
+    if (Math.abs(derivative) < 1e-6) {
+      break;
+    }
+    t -= estimate / derivative;
+    t = Math.min(1, Math.max(0, t));
+  }
+
+  return sampleCurve(t, 0, y1, y2, 1);
+}
+
+function applyFallbackMask(
+  overlay: HTMLDivElement,
+  direction: "expand" | "collapse",
+  origin: TransitionOrigin,
+  radius: number,
+  featherPx: number,
+): void {
+  const inner = Math.max(0, radius - featherPx);
+  const outer = Math.max(inner + 0.001, radius + featherPx);
+  const gradient =
+    direction === "expand"
+      ? `radial-gradient(circle at ${origin.x}px ${origin.y}px, transparent ${inner}px, rgb(0 0 0) ${outer}px)`
+      : `radial-gradient(circle at ${origin.x}px ${origin.y}px, rgb(0 0 0) ${inner}px, transparent ${outer}px)`;
+
+  overlay.style.maskImage = gradient;
+  overlay.style.webkitMaskImage = gradient;
+}
+
+async function runViewRevealTransition({
+  from,
+  to,
+  apply,
+  origin: explicitOrigin,
+  durationMs,
+}: Omit<RunModeTransitionOptions, "animate">): Promise<void> {
+  const origin = explicitOrigin ?? getViewportCenter();
+  const radius = distanceToFarthestCorner(origin);
+  const isEnteringDark = from === "light" && to === "dark";
+  const transitionState: TransitionState = isEnteringDark ? "reveal-expand" : "reveal-collapse";
+  const profile = isEnteringDark ? MOTION_PROFILE.revealExpand : MOTION_PROFILE.revealCollapse;
+  const pseudoElement = isEnteringDark ? "::view-transition-new(root)" : "::view-transition-old(root)";
+  const startingRadius = isEnteringDark ? profile.startRadiusPx : radius;
+  const endingRadius = isEnteringDark ? radius : profile.endRadiusPx;
+  let hasApplied = false;
+  let isCanceled = false;
+  let animation: Animation | null = null;
+  const active: ActiveTransition = {
+    cancel: () => {
+      isCanceled = true;
+      animation?.cancel();
+      clearTransitionAttributes();
+      removeFallbackOverlays();
+    },
+  };
+
+  setActiveTransition(active);
+  setTransitionAttributes(transitionState, origin, radius);
+
+  try {
+    const transition = document.startViewTransition?.(() => {
+      hasApplied = true;
+      apply();
+    });
+
+    if (!transition) {
+      hasApplied = true;
+      apply();
+      return;
+    }
+
+    await transition.ready;
+    if (isCanceled) {
+      return;
+    }
+
+    const dropShadowFrom = isEnteringDark
+      ? `drop-shadow(0 0 ${Math.round(profile.featherPx * 1.5)}px rgba(0, 0, 0, 0.22))`
+      : `drop-shadow(0 0 ${profile.featherPx}px rgba(0, 0, 0, 0.14))`;
+    const dropShadowTo = isEnteringDark
+      ? `drop-shadow(0 0 ${profile.featherPx}px rgba(0, 0, 0, 0.1))`
+      : `drop-shadow(0 0 ${profile.featherPx}px rgba(0, 0, 0, 0.14))`;
+
+    animation = document.documentElement.animate(
+      [
+        { clipPath: buildClipPath(startingRadius, origin), filter: dropShadowFrom },
+        { clipPath: buildClipPath(endingRadius, origin), filter: dropShadowTo },
+      ],
+      {
+        duration: durationMs ?? profile.durationMs,
+        easing: profile.easing,
+        fill: "both",
+        pseudoElement,
+      },
+    );
+
+    await Promise.allSettled([animation.finished.catch(() => null), transition.finished.catch(() => null)]);
+  } catch (error) {
+    if (!hasApplied) {
+      throw error;
+    }
+  } finally {
+    clearActiveTransition(active);
+    clearTransitionAttributes();
+  }
+}
+
+async function runDirectionalFallbackTransition({
+  from,
+  to,
+  apply,
+  origin: explicitOrigin,
+  durationMs,
+}: Omit<RunModeTransitionOptions, "animate">): Promise<void> {
+  const origin = explicitOrigin ?? getViewportCenter();
+  const radius = distanceToFarthestCorner(origin);
+  const isEnteringDark = from === "light" && to === "dark";
+  const transitionState: TransitionState = isEnteringDark ? "fallback-expand" : "fallback-collapse";
+  const direction = isEnteringDark ? "expand" : "collapse";
+  const fallbackProfile = MOTION_PROFILE.fallbackDirectional;
+  const duration = durationMs ?? fallbackProfile.durationMs;
+  const feather = fallbackProfile.featherPx;
+  const startRadius = isEnteringDark ? 0 : radius;
+  const endRadius = isEnteringDark ? radius : 0;
+  const root = document.documentElement;
+  const overlay = document.createElement("div");
+  const bodyColor = getComputedStyle(document.body).backgroundColor;
+  const rootColor = getComputedStyle(document.documentElement).backgroundColor;
+  const overlayColor = bodyColor || rootColor || "rgb(255, 255, 255)";
+  let rafId = 0;
+  let isCanceled = false;
+  let resolveTransition: (() => void) | null = null;
+  let rejectTransition: ((error: unknown) => void) | null = null;
+  const transitionPromise = new Promise<void>((resolve, reject) => {
+    resolveTransition = resolve;
+    rejectTransition = reject;
+  });
+  const active: ActiveTransition = {
+    cancel: () => {
+      isCanceled = true;
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+      }
+      overlay.remove();
+      clearTransitionAttributes();
+      removeFallbackOverlays();
+      resolveTransition?.();
+    },
+  };
+
+  setActiveTransition(active);
+  setTransitionAttributes(transitionState, origin, radius);
+
+  overlay.setAttribute(FALLBACK_OVERLAY_ATTR, "true");
+  overlay.style.position = "fixed";
+  overlay.style.inset = "0";
+  overlay.style.pointerEvents = "none";
+  overlay.style.zIndex = "var(--app-z-tooltip)";
+  overlay.style.backgroundColor = overlayColor;
+  overlay.style.willChange = "mask-image, -webkit-mask-image";
+  overlay.style.contain = "strict";
+  document.body.appendChild(overlay);
+
+  apply();
+
+  const easing = fallbackProfile.bezier;
+  const startedAt = performance.now();
+
+  const frame = (now: number) => {
+    if (isCanceled) {
+      return;
+    }
+
+    const elapsed = Math.max(0, now - startedAt);
+    const rawProgress = Math.min(1, elapsed / duration);
+    const easedProgress = cubicBezierProgress(rawProgress, easing);
+    const currentRadius = startRadius + (endRadius - startRadius) * easedProgress;
+
+    applyFallbackMask(overlay, direction, origin, currentRadius, feather);
+
+    if (rawProgress >= 1) {
+      overlay.remove();
+      clearTransitionAttributes();
+      clearActiveTransition(active);
+      resolveTransition?.();
+      return;
+    }
+
+    rafId = requestAnimationFrame(frame);
+  };
+
+  try {
+    applyFallbackMask(overlay, direction, origin, startRadius, feather);
+    rafId = requestAnimationFrame(frame);
+    await transitionPromise;
+  } catch (error) {
+    rejectTransition?.(error);
+    throw error;
+  } finally {
+    overlay.remove();
+    clearTransitionAttributes();
+    clearActiveTransition(active);
+    if (root.getAttribute(MODE_TRANSITION_ATTR)?.startsWith("fallback")) {
+      root.removeAttribute(MODE_TRANSITION_ATTR);
+    }
+  }
+}
+
+export async function runModeTransition(options: RunModeTransitionOptions): Promise<void> {
+  const { from, to, apply, animate, origin, durationMs } = options;
+
+  if (typeof document === "undefined" || from === to) {
+    apply();
+    return;
+  }
+
+  if (!animate || prefersReducedMotion() || shouldSkipAnimation()) {
+    apply();
+    return;
+  }
+
+  cancelInFlightTransition();
+
+  if (!supportsViewTransition()) {
+    await runDirectionalFallbackTransition({ from, to, apply, origin, durationMs });
+    return;
+  }
+
+  try {
+    await runViewRevealTransition({ from, to, apply, origin, durationMs });
+  } catch (error) {
+    console.warn("Failed to run mode transition animation", error);
+    clearTransitionAttributes();
+    apply();
+  }
+}
+
+export function findModeTransitionOrigin(anchorName = WORKSPACE_THEME_MODE_ANCHOR): TransitionOrigin | undefined {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  const anchor = document.querySelector<HTMLElement>(`[${THEME_MODE_ANCHOR_ATTR}="${anchorName}"]`);
+  if (!anchor) {
+    return undefined;
+  }
+
+  const rect = anchor.getBoundingClientRect();
+  return {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  };
+}


### PR DESCRIPTION
## Summary
- replace workspace topbar mode switch with a split control (primary toggle + caret menu for System/Light/Dark)
- add polished dark-mode origin reveal transitions with motion profiles, fallbacks, and interruption guards
- refine dropdown UX details (icon consistency, option descriptions, selected-row treatment, cleaner open state)
- extend theme provider + transition API plumbing to support animated, origin-based mode changes
- add unit/integration coverage for transition engine, provider behavior, and topbar interactions

## Validation
- cd backend && uv run ade web test
- cd backend && uv run ade web lint