### PR TITLE
feat: launch first-class organization settings admin UX

### DIFF
--- a/backend/src/ade_api/features/system_settings/router.py
+++ b/backend/src/ade_api/features/system_settings/router.py
@@ -27,6 +27,7 @@ router = APIRouter(
 )
 def read_safe_mode(
     service: Annotated[SafeModeService, Depends(get_safe_mode_service_read)],
+    _actor: Annotated[object, Security(require_global("system.settings.read"))],
 ) -> SafeModeStatus:
     """Return the current ADE safe mode status."""
 

--- a/backend/src/ade_api/features/users/schemas.py
+++ b/backend/src/ade_api/features/users/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import EmailStr, Field, field_validator, model_validator
 
 from ade_api.common.ids import UUIDStr
 from ade_api.common.cursor_listing import CursorPage
@@ -62,8 +62,30 @@ class UserUpdate(BaseSchema):
         return self
 
 
+class UserCreate(BaseSchema):
+    """Payload for pre-provisioning a user account."""
+
+    email: EmailStr = Field(
+        ...,
+        description="User email.",
+    )
+    display_name: str | None = Field(
+        default=None,
+        description="Optional display name for the user.",
+        max_length=255,
+    )
+
+    @field_validator("display_name")
+    @classmethod
+    def _normalize_create_display_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+
 class UserPage(CursorPage[UserOut]):
     """Cursor-based collection of users."""
 
 
-__all__ = ["UserOut", "UserPage", "UserProfile", "UserUpdate"]
+__all__ = ["UserCreate", "UserOut", "UserPage", "UserProfile", "UserUpdate"]

--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -621,7 +621,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UserCreate"
+                "$ref": "#/components/schemas/ade_api__core__auth__users__UserCreate"
               }
             }
           },
@@ -801,6 +801,231 @@
           }
         },
         "security": []
+      }
+    },
+    "/api/v1/apikeys": {
+      "get": {
+        "tags": [
+          "api-keys"
+        ],
+        "summary": "List API keys across the tenant (admin)",
+        "operationId": "list_api_keys_api_v1_apikeys_get",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional user identifier filter.",
+              "title": "Userid"
+            },
+            "description": "Optional user identifier filter."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "description": "Items per page (max 200)",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Items per page (max 200)"
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor token for pagination.",
+              "title": "Cursor"
+            },
+            "description": "Opaque cursor token for pagination."
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "JSON array of {id, desc}.",
+              "title": "Sort"
+            },
+            "description": "JSON array of {id, desc}."
+          },
+          {
+            "name": "filters",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "URL-encoded JSON array of filter objects.",
+              "examples": {
+                "statusIn": {
+                  "summary": "Status filter",
+                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+                }
+              },
+              "title": "Filters"
+            },
+            "description": "URL-encoded JSON array of filter objects."
+          },
+          {
+            "name": "joinOperator",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/FilterJoinOperator",
+              "description": "Logical operator to join filters (and/or).",
+              "default": "and"
+            },
+            "description": "Logical operator to join filters (and/or)."
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
+              "examples": {
+                "multiToken": {
+                  "summary": "Search multiple tokens",
+                  "value": "acme invoice"
+                }
+              },
+              "title": "Q"
+            },
+            "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Include totalCount in the response.",
+              "default": false,
+              "title": "Includetotal"
+            },
+            "description": "Include totalCount in the response."
+          },
+          {
+            "name": "includeFacets",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Include facet counts in the response.",
+              "default": false,
+              "title": "Includefacets"
+            },
+            "description": "Include facet counts in the response."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyPage"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "403": {
+            "description": "Requires api_keys.read_all global permission.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
       }
     },
     "/api/v1/users/me/apikeys": {
@@ -2007,6 +2232,112 @@
                 }
               }
             },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Create a user (administrator only)",
+        "operationId": "create_user_api_v1_users_post",
+        "parameters": [
+          {
+            "name": "X-CSRF-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreate",
+                "description": "Fields to pre-provision a user account."
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required to create users.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "403": {
+            "description": "Global users.manage_all permission required.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "description": "Email already in use.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
@@ -17025,66 +17356,30 @@
           "email": {
             "type": "string",
             "format": "email",
-            "title": "Email"
-          },
-          "password": {
-            "type": "string",
-            "title": "Password"
-          },
-          "is_active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Active",
-            "default": true
-          },
-          "is_superuser": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Superuser",
-            "default": false
-          },
-          "is_verified": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Verified",
-            "default": false
+            "title": "Email",
+            "description": "User email."
           },
           "display_name": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 255
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Display Name"
+            "title": "Display Name",
+            "description": "Optional display name for the user."
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
-          "email",
-          "password"
+          "email"
         ],
-        "title": "UserCreate"
+        "title": "UserCreate",
+        "description": "Payload for pre-provisioning a user account."
       },
       "UserOut": {
         "properties": {
@@ -17818,6 +18113,72 @@
         "type": "object",
         "title": "WorkspaceUpdate",
         "description": "Payload for updating workspace metadata."
+      },
+      "ade_api__core__auth__users__UserCreate": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active",
+            "default": true
+          },
+          "is_superuser": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Superuser",
+            "default": false
+          },
+          "is_verified": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Verified",
+            "default": false
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "UserCreate"
       },
       "ProblemDetailsErrorItem": {
         "type": "object",

--- a/backend/tests/api/integration/auth/test_api_keys_flow.py
+++ b/backend/tests/api/integration/auth/test_api_keys_flow.py
@@ -47,3 +47,58 @@ async def test_create_list_revoke_api_key(
         headers={**auth_header, "If-Match": etag},
     )
     assert revoke.status_code == 204, revoke.text
+
+
+async def test_list_tenant_api_keys_requires_permission(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+
+    response = await async_client.get(
+        "/api/v1/apikeys",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 403
+
+
+async def test_list_tenant_api_keys_admin_supports_user_filter(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    admin = seed_identity.admin
+    member = seed_identity.member
+    owner = seed_identity.workspace_owner
+    token, _ = await login(async_client, email=admin.email, password=admin.password)
+    auth_header = {"Authorization": f"Bearer {token}"}
+
+    create_member_key = await async_client.post(
+        f"/api/v1/users/{member.id}/apikeys",
+        json={"name": "Member key"},
+        headers=auth_header,
+    )
+    assert create_member_key.status_code == 201, create_member_key.text
+
+    create_owner_key = await async_client.post(
+        f"/api/v1/users/{owner.id}/apikeys",
+        json={"name": "Owner key"},
+        headers=auth_header,
+    )
+    assert create_owner_key.status_code == 201, create_owner_key.text
+
+    list_response = await async_client.get("/api/v1/apikeys", headers=auth_header)
+    assert list_response.status_code == 200, list_response.text
+    all_keys = list_response.json()["items"]
+    assert any(item["user_id"] == str(member.id) for item in all_keys)
+    assert any(item["user_id"] == str(owner.id) for item in all_keys)
+
+    filtered_response = await async_client.get(
+        "/api/v1/apikeys",
+        headers=auth_header,
+        params={"userId": str(member.id)},
+    )
+    assert filtered_response.status_code == 200, filtered_response.text
+    filtered_keys = filtered_response.json()["items"]
+    assert filtered_keys
+    assert all(item["user_id"] == str(member.id) for item in filtered_keys)

--- a/backend/tests/api/integration/health/test_safe_mode_router.py
+++ b/backend/tests/api/integration/health/test_safe_mode_router.py
@@ -49,3 +49,19 @@ async def test_safe_mode_toggle_persists_state(
     assert safe_mode_component is not None
     assert safe_mode_component["status"] == "degraded"
     assert safe_mode_component["detail"] == "Maintenance window"
+
+
+async def test_safe_mode_read_requires_system_settings_permission(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    """Non-admins should be denied when reading safe mode status."""
+
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+
+    response = await async_client.get(
+        "/api/v1/system/safemode",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 403

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -8,6 +8,7 @@ import { appRoutes } from "@/app/routes";
 vi.mock("@/pages/Home", () => ({ default: () => <div data-testid="home-screen">home</div> }));
 vi.mock("@/pages/Login", () => ({ default: () => <div data-testid="login-screen">login</div> }));
 vi.mock("@/pages/Setup", () => ({ default: () => <div data-testid="setup-screen">setup</div> }));
+vi.mock("@/pages/OrganizationSettings", () => ({ default: () => <div data-testid="org-settings-screen">org-settings</div> }));
 vi.mock("@/pages/Workspaces", () => ({ default: () => <div data-testid="workspaces-screen">workspaces</div> }));
 vi.mock("@/pages/Workspaces/New", () => ({ default: () => <div data-testid="workspace-new-screen">new</div> }));
 vi.mock("@/pages/Workspace", () => ({ default: () => <div data-testid="workspace-screen">workspace</div> }));
@@ -35,6 +36,8 @@ describe("App routes", () => {
     { path: "/", testId: "home-screen" },
     { path: "/login", testId: "login-screen" },
     { path: "/setup", testId: "setup-screen" },
+    { path: "/organization/settings", testId: "org-settings-screen" },
+    { path: "/organization/settings/users", testId: "org-settings-screen" },
     { path: "/workspaces", testId: "workspaces-screen" },
     { path: "/workspaces/new", testId: "workspace-new-screen" },
     { path: "/workspaces/ws-1", testId: "workspace-screen" },

--- a/frontend/src/api/__tests__/uiErrors.test.ts
+++ b/frontend/src/api/__tests__/uiErrors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError, type ProblemDetails } from "@/api/errors";
+import { mapUiError } from "@/api/uiErrors";
+
+function asProblemDetails(value: unknown): ProblemDetails {
+  return value as ProblemDetails;
+}
+
+describe("mapUiError", () => {
+  it("uses generic fallback for unknown values", () => {
+    expect(mapUiError(null, { fallback: "Unable to save." }).message).toBe("Unable to save.");
+  });
+
+  it("returns a safe message for etag conflicts", () => {
+    const apiError = new ApiError("etag mismatch", 412);
+
+    const mapped = mapUiError(apiError, { fallback: "Unable to save." });
+
+    expect(mapped.message).toBe("This record changed while you were editing. Refresh and try again.");
+    expect(mapped.status).toBe(412);
+  });
+
+  it("collects field-level problem details", () => {
+    const problem = asProblemDetails({
+      type: "about:blank",
+      title: "Unprocessable Content",
+      status: 422,
+      instance: "/api/v1/admin/sso/providers",
+      errors: [
+        { path: "label", message: "Label is required.", code: "required" },
+        { path: "issuer", message: "Issuer must be a URL.", code: "invalid" },
+      ],
+    });
+
+    const mapped = mapUiError(new ApiError("Validation failed", 422, problem), {
+      fallback: "Unable to save provider.",
+    });
+
+    expect(mapped.fieldErrors.label).toEqual(["Label is required."]);
+    expect(mapped.fieldErrors.issuer).toEqual(["Issuer must be a URL."]);
+  });
+});

--- a/frontend/src/api/admin/__tests__/api-keys.test.ts
+++ b/frontend/src/api/admin/__tests__/api-keys.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listTenantApiKeys, revokeAdminUserApiKey } from "../api-keys";
+import { client } from "@/api/client";
+
+vi.mock("@/api/client", () => ({
+  client: {
+    GET: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+describe("admin api keys api", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists tenant keys and supports user filter", async () => {
+    (client.GET as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { items: [], meta: { limit: 50, hasMore: false, nextCursor: null, totalIncluded: true, totalCount: 0, changesCursor: "0" }, facets: null },
+    });
+
+    await listTenantApiKeys({ userId: "u1", includeRevoked: true, limit: 25 });
+
+    expect(client.GET).toHaveBeenCalledWith("/api/v1/apikeys", {
+      params: { query: { limit: 25, userId: "u1" } },
+      signal: undefined,
+    });
+  });
+
+  it("revokes a user api key", async () => {
+    (client.DELETE as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null });
+
+    await revokeAdminUserApiKey("u1", "k1", { ifMatch: "*" });
+    expect(client.DELETE).toHaveBeenCalledWith("/api/v1/users/{userId}/apikeys/{apiKeyId}", {
+      params: {
+        path: { userId: "u1", apiKeyId: "k1" },
+        header: { "If-Match": "*" },
+      },
+    });
+  });
+});

--- a/frontend/src/api/admin/__tests__/roles.test.ts
+++ b/frontend/src/api/admin/__tests__/roles.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  assignAdminUserRole,
+  listAdminPermissions,
+  listAdminRoles,
+  removeAdminUserRole,
+} from "../roles";
+import { client } from "@/api/client";
+
+vi.mock("@/api/client", () => ({
+  client: {
+    GET: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+describe("admin roles api", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists global roles with scope filter", async () => {
+    (client.GET as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { items: [], meta: { limit: 50, hasMore: false, nextCursor: null, totalIncluded: false, totalCount: null, changesCursor: "0" }, facets: null },
+    });
+
+    await listAdminRoles({ limit: 10 });
+    expect(client.GET).toHaveBeenCalledWith("/api/v1/roles", {
+      params: {
+        query: {
+          limit: 10,
+          filters: JSON.stringify([{ id: "scopeType", operator: "eq", value: "global" }]),
+        },
+      },
+      signal: undefined,
+    });
+  });
+
+  it("lists global permissions and manages assignments", async () => {
+    (client.GET as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { items: [], meta: { limit: 50, hasMore: false, nextCursor: null, totalIncluded: false, totalCount: null, changesCursor: "0" }, facets: null },
+    });
+    (client.PUT as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { user_id: "u1", roles: [] } });
+    (client.DELETE as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null });
+
+    await listAdminPermissions({ scope: "global" });
+    expect(client.GET).toHaveBeenCalledWith("/api/v1/permissions", expect.any(Object));
+
+    await assignAdminUserRole("u1", "r1");
+    expect(client.PUT).toHaveBeenCalledWith("/api/v1/users/{userId}/roles/{roleId}", {
+      params: { path: { userId: "u1", roleId: "r1" } },
+    });
+
+    await removeAdminUserRole("u1", "r1", { ifMatch: "*" });
+    expect(client.DELETE).toHaveBeenCalledWith("/api/v1/users/{userId}/roles/{roleId}", {
+      params: { path: { userId: "u1", roleId: "r1" } },
+      headers: { "If-Match": "*" },
+    });
+  });
+});

--- a/frontend/src/api/admin/__tests__/sso.test.ts
+++ b/frontend/src/api/admin/__tests__/sso.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listSsoProviders, readSafeModeStatus, updateSafeModeStatus } from "../sso";
+import { client } from "@/api/client";
+
+vi.mock("@/api/client", () => ({
+  client: {
+    GET: vi.fn(),
+    PUT: vi.fn(),
+  },
+}));
+
+describe("admin sso api", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists SSO providers", async () => {
+    (client.GET as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { items: [] } });
+    await listSsoProviders();
+    expect(client.GET).toHaveBeenCalledWith("/api/v1/admin/sso/providers", { signal: undefined });
+  });
+
+  it("updates and rereads safe mode", async () => {
+    (client.PUT as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null });
+    (client.GET as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { enabled: true, detail: "Maint" } });
+
+    const updated = await updateSafeModeStatus({ enabled: true, detail: "Maint" });
+    expect(client.PUT).toHaveBeenCalledWith("/api/v1/system/safemode", {
+      body: { enabled: true, detail: "Maint" },
+    });
+    expect(updated).toEqual({ enabled: true, detail: "Maint" });
+
+    await readSafeModeStatus();
+    expect(client.GET).toHaveBeenCalledWith("/api/v1/system/safemode", { signal: undefined });
+  });
+});

--- a/frontend/src/api/admin/__tests__/users.test.ts
+++ b/frontend/src/api/admin/__tests__/users.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAdminUser, listAdminUsers, updateAdminUser } from "../users";
+import { client } from "@/api/client";
+
+vi.mock("@/api/client", () => ({
+  client: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PATCH: vi.fn(),
+  },
+}));
+
+describe("admin users api", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists users with listing query", async () => {
+    (client.GET as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { items: [], meta: { limit: 50, hasMore: false, nextCursor: null, totalIncluded: true, totalCount: 0, changesCursor: "0" }, facets: null },
+    });
+
+    await listAdminUsers({ limit: 50, search: "alice", includeTotal: true });
+
+    expect(client.GET).toHaveBeenCalledWith("/api/v1/users", {
+      params: { query: { limit: 50, q: "alice", includeTotal: true } },
+      signal: undefined,
+    });
+  });
+
+  it("creates and updates users", async () => {
+    (client.POST as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { id: "u1" } });
+    (client.PATCH as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { id: "u1" } });
+
+    await createAdminUser({ email: "u@example.com", display_name: "User" });
+    expect(client.POST).toHaveBeenCalledWith("/api/v1/users", {
+      body: { email: "u@example.com", display_name: "User" },
+    });
+
+    await updateAdminUser("u1", { display_name: "Updated" });
+    expect(client.PATCH).toHaveBeenCalledWith("/api/v1/users/{userId}", {
+      params: { path: { userId: "u1" } },
+      body: { display_name: "Updated" },
+    });
+  });
+});

--- a/frontend/src/api/admin/api-keys.ts
+++ b/frontend/src/api/admin/api-keys.ts
@@ -1,0 +1,89 @@
+import { buildListQuery, type FilterItem } from "@/api/listing";
+import { client } from "@/api/client";
+import type { ApiKeyCreateRequest, ApiKeyCreateResponse, ApiKeyPage } from "@/types";
+
+export interface AdminApiKeyListOptions {
+  readonly limit?: number;
+  readonly cursor?: string | null;
+  readonly includeRevoked?: boolean;
+  readonly sort?: string | null;
+  readonly q?: string | null;
+  readonly includeTotal?: boolean;
+  readonly userId?: string | null;
+  readonly signal?: AbortSignal;
+}
+
+function buildApiKeyListQuery(options: AdminApiKeyListOptions) {
+  const filters: FilterItem[] = [];
+  if (!options.includeRevoked) {
+    filters.push({ id: "revokedAt", operator: "isEmpty" });
+  }
+
+  return buildListQuery({
+    limit: options.limit,
+    cursor: options.cursor ?? null,
+    sort: options.sort ?? null,
+    q: options.q ?? null,
+    filters,
+    includeTotal: options.includeTotal,
+  });
+}
+
+export async function listTenantApiKeys(options: AdminApiKeyListOptions = {}): Promise<ApiKeyPage> {
+  const query = buildApiKeyListQuery(options);
+  const paramsQuery = options.userId ? { ...query, userId: options.userId } : query;
+
+  const { data } = await client.GET("/api/v1/apikeys", {
+    params: { query: paramsQuery },
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected API key page payload.");
+  }
+
+  return data;
+}
+
+export async function listAdminUserApiKeys(userId: string, options: AdminApiKeyListOptions = {}): Promise<ApiKeyPage> {
+  const query = buildApiKeyListQuery(options);
+  const { data } = await client.GET("/api/v1/users/{userId}/apikeys", {
+    params: { path: { userId }, query },
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected API key page payload.");
+  }
+
+  return data;
+}
+
+export async function createAdminUserApiKey(
+  userId: string,
+  payload: ApiKeyCreateRequest,
+): Promise<ApiKeyCreateResponse> {
+  const { data } = await client.POST("/api/v1/users/{userId}/apikeys", {
+    params: { path: { userId } },
+    body: payload,
+  });
+
+  if (!data) {
+    throw new Error("Expected API key creation payload.");
+  }
+
+  return data;
+}
+
+export async function revokeAdminUserApiKey(
+  userId: string,
+  apiKeyId: string,
+  options: { ifMatch?: string | null } = {},
+): Promise<void> {
+  await client.DELETE("/api/v1/users/{userId}/apikeys/{apiKeyId}", {
+    params: {
+      path: { userId, apiKeyId },
+      header: { "If-Match": options.ifMatch ?? "*" },
+    },
+  });
+}

--- a/frontend/src/api/admin/roles.ts
+++ b/frontend/src/api/admin/roles.ts
@@ -1,0 +1,156 @@
+import { buildListQuery, type FilterItem } from "@/api/listing";
+import { client } from "@/api/client";
+import type { components } from "@/types";
+
+export type AdminRole = components["schemas"]["RoleOut"];
+export type AdminRolePage = components["schemas"]["RolePage"];
+export type AdminRoleCreateRequest = components["schemas"]["RoleCreate"];
+export type AdminRoleUpdateRequest = components["schemas"]["RoleUpdate"];
+export type AdminPermissionPage = components["schemas"]["PermissionPage"];
+export type AdminPermission = components["schemas"]["PermissionOut"];
+export type AdminUserRoles = components["schemas"]["UserRolesEnvelope"];
+
+export interface ListAdminRolesOptions {
+  readonly limit?: number;
+  readonly cursor?: string | null;
+  readonly q?: string | null;
+  readonly sort?: string | null;
+  readonly includeTotal?: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export async function listAdminRoles(options: ListAdminRolesOptions = {}): Promise<AdminRolePage> {
+  const filters: FilterItem[] = [{ id: "scopeType", operator: "eq", value: "global" }];
+  const query = buildListQuery({
+    limit: options.limit,
+    cursor: options.cursor ?? null,
+    sort: options.sort ?? null,
+    q: options.q ?? null,
+    filters,
+    includeTotal: options.includeTotal,
+  });
+
+  const { data } = await client.GET("/api/v1/roles", {
+    params: { query },
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected role page payload.");
+  }
+
+  return data;
+}
+
+export async function createAdminRole(payload: AdminRoleCreateRequest): Promise<AdminRole> {
+  const rolePayload: AdminRoleCreateRequest = {
+    ...payload,
+    scope_type: "global",
+  };
+  const { data } = await client.POST("/api/v1/roles", {
+    body: rolePayload,
+  });
+
+  if (!data) {
+    throw new Error("Expected role payload.");
+  }
+
+  return data;
+}
+
+export async function updateAdminRole(
+  roleId: string,
+  payload: AdminRoleUpdateRequest,
+  options: { ifMatch?: string | null } = {},
+): Promise<AdminRole> {
+  const { data } = await client.PATCH("/api/v1/roles/{roleId}", {
+    params: { path: { roleId } },
+    body: payload,
+    headers: options.ifMatch ? { "If-Match": options.ifMatch } : undefined,
+  });
+
+  if (!data) {
+    throw new Error("Expected role payload.");
+  }
+
+  return data;
+}
+
+export async function deleteAdminRole(roleId: string, options: { ifMatch?: string | null } = {}): Promise<void> {
+  await client.DELETE("/api/v1/roles/{roleId}", {
+    params: { path: { roleId } },
+    headers: { "If-Match": options.ifMatch ?? "*" },
+  });
+}
+
+export interface ListAdminPermissionsOptions {
+  readonly scope?: "global" | "workspace";
+  readonly limit?: number;
+  readonly cursor?: string | null;
+  readonly q?: string | null;
+  readonly sort?: string | null;
+  readonly includeTotal?: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export async function listAdminPermissions(
+  options: ListAdminPermissionsOptions = {},
+): Promise<AdminPermissionPage> {
+  const scope = options.scope ?? "global";
+  const filters: FilterItem[] = [{ id: "scopeType", operator: "eq", value: scope }];
+  const query = buildListQuery({
+    limit: options.limit,
+    cursor: options.cursor ?? null,
+    sort: options.sort ?? null,
+    q: options.q ?? null,
+    filters,
+    includeTotal: options.includeTotal,
+  });
+
+  const { data } = await client.GET("/api/v1/permissions", {
+    params: { query },
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected permission page payload.");
+  }
+
+  return data;
+}
+
+export async function listAdminUserRoles(userId: string, options: { signal?: AbortSignal } = {}): Promise<AdminUserRoles> {
+  const { data } = await client.GET("/api/v1/users/{userId}/roles", {
+    params: { path: { userId } },
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected user roles payload.");
+  }
+
+  return data;
+}
+
+export async function assignAdminUserRole(userId: string, roleId: string): Promise<AdminUserRoles> {
+  const { data } = await client.PUT("/api/v1/users/{userId}/roles/{roleId}", {
+    params: { path: { userId, roleId } },
+  });
+
+  if (!data) {
+    throw new Error("Expected user roles payload.");
+  }
+
+  return data;
+}
+
+export async function removeAdminUserRole(
+  userId: string,
+  roleId: string,
+  options: { ifMatch?: string | null } = {},
+): Promise<void> {
+  await client.DELETE("/api/v1/users/{userId}/roles/{roleId}", {
+    params: { path: { userId, roleId } },
+    headers: { "If-Match": options.ifMatch ?? "*" },
+  });
+}

--- a/frontend/src/api/admin/sso.ts
+++ b/frontend/src/api/admin/sso.ts
@@ -1,0 +1,96 @@
+import { client } from "@/api/client";
+import type { components } from "@/types";
+
+export type SsoProviderAdmin = components["schemas"]["SsoProviderAdminOut"];
+export type SsoProviderListResponse = components["schemas"]["SsoProviderListResponse"];
+export type SsoProviderCreateRequest = components["schemas"]["SsoProviderCreate"];
+export type SsoProviderUpdateRequest = components["schemas"]["SsoProviderUpdate"];
+export type SsoSettings = components["schemas"]["SsoSettings"];
+export type SafeModeStatus = components["schemas"]["SafeModeStatus"];
+export type SafeModeUpdateRequest = components["schemas"]["SafeModeUpdateRequest"];
+
+export async function listSsoProviders(options: { signal?: AbortSignal } = {}): Promise<SsoProviderListResponse> {
+  const { data } = await client.GET("/api/v1/admin/sso/providers", {
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected SSO provider list payload.");
+  }
+
+  return data;
+}
+
+export async function createSsoProvider(payload: SsoProviderCreateRequest): Promise<SsoProviderAdmin> {
+  const { data } = await client.POST("/api/v1/admin/sso/providers", {
+    body: payload,
+  });
+
+  if (!data) {
+    throw new Error("Expected SSO provider payload.");
+  }
+
+  return data;
+}
+
+export async function updateSsoProvider(id: string, payload: SsoProviderUpdateRequest): Promise<SsoProviderAdmin> {
+  const { data } = await client.PATCH("/api/v1/admin/sso/providers/{id}", {
+    params: { path: { id } },
+    body: payload,
+  });
+
+  if (!data) {
+    throw new Error("Expected SSO provider payload.");
+  }
+
+  return data;
+}
+
+export async function deleteSsoProvider(id: string): Promise<void> {
+  await client.DELETE("/api/v1/admin/sso/providers/{id}", {
+    params: { path: { id } },
+  });
+}
+
+export async function readSsoSettings(options: { signal?: AbortSignal } = {}): Promise<SsoSettings> {
+  const { data } = await client.GET("/api/v1/admin/sso/settings", {
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected SSO settings payload.");
+  }
+
+  return data;
+}
+
+export async function updateSsoSettings(payload: SsoSettings): Promise<SsoSettings> {
+  const { data } = await client.PUT("/api/v1/admin/sso/settings", {
+    body: payload,
+  });
+
+  if (!data) {
+    throw new Error("Expected SSO settings payload.");
+  }
+
+  return data;
+}
+
+export async function readSafeModeStatus(options: { signal?: AbortSignal } = {}): Promise<SafeModeStatus> {
+  const { data } = await client.GET("/api/v1/system/safemode", {
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected safe mode payload.");
+  }
+
+  return data;
+}
+
+export async function updateSafeModeStatus(payload: SafeModeUpdateRequest): Promise<SafeModeStatus> {
+  await client.PUT("/api/v1/system/safemode", {
+    body: payload,
+  });
+  return readSafeModeStatus();
+}

--- a/frontend/src/api/admin/users.ts
+++ b/frontend/src/api/admin/users.ts
@@ -1,0 +1,88 @@
+import { client } from "@/api/client";
+import { buildListQuery } from "@/api/listing";
+import type { components } from "@/types";
+
+export type AdminUser = components["schemas"]["UserOut"];
+export type AdminUserPage = components["schemas"]["UserPage"];
+export type AdminUserCreateRequest = components["schemas"]["UserCreate"];
+export type AdminUserUpdateRequest = components["schemas"]["UserUpdate"];
+
+export interface ListAdminUsersOptions {
+  readonly limit?: number;
+  readonly cursor?: string | null;
+  readonly search?: string;
+  readonly sort?: string;
+  readonly includeTotal?: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export async function listAdminUsers(options: ListAdminUsersOptions = {}): Promise<AdminUserPage> {
+  const query = buildListQuery({
+    limit: options.limit,
+    cursor: options.cursor ?? null,
+    sort: options.sort ?? null,
+    q: options.search?.trim() || null,
+    includeTotal: options.includeTotal,
+  });
+
+  const { data } = await client.GET("/api/v1/users", {
+    params: { query },
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected user page payload.");
+  }
+
+  return data;
+}
+
+export async function createAdminUser(payload: AdminUserCreateRequest): Promise<AdminUser> {
+  const { data } = await client.POST("/api/v1/users", {
+    body: payload,
+  });
+
+  if (!data) {
+    throw new Error("Expected user payload.");
+  }
+
+  return data;
+}
+
+export async function getAdminUser(userId: string, options: { signal?: AbortSignal } = {}): Promise<AdminUser> {
+  const { data } = await client.GET("/api/v1/users/{userId}", {
+    params: { path: { userId } },
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected user payload.");
+  }
+
+  return data;
+}
+
+export async function updateAdminUser(userId: string, payload: AdminUserUpdateRequest): Promise<AdminUser> {
+  const { data } = await client.PATCH("/api/v1/users/{userId}", {
+    params: { path: { userId } },
+    body: payload,
+  });
+
+  if (!data) {
+    throw new Error("Expected user payload.");
+  }
+
+  return data;
+}
+
+export async function deactivateAdminUser(userId: string): Promise<AdminUser> {
+  const { data } = await client.POST("/api/v1/users/{userId}/deactivate", {
+    params: { path: { userId } },
+  });
+
+  if (!data) {
+    throw new Error("Expected user payload.");
+  }
+
+  return data;
+}

--- a/frontend/src/api/uiErrors.ts
+++ b/frontend/src/api/uiErrors.ts
@@ -1,0 +1,56 @@
+import { ApiError, type ProblemDetailsErrorMap, groupProblemDetailsErrors } from "@/api/errors";
+
+type UiStatusMessageMap = Partial<Record<number, string>>;
+
+export interface UiErrorResult {
+  readonly message: string;
+  readonly status?: number;
+  readonly fieldErrors: ProblemDetailsErrorMap;
+}
+
+const DEFAULT_STATUS_MESSAGES: Record<number, string> = {
+  400: "The request is invalid. Review your inputs and try again.",
+  401: "Your session has expired. Sign in again and retry.",
+  403: "You do not have permission to perform this action.",
+  409: "This record was changed by another user. Refresh and retry.",
+  412: "This record changed while you were editing. Refresh and try again.",
+  422: "One or more fields are invalid. Correct them and retry.",
+};
+
+const ETAG_MISMATCH_PATTERN = /etag mismatch/i;
+
+export function mapUiError(
+  error: unknown,
+  options: {
+    readonly fallback: string;
+    readonly statusMessages?: UiStatusMessageMap;
+  },
+): UiErrorResult {
+  const fallback = options.fallback;
+  const statusMessages = { ...DEFAULT_STATUS_MESSAGES, ...(options.statusMessages ?? {}) };
+  if (!(error instanceof ApiError)) {
+    if (error instanceof Error && error.message.trim().length > 0) {
+      return { message: error.message, fieldErrors: {} };
+    }
+    return { message: fallback, fieldErrors: {} };
+  }
+
+  const status = error.status;
+  const fieldErrors = groupProblemDetailsErrors(error.problem?.errors);
+  const defaultStatusMessage = statusMessages[status];
+  const rawMessage = error.message?.trim() || "";
+
+  if (!rawMessage || ETAG_MISMATCH_PATTERN.test(rawMessage)) {
+    return {
+      message: defaultStatusMessage ?? fallback,
+      status,
+      fieldErrors,
+    };
+  }
+
+  return {
+    message: rawMessage,
+    status,
+    fieldErrors,
+  };
+}

--- a/frontend/src/app/layouts/components/topbar/TopbarControls.tsx
+++ b/frontend/src/app/layouts/components/topbar/TopbarControls.tsx
@@ -1,16 +1,44 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { AppearanceMenu } from "@/app/layouts/components/topbar/actions/AppearanceMenu";
 import { AboutVersionsModal } from "@/app/layouts/components/topbar/actions/AboutVersionsModal";
 import { ProfileDropdown } from "@/app/layouts/components/topbar/actions/ProfileDropdown";
 import { openReleaseNotes } from "@/config/release-notes";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
 import { useSession } from "@/providers/auth/SessionContext";
 
 export function TopbarControls() {
   const session = useSession();
+  const navigate = useNavigate();
+  const { canAccessOrganizationSettings } = useGlobalPermissions();
   const [isVersionsModalOpen, setIsVersionsModalOpen] = useState(false);
   const displayName = session.user.display_name || session.user.email || "Signed in";
   const email = session.user.email ?? "";
+  const actions = [
+    ...(canAccessOrganizationSettings
+      ? [
+          {
+            id: "organization-settings",
+            label: "Organization Settings",
+            description: "Users, roles, API keys, and system controls",
+            onSelect: () => navigate("/organization/settings"),
+          },
+        ]
+      : []),
+    {
+      id: "release-notes",
+      label: "Release notes",
+      description: "GitHub releases + changelog",
+      onSelect: openReleaseNotes,
+    },
+    {
+      id: "about-versions",
+      label: "About / Versions",
+      description: "ade-web, ade-api, ade-engine",
+      onSelect: () => setIsVersionsModalOpen(true),
+    },
+  ];
 
   return (
     <>
@@ -21,20 +49,7 @@ export function TopbarControls() {
           displayName={displayName}
           email={email}
           tone="header"
-          actions={[
-            {
-              id: "release-notes",
-              label: "Release notes",
-              description: "GitHub releases + changelog",
-              onSelect: openReleaseNotes,
-            },
-            {
-              id: "about-versions",
-              label: "About / Versions",
-              description: "ade-web, ade-api, ade-engine",
-              onSelect: () => setIsVersionsModalOpen(true),
-            },
-          ]}
+          actions={actions}
         />
       </div>
     </>

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -10,6 +10,7 @@ const HomeScreen = lazy(() => import("@/pages/Home"));
 const LoginScreen = lazy(() => import("@/pages/Login"));
 const LogoutScreen = lazy(() => import("@/pages/Logout"));
 const NotFoundScreen = lazy(() => import("@/pages/NotFound"));
+const OrganizationSettingsScreen = lazy(() => import("@/pages/OrganizationSettings"));
 const SetupScreen = lazy(() => import("@/pages/Setup"));
 const WorkspaceScreen = lazy(() => import("@/pages/Workspace"));
 const WorkspaceCreateScreen = lazy(() => import("@/pages/Workspaces/New"));
@@ -44,6 +45,7 @@ export const appRoutes: RouteObject[] = [
             element: <AuthenticatedLayout />,
             children: [
               { index: true, element: withRouteSuspense(<HomeScreen />) },
+              { path: "organization/settings/*", element: withRouteSuspense(<OrganizationSettingsScreen />) },
               { path: "workspaces", element: withRouteSuspense(<WorkspacesScreen />) },
               { path: "workspaces/new", element: withRouteSuspense(<WorkspaceCreateScreen />) },
               { path: "*", element: withRouteSuspense(<NotFoundScreen />) },

--- a/frontend/src/hooks/admin/index.ts
+++ b/frontend/src/hooks/admin/index.ts
@@ -1,0 +1,5 @@
+export * from "./keys";
+export * from "./useAdminUsers";
+export * from "./useAdminRoles";
+export * from "./useAdminApiKeys";
+export * from "./useAdminSystem";

--- a/frontend/src/hooks/admin/keys.ts
+++ b/frontend/src/hooks/admin/keys.ts
@@ -1,0 +1,17 @@
+export const adminKeys = {
+  all: () => ["admin"] as const,
+  users: () => [...adminKeys.all(), "users"] as const,
+  usersList: (params: Record<string, unknown> = {}) => [...adminKeys.users(), "list", params] as const,
+  user: (userId: string) => [...adminKeys.users(), "detail", userId] as const,
+  roles: () => [...adminKeys.all(), "roles"] as const,
+  rolesList: (params: Record<string, unknown> = {}) => [...adminKeys.roles(), "list", params] as const,
+  permissions: (scope: "global" | "workspace") => [...adminKeys.roles(), "permissions", scope] as const,
+  userRoles: (userId: string) => [...adminKeys.roles(), "user-roles", userId] as const,
+  apiKeys: () => [...adminKeys.all(), "api-keys"] as const,
+  apiKeysList: (params: Record<string, unknown> = {}) => [...adminKeys.apiKeys(), "list", params] as const,
+  userApiKeys: (userId: string) => [...adminKeys.apiKeys(), "user", userId] as const,
+  sso: () => [...adminKeys.all(), "sso"] as const,
+  ssoProviders: () => [...adminKeys.sso(), "providers"] as const,
+  ssoSettings: () => [...adminKeys.sso(), "settings"] as const,
+  safeMode: () => [...adminKeys.all(), "safe-mode"] as const,
+};

--- a/frontend/src/hooks/admin/useAdminApiKeys.ts
+++ b/frontend/src/hooks/admin/useAdminApiKeys.ts
@@ -1,0 +1,101 @@
+import { useCallback } from "react";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useFlattenedPages } from "@/api/pagination";
+import {
+  createAdminUserApiKey,
+  listAdminUserApiKeys,
+  listTenantApiKeys,
+  revokeAdminUserApiKey,
+  type AdminApiKeyListOptions,
+} from "@/api/admin/api-keys";
+import type { ApiKeyCreateRequest, ApiKeyCreateResponse, ApiKeyPage, ApiKeySummary } from "@/types";
+import { adminKeys } from "@/hooks/admin/keys";
+
+export interface UseTenantApiKeysQueryOptions {
+  readonly enabled?: boolean;
+  readonly pageSize?: number;
+  readonly search?: string;
+  readonly includeRevoked?: boolean;
+  readonly userId?: string | null;
+}
+
+export function useTenantApiKeysQuery(options: UseTenantApiKeysQueryOptions = {}) {
+  const {
+    enabled = true,
+    pageSize,
+    search = "",
+    includeRevoked = false,
+    userId = null,
+  } = options;
+
+  const trimmedSearch = search.trim();
+  const effectiveSearch = trimmedSearch.length >= 2 ? trimmedSearch : "";
+
+  const query = useInfiniteQuery<ApiKeyPage, Error>({
+    queryKey: adminKeys.apiKeysList({ pageSize, search: trimmedSearch, includeRevoked, userId }),
+    initialPageParam: null,
+    queryFn: ({ pageParam, signal }) =>
+      listTenantApiKeys({
+        limit: pageSize,
+        cursor: typeof pageParam === "string" ? pageParam : null,
+        q: effectiveSearch || null,
+        includeRevoked,
+        includeTotal: true,
+        userId,
+        signal,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.meta.hasMore ? lastPage.meta.nextCursor ?? undefined : undefined,
+    enabled,
+    staleTime: 15_000,
+    placeholderData: (previous) => previous,
+  });
+
+  const getApiKeyId = useCallback((item: ApiKeySummary) => item.id, []);
+  const apiKeys = useFlattenedPages(query.data?.pages, getApiKeyId);
+  const total = query.data?.pages?.[0]?.meta.totalCount ?? apiKeys.length;
+
+  return {
+    ...query,
+    apiKeys,
+    total,
+  };
+}
+
+export function useAdminUserApiKeysQuery(userId: string | null | undefined, options: AdminApiKeyListOptions = {}) {
+  return useQuery<ApiKeyPage>({
+    queryKey: adminKeys.userApiKeys(userId ?? ""),
+    queryFn: ({ signal }) =>
+      listAdminUserApiKeys(userId ?? "", {
+        ...options,
+        includeTotal: true,
+        signal,
+      }),
+    enabled: Boolean(userId),
+    staleTime: 10_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+export function useCreateAdminUserApiKeyMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<ApiKeyCreateResponse, Error, { userId: string; payload: ApiKeyCreateRequest }>({
+    mutationFn: ({ userId, payload }) => createAdminUserApiKey(userId, payload),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.userApiKeys(vars.userId) });
+      queryClient.invalidateQueries({ queryKey: adminKeys.apiKeys() });
+    },
+  });
+}
+
+export function useRevokeAdminUserApiKeyMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, { userId: string; apiKeyId: string; ifMatch?: string | null }>({
+    mutationFn: ({ userId, apiKeyId, ifMatch }) => revokeAdminUserApiKey(userId, apiKeyId, { ifMatch }),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.userApiKeys(vars.userId) });
+      queryClient.invalidateQueries({ queryKey: adminKeys.apiKeys() });
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useAdminRoles.ts
+++ b/frontend/src/hooks/admin/useAdminRoles.ts
@@ -1,0 +1,121 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { collectAllPages, MAX_PAGE_SIZE } from "@/api/pagination";
+import {
+  assignAdminUserRole,
+  createAdminRole,
+  deleteAdminRole,
+  listAdminPermissions,
+  listAdminRoles,
+  listAdminUserRoles,
+  removeAdminUserRole,
+  updateAdminRole,
+  type AdminPermissionPage,
+  type AdminRole,
+  type AdminRoleCreateRequest,
+  type AdminRolePage,
+  type AdminRoleUpdateRequest,
+  type AdminUserRoles,
+} from "@/api/admin/roles";
+import { adminKeys } from "@/hooks/admin/keys";
+
+const ROLE_PAGE_SIZE = MAX_PAGE_SIZE;
+const PERMISSION_PAGE_SIZE = MAX_PAGE_SIZE;
+
+export function useAdminRolesQuery(scope: "global" | "workspace" = "global") {
+  return useQuery<AdminRolePage>({
+    queryKey: adminKeys.rolesList({ scope, limit: ROLE_PAGE_SIZE }),
+    queryFn: ({ signal }) =>
+      collectAllPages((cursor) =>
+        listAdminRoles({
+          limit: ROLE_PAGE_SIZE,
+          cursor,
+          includeTotal: true,
+          signal,
+        }),
+      ),
+    staleTime: 30_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+export function useAdminPermissionsQuery(scope: "global" | "workspace" = "global") {
+  return useQuery<AdminPermissionPage>({
+    queryKey: adminKeys.permissions(scope),
+    queryFn: ({ signal }) =>
+      collectAllPages((cursor) =>
+        listAdminPermissions({
+          scope,
+          limit: PERMISSION_PAGE_SIZE,
+          cursor,
+          includeTotal: true,
+          signal,
+        }),
+      ),
+    staleTime: 60_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+export function useAdminUserRolesQuery(userId: string | null | undefined) {
+  return useQuery<AdminUserRoles>({
+    queryKey: adminKeys.userRoles(userId ?? ""),
+    queryFn: ({ signal }) => listAdminUserRoles(userId ?? "", { signal }),
+    enabled: Boolean(userId),
+    staleTime: 15_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+export function useCreateAdminRoleMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<AdminRole, Error, AdminRoleCreateRequest>({
+    mutationFn: (payload) => createAdminRole(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.roles() });
+    },
+  });
+}
+
+export function useUpdateAdminRoleMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<AdminRole, Error, { roleId: string; payload: AdminRoleUpdateRequest; ifMatch?: string | null }>({
+    mutationFn: ({ roleId, payload, ifMatch }) => updateAdminRole(roleId, payload, { ifMatch }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.roles() });
+    },
+  });
+}
+
+export function useDeleteAdminRoleMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, { roleId: string; ifMatch?: string | null }>({
+    mutationFn: ({ roleId, ifMatch }) => deleteAdminRole(roleId, { ifMatch }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.roles() });
+      queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+    },
+  });
+}
+
+export function useAssignAdminUserRoleMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<AdminUserRoles, Error, { userId: string; roleId: string }>({
+    mutationFn: ({ userId, roleId }) => assignAdminUserRole(userId, roleId),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.userRoles(vars.userId) });
+      queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+    },
+  });
+}
+
+export function useRemoveAdminUserRoleMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, { userId: string; roleId: string }>({
+    mutationFn: ({ userId, roleId }) => removeAdminUserRole(userId, roleId, { ifMatch: "*" }),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.userRoles(vars.userId) });
+      queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useAdminSystem.ts
+++ b/frontend/src/hooks/admin/useAdminSystem.ts
@@ -1,0 +1,100 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createSsoProvider,
+  deleteSsoProvider,
+  listSsoProviders,
+  readSafeModeStatus,
+  readSsoSettings,
+  updateSafeModeStatus,
+  updateSsoProvider,
+  updateSsoSettings,
+  type SafeModeStatus,
+  type SafeModeUpdateRequest,
+  type SsoProviderAdmin,
+  type SsoProviderCreateRequest,
+  type SsoProviderListResponse,
+  type SsoProviderUpdateRequest,
+  type SsoSettings,
+} from "@/api/admin/sso";
+import { adminKeys } from "@/hooks/admin/keys";
+
+export function useSsoProvidersQuery(options: { enabled?: boolean } = {}) {
+  return useQuery<SsoProviderListResponse>({
+    queryKey: adminKeys.ssoProviders(),
+    queryFn: ({ signal }) => listSsoProviders({ signal }),
+    enabled: options.enabled ?? true,
+    staleTime: 30_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+export function useSsoSettingsQuery(options: { enabled?: boolean } = {}) {
+  return useQuery<SsoSettings>({
+    queryKey: adminKeys.ssoSettings(),
+    queryFn: ({ signal }) => readSsoSettings({ signal }),
+    enabled: options.enabled ?? true,
+    staleTime: 30_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+export function useSafeModeQuery(options: { enabled?: boolean } = {}) {
+  return useQuery<SafeModeStatus>({
+    queryKey: adminKeys.safeMode(),
+    queryFn: ({ signal }) => readSafeModeStatus({ signal }),
+    enabled: options.enabled ?? true,
+    staleTime: 10_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+export function useCreateSsoProviderMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<SsoProviderAdmin, Error, SsoProviderCreateRequest>({
+    mutationFn: (payload) => createSsoProvider(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.ssoProviders() });
+    },
+  });
+}
+
+export function useUpdateSsoProviderMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<SsoProviderAdmin, Error, { id: string; payload: SsoProviderUpdateRequest }>({
+    mutationFn: ({ id, payload }) => updateSsoProvider(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.ssoProviders() });
+    },
+  });
+}
+
+export function useDeleteSsoProviderMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (id) => deleteSsoProvider(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.ssoProviders() });
+    },
+  });
+}
+
+export function useUpdateSsoSettingsMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<SsoSettings, Error, SsoSettings>({
+    mutationFn: (payload) => updateSsoSettings(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.ssoSettings() });
+    },
+  });
+}
+
+export function useUpdateSafeModeMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<SafeModeStatus, Error, SafeModeUpdateRequest>({
+    mutationFn: (payload) => updateSafeModeStatus(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.safeMode() });
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUsers.ts
+++ b/frontend/src/hooks/admin/useAdminUsers.ts
@@ -1,0 +1,92 @@
+import { useCallback } from "react";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { useFlattenedPages } from "@/api/pagination";
+import {
+  createAdminUser,
+  deactivateAdminUser,
+  listAdminUsers,
+  updateAdminUser,
+  type AdminUser,
+  type AdminUserCreateRequest,
+  type AdminUserPage,
+  type AdminUserUpdateRequest,
+} from "@/api/admin/users";
+import { adminKeys } from "@/hooks/admin/keys";
+
+export interface UseAdminUsersQueryOptions {
+  readonly enabled?: boolean;
+  readonly search?: string;
+  readonly pageSize?: number;
+}
+
+export function useAdminUsersQuery(options: UseAdminUsersQueryOptions = {}) {
+  const {
+    enabled = true,
+    search = "",
+    pageSize,
+  } = options;
+
+  const trimmedSearch = search.trim();
+  const effectiveSearch = trimmedSearch.length >= 2 ? trimmedSearch : "";
+
+  const query = useInfiniteQuery<AdminUserPage, Error>({
+    queryKey: adminKeys.usersList({ search: trimmedSearch, pageSize }),
+    initialPageParam: null,
+    queryFn: ({ pageParam, signal }) =>
+      listAdminUsers({
+        limit: pageSize,
+        cursor: typeof pageParam === "string" ? pageParam : null,
+        search: effectiveSearch || undefined,
+        includeTotal: true,
+        signal,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.meta.hasMore ? lastPage.meta.nextCursor ?? undefined : undefined,
+    enabled,
+    staleTime: 15_000,
+    placeholderData: (previous) => previous,
+  });
+
+  const getUserKey = useCallback((user: AdminUser) => user.id, []);
+  const users = useFlattenedPages(query.data?.pages, getUserKey);
+  const total = query.data?.pages?.[0]?.meta.totalCount ?? users.length;
+
+  return {
+    ...query,
+    users,
+    total,
+  };
+}
+
+export function useCreateAdminUserMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<AdminUser, Error, AdminUserCreateRequest>({
+    mutationFn: (payload) => createAdminUser(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+    },
+  });
+}
+
+export function useUpdateAdminUserMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<AdminUser, Error, { userId: string; payload: AdminUserUpdateRequest }>({
+    mutationFn: ({ userId, payload }) => updateAdminUser(userId, payload),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.user(vars.userId) });
+      queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+    },
+  });
+}
+
+export function useDeactivateAdminUserMutation() {
+  const queryClient = useQueryClient();
+  return useMutation<AdminUser, Error, string>({
+    mutationFn: (userId) => deactivateAdminUser(userId),
+    onSuccess: (_data, userId) => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.user(userId) });
+      queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+    },
+  });
+}

--- a/frontend/src/hooks/auth/useGlobalPermissions.ts
+++ b/frontend/src/hooks/auth/useGlobalPermissions.ts
@@ -1,0 +1,47 @@
+import { useCallback, useMemo } from "react";
+
+import { useSession } from "@/providers/auth/SessionContext";
+
+export const ORG_SETTINGS_PERMISSIONS = [
+  "users.read_all",
+  "users.manage_all",
+  "roles.read_all",
+  "roles.manage_all",
+  "api_keys.read_all",
+  "api_keys.manage_all",
+  "system.settings.read",
+  "system.settings.manage",
+] as const;
+
+export function useGlobalPermissions() {
+  const session = useSession();
+
+  const permissionSet = useMemo(() => {
+    const values = [
+      ...(session.permissions ?? []),
+      ...(session.user.permissions ?? []),
+    ]
+      .map((permission) => permission.trim().toLowerCase())
+      .filter(Boolean);
+    return new Set(values);
+  }, [session.permissions, session.user.permissions]);
+
+  const hasPermission = useCallback(
+    (permission: string) => permissionSet.has(permission.toLowerCase()),
+    [permissionSet],
+  );
+
+  const hasAnyPermission = useCallback(
+    (permissions: readonly string[]) => permissions.some((permission) => hasPermission(permission)),
+    [hasPermission],
+  );
+
+  const canAccessOrganizationSettings = hasAnyPermission(ORG_SETTINGS_PERMISSIONS);
+
+  return {
+    permissions: permissionSet,
+    hasPermission,
+    hasAnyPermission,
+    canAccessOrganizationSettings,
+  };
+}

--- a/frontend/src/pages/OrganizationSettings/__tests__/apiKeysSettingsPage.test.ts
+++ b/frontend/src/pages/OrganizationSettings/__tests__/apiKeysSettingsPage.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidUuidFilter } from "../pages/ApiKeysSettingsPage";
+
+describe("isValidUuidFilter", () => {
+  it("accepts canonical UUID values", () => {
+    expect(isValidUuidFilter("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+  });
+
+  it("rejects invalid UUID values", () => {
+    expect(isValidUuidFilter("not-a-uuid")).toBe(false);
+    expect(isValidUuidFilter("550e8400e29b41d4a716446655440000")).toBe(false);
+  });
+});

--- a/frontend/src/pages/OrganizationSettings/__tests__/settingsNav.test.tsx
+++ b/frontend/src/pages/OrganizationSettings/__tests__/settingsNav.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildOrganizationSettingsNav,
+  defaultOrganizationSettingsSection,
+  getDefaultOrganizationSettingsSection,
+  getOrganizationSectionAccessState,
+  organizationSettingsSections,
+  resolveOrganizationSectionByPath,
+} from "../settingsNav";
+
+describe("organization settings nav", () => {
+  it("builds grouped navigation links for each section", () => {
+    const navGroups = buildOrganizationSettingsNav(() => true);
+    const links = navGroups.flatMap((group) => group.items.map((item) => item.href));
+
+    expect(links).toEqual([
+      "/organization/settings/users",
+      "/organization/settings/roles",
+      "/organization/settings/api-keys",
+      "/organization/settings/system/sso",
+      "/organization/settings/system/safe-mode",
+    ]);
+    expect(defaultOrganizationSettingsSection.path).toBe("users");
+  });
+
+  it("hides sections when the user has no matching permissions", () => {
+    const hasPermission = vi.fn().mockReturnValue(false);
+    const nav = buildOrganizationSettingsNav(hasPermission);
+    expect(nav).toEqual([]);
+    expect(hasPermission).toHaveBeenCalled();
+  });
+
+  it("resolves nested paths for deep links", () => {
+    const section = resolveOrganizationSectionByPath(["users", "abc-123"]);
+    expect(section?.id).toBe("identity.users");
+  });
+
+  it("returns the first allowed section as default", () => {
+    const section = getDefaultOrganizationSettingsSection((permission) => permission === "api_keys.read_all");
+    expect(section.id).toBe("security.apiKeys");
+  });
+
+  it("derives section view/edit access from permission sets", () => {
+    const usersSection = organizationSettingsSections.find((section) => section.id === "identity.users");
+    expect(usersSection).toBeDefined();
+    if (!usersSection) {
+      return;
+    }
+
+    expect(
+      getOrganizationSectionAccessState(usersSection, (permission) => permission === "users.read_all"),
+    ).toEqual({
+      canView: true,
+      canEdit: false,
+      canAccess: true,
+    });
+
+    expect(
+      getOrganizationSectionAccessState(usersSection, (permission) => permission === "users.manage_all"),
+    ).toEqual({
+      canView: true,
+      canEdit: true,
+      canAccess: true,
+    });
+  });
+
+  it("exposes all configured sections", () => {
+    expect(organizationSettingsSections.map((section) => section.id)).toEqual([
+      "identity.users",
+      "identity.roles",
+      "security.apiKeys",
+      "system.sso",
+      "system.safeMode",
+    ]);
+  });
+});

--- a/frontend/src/pages/OrganizationSettings/components/OrganizationSettingsShell.tsx
+++ b/frontend/src/pages/OrganizationSettings/components/OrganizationSettingsShell.tsx
@@ -1,0 +1,162 @@
+import clsx from "clsx";
+import { Check, ChevronsUpDown, Settings2 } from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import type { OrganizationSettingsNavGroup, OrganizationSettingsRouteId } from "../settingsNav";
+
+interface OrganizationSettingsShellProps {
+  readonly navGroups: readonly OrganizationSettingsNavGroup[];
+  readonly activeSectionId: OrganizationSettingsRouteId;
+  readonly activeSectionLabel: string;
+  readonly activeSectionDescription?: string;
+  readonly children: ReactNode;
+}
+
+export function OrganizationSettingsShell({
+  navGroups,
+  activeSectionId,
+  activeSectionLabel,
+  activeSectionDescription,
+  children,
+}: OrganizationSettingsShellProps) {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const activeNavItem = useMemo(
+    () => navGroups.flatMap((group) => group.items).find((item) => item.id === activeSectionId),
+    [activeSectionId, navGroups],
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-5 sm:px-6 sm:py-8">
+      <div className="sticky top-14 z-20 -mx-4 mb-6 border-y border-border/70 bg-background/95 px-4 py-3 backdrop-blur lg:hidden">
+        <p className="text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-muted-foreground">
+          Organization settings
+        </p>
+        <div className="mt-2 flex items-center gap-2">
+          <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+            <SheetTrigger asChild>
+              <Button type="button" variant="outline" className="w-full justify-between">
+                <span className="flex items-center gap-2 truncate">
+                  {activeNavItem ? <activeNavItem.icon className="h-4 w-4 text-muted-foreground" /> : <Settings2 className="h-4 w-4 text-muted-foreground" />}
+                  <span className="truncate font-semibold">{activeNavItem?.shortLabel ?? activeSectionLabel}</span>
+                </span>
+                <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-[88vw] max-w-sm p-0 sm:max-w-sm">
+              <div className="flex h-full flex-col bg-card">
+                <SheetHeader className="border-b border-border/80 px-4 py-4 text-left">
+                  <SheetTitle>Organization Settings</SheetTitle>
+                  <SheetDescription>Choose a section to manage users, access, and system controls.</SheetDescription>
+                </SheetHeader>
+                <div className="flex-1 overflow-y-auto px-4 py-4">
+                  <OrganizationSettingsNavList
+                    navGroups={navGroups}
+                    activeSectionId={activeSectionId}
+                    onSelect={() => setMobileNavOpen(false)}
+                  />
+                </div>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[16rem_minmax(0,1fr)] lg:items-start lg:gap-8">
+        <aside className="hidden w-full lg:sticky lg:top-6 lg:block lg:w-64 lg:shrink-0">
+          <div className="mb-6">
+            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-muted-foreground">
+              Settings
+            </p>
+            <h1 className="text-lg font-semibold text-foreground">Organization</h1>
+            <p className="text-xs text-muted-foreground">Tenant administration and governance.</p>
+          </div>
+          <div className="rounded-xl border border-border bg-card px-3 py-3 shadow-xs">
+            <OrganizationSettingsNavList navGroups={navGroups} activeSectionId={activeSectionId} />
+          </div>
+        </aside>
+
+        <main className="min-w-0 animate-in fade-in-0 duration-200">
+          <div className="mb-6">
+            <h2 className="text-xl font-semibold text-foreground">{activeSectionLabel}</h2>
+            {activeSectionDescription ? (
+              <p className="mt-1 text-sm text-muted-foreground">{activeSectionDescription}</p>
+            ) : null}
+            <Separator className="mt-4" />
+          </div>
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function OrganizationSettingsNavList({
+  navGroups,
+  activeSectionId,
+  onSelect,
+}: {
+  readonly navGroups: readonly OrganizationSettingsNavGroup[];
+  readonly activeSectionId: OrganizationSettingsRouteId;
+  readonly onSelect?: () => void;
+}) {
+  return (
+    <nav className="space-y-6" aria-label="Organization settings sections">
+      {navGroups.map((group) => (
+        <div key={group.id} className="space-y-2">
+          <p className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+            {group.label}
+          </p>
+          <ul className="space-y-1">
+            {group.items.map((item) => {
+              const isActive = item.id === activeSectionId;
+              const baseClasses = clsx(
+                "group flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                isActive
+                  ? "bg-accent text-foreground shadow-xs ring-1 ring-border/70"
+                  : "text-foreground hover:bg-muted/40",
+                item.disabled && "cursor-not-allowed opacity-50 hover:bg-transparent",
+              );
+
+              if (item.disabled) {
+                return (
+                  <li key={item.id} className="w-full">
+                    <div className={baseClasses} aria-disabled>
+                      <item.icon className="h-4 w-4 text-muted-foreground" />
+                      <span className="flex-1 font-semibold">{item.label}</span>
+                    </div>
+                  </li>
+                );
+              }
+
+              return (
+                <li key={item.id} className="w-full">
+                  <Link
+                    to={item.href}
+                    className={baseClasses}
+                    aria-current={isActive ? "page" : undefined}
+                    onClick={onSelect}
+                  >
+                    <item.icon className="h-4 w-4 text-muted-foreground" />
+                    <span className="flex-1 font-semibold">{item.label}</span>
+                    {isActive ? <Check className="h-4 w-4 text-foreground/70" /> : null}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/pages/OrganizationSettings/components/ResponsiveAdminTable.tsx
+++ b/frontend/src/pages/OrganizationSettings/components/ResponsiveAdminTable.tsx
@@ -1,0 +1,36 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+interface ResponsiveAdminTableProps<TItem> {
+  readonly items: readonly TItem[];
+  readonly getItemKey: (item: TItem) => string;
+  readonly desktopTable: ReactNode;
+  readonly mobileCard: (item: TItem) => ReactNode;
+  readonly mobileListLabel: string;
+  readonly className?: string;
+}
+
+export function ResponsiveAdminTable<TItem>({
+  items,
+  getItemKey,
+  desktopTable,
+  mobileCard,
+  mobileListLabel,
+  className,
+}: ResponsiveAdminTableProps<TItem>) {
+  return (
+    <div className={clsx("space-y-3", className)}>
+      <div className="hidden md:block">{desktopTable}</div>
+      <div className="space-y-3 md:hidden" aria-label={mobileListLabel}>
+        {items.map((item) => (
+          <article
+            key={getItemKey(item)}
+            className="space-y-3 rounded-xl border border-border bg-card p-4 shadow-xs"
+          >
+            {mobileCard(item)}
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/OrganizationSettings/index.tsx
+++ b/frontend/src/pages/OrganizationSettings/index.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo } from "react";
+
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { PageState } from "@/components/layout";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
+import { OrganizationSettingsShell } from "./components/OrganizationSettingsShell";
+import { OrganizationSettingsSectionProvider } from "./sectionContext";
+import {
+  buildOrganizationSettingsNav,
+  getDefaultOrganizationSettingsSection,
+  getOrganizationSectionAccessState,
+  organizationSettingsSections,
+  resolveOrganizationSectionByPath,
+} from "./settingsNav";
+
+interface OrganizationSettingsScreenProps {
+  readonly sectionSegments?: readonly string[];
+}
+
+export default function OrganizationSettingsScreen({ sectionSegments = [] }: OrganizationSettingsScreenProps) {
+  const { hasPermission, canAccessOrganizationSettings } = useGlobalPermissions();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const routeParams = useParams<{ "*": string }>();
+  const effectiveInputSegments = useMemo(() => {
+    if (sectionSegments.length > 0) {
+      return sectionSegments;
+    }
+    const wildcard = routeParams["*"] ?? "";
+    return wildcard
+      .split("/")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  }, [routeParams, sectionSegments]);
+
+  const defaultSection = useMemo(() => getDefaultOrganizationSettingsSection(hasPermission), [hasPermission]);
+
+  const { effectiveSegments, redirectTo } = useMemo(
+    () => normalizeSectionSegments(effectiveInputSegments, location.search, location.hash, defaultSection.path),
+    [effectiveInputSegments, location.search, location.hash, defaultSection.path],
+  );
+
+  useEffect(() => {
+    if (redirectTo) {
+      navigate(redirectTo, { replace: true });
+    }
+  }, [navigate, redirectTo]);
+
+  if (!canAccessOrganizationSettings) {
+    return (
+      <div className="mx-auto w-full max-w-6xl px-6 py-8">
+        <PageState
+          title="You don't have access"
+          description="You need organization-level permissions to view this area."
+          variant="error"
+        />
+      </div>
+    );
+  }
+
+  const activeSection = resolveOrganizationSectionByPath(effectiveSegments) ?? defaultSection;
+
+  const navGroups = buildOrganizationSettingsNav(hasPermission);
+  const flatNavItems = navGroups.flatMap((group) => group.items);
+  const activeNavItem = flatNavItems.find((item) => item.id === activeSection.id);
+  const activeAccess = getOrganizationSectionAccessState(activeSection, hasPermission);
+  const isRestricted = !activeAccess.canAccess || Boolean(activeNavItem?.disabled);
+
+  const sectionParams = effectiveSegments.slice(activeSection.path.split("/").length);
+
+  const content = isRestricted ? (
+    <PageState
+      title="You don't have access to this section"
+      description="You need additional permissions to manage this area of organization settings."
+      variant="error"
+    />
+  ) : (
+    activeSection.element
+  );
+
+  return (
+    <OrganizationSettingsShell
+      navGroups={navGroups}
+      activeSectionId={activeSection.id}
+      activeSectionLabel={activeSection.label}
+      activeSectionDescription={activeSection.description}
+    >
+      <OrganizationSettingsSectionProvider value={{ sectionId: activeSection.id, params: sectionParams }}>
+        {content}
+      </OrganizationSettingsSectionProvider>
+    </OrganizationSettingsShell>
+  );
+}
+
+function normalizeSectionSegments(
+  sectionSegments: readonly string[],
+  search: string,
+  hash: string,
+  defaultPath: string,
+) {
+  const initialSegments = sectionSegments.length > 0 ? [...sectionSegments] : defaultPath.split("/");
+  const joined = initialSegments.join("/");
+  const needsDefaultRedirect = sectionSegments.length === 0;
+  const isKnownPath = organizationSettingsSections.some(
+    (section) => joined === section.path || joined.startsWith(`${section.path}/`),
+  );
+
+  return {
+    effectiveSegments: isKnownPath ? initialSegments : defaultPath.split("/"),
+    redirectTo: needsDefaultRedirect || !isKnownPath ? `/organization/settings/${defaultPath}${search}${hash}` : null,
+  };
+}

--- a/frontend/src/pages/OrganizationSettings/pages/ApiKeysSettingsPage.tsx
+++ b/frontend/src/pages/OrganizationSettings/pages/ApiKeysSettingsPage.tsx
@@ -1,0 +1,237 @@
+import { useState } from "react";
+
+import { buildWeakEtag } from "@/api/etag";
+import { mapUiError } from "@/api/uiErrors";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
+import { useRevokeAdminUserApiKeyMutation, useTenantApiKeysQuery } from "@/hooks/admin";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { SettingsSection } from "@/pages/Workspace/sections/Settings/components/SettingsSection";
+import { ResponsiveAdminTable } from "../components/ResponsiveAdminTable";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isValidUuidFilter(value: string): boolean {
+  return UUID_PATTERN.test(value.trim());
+}
+
+export function ApiKeysSettingsPage() {
+  const { hasPermission } = useGlobalPermissions();
+  const canManage = hasPermission("api_keys.manage_all");
+  const canRead = hasPermission("api_keys.read_all") || canManage;
+
+  const [search, setSearch] = useState("");
+  const [userIdFilter, setUserIdFilter] = useState("");
+  const [includeRevoked, setIncludeRevoked] = useState(false);
+  const [feedback, setFeedback] = useState<{ tone: "success" | "danger"; message: string } | null>(null);
+  const trimmedUserId = userIdFilter.trim();
+  const hasUserIdFilter = trimmedUserId.length > 0;
+  const userIdError =
+    hasUserIdFilter && !isValidUuidFilter(trimmedUserId)
+      ? "Enter a valid user ID in UUID format."
+      : null;
+
+  const keysQuery = useTenantApiKeysQuery({
+    enabled: canRead && !userIdError,
+    pageSize: 100,
+    search,
+    includeRevoked,
+    userId: hasUserIdFilter ? trimmedUserId : null,
+  });
+
+  const revokeMutation = useRevokeAdminUserApiKeyMutation();
+
+  if (!canRead) {
+    return <Alert tone="danger">You do not have permission to access API keys.</Alert>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {feedback ? <Alert tone={feedback.tone}>{feedback.message}</Alert> : null}
+      {keysQuery.isError ? (
+        <Alert tone="danger">
+          {mapUiError(keysQuery.error, {
+            fallback: "Unable to load API keys.",
+            statusMessages: { 422: "One or more filters are invalid. Review your filter values and retry." },
+          }).message}
+        </Alert>
+      ) : null}
+
+      <SettingsSection
+        title="API keys"
+        description={keysQuery.isLoading ? "Loading keys…" : `${keysQuery.total} key${keysQuery.total === 1 ? "" : "s"}`}
+      >
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+          <FormField label="Search">
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search by key name or prefix"
+            />
+          </FormField>
+          <FormField label="Filter by user ID" error={userIdError}>
+            <Input
+              value={userIdFilter}
+              onChange={(event) => setUserIdFilter(event.target.value)}
+              placeholder="Optional user ID"
+            />
+          </FormField>
+          <label className="mt-7 flex items-center gap-2 text-sm text-foreground">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-border"
+              checked={includeRevoked}
+              onChange={(event) => setIncludeRevoked(event.target.checked)}
+            />
+            Include revoked
+          </label>
+        </div>
+
+        {keysQuery.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading API keys…</p>
+        ) : userIdError ? (
+          <Alert tone="warning">Provide a valid user ID to run this filter.</Alert>
+        ) : keysQuery.apiKeys.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
+            {search.trim() || hasUserIdFilter || includeRevoked
+              ? "No API keys match your current filters."
+              : "No API keys have been created for this organization yet."}
+          </p>
+        ) : (
+          <ResponsiveAdminTable
+            items={keysQuery.apiKeys}
+            getItemKey={(key) => key.id}
+            mobileListLabel="Organization API keys"
+            desktopTable={
+              <div className="overflow-hidden rounded-xl border border-border">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      <TableHead className="px-4">Name</TableHead>
+                      <TableHead className="px-4">User ID</TableHead>
+                      <TableHead className="px-4">Prefix</TableHead>
+                      <TableHead className="px-4">Status</TableHead>
+                      <TableHead className="px-4 text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {keysQuery.apiKeys.map((key) => {
+                      const isRevoked = Boolean(key.revoked_at);
+                      return (
+                        <TableRow key={key.id} className="text-sm text-foreground">
+                          <TableCell className="px-4 py-3">{key.name ?? "(unnamed)"}</TableCell>
+                          <TableCell className="px-4 py-3 font-mono text-xs text-muted-foreground">{key.user_id}</TableCell>
+                          <TableCell className="px-4 py-3 font-mono text-xs text-muted-foreground">{key.prefix}</TableCell>
+                          <TableCell className="px-4 py-3">
+                            <Badge variant={isRevoked ? "outline" : "secondary"}>
+                              {isRevoked ? "Revoked" : "Active"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="px-4 py-3 text-right">
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="ghost"
+                              disabled={!canManage || isRevoked || revokeMutation.isPending}
+                              onClick={async () => {
+                                setFeedback(null);
+                                try {
+                                  await revokeMutation.mutateAsync({
+                                    userId: key.user_id,
+                                    apiKeyId: key.id,
+                                    ifMatch: buildWeakEtag(key.id, key.revoked_at ?? key.created_at),
+                                  });
+                                  setFeedback({ tone: "success", message: "API key revoked." });
+                                } catch (error) {
+                                  const mapped = mapUiError(error, {
+                                    fallback: "Unable to revoke API key.",
+                                  });
+                                  setFeedback({ tone: "danger", message: mapped.message });
+                                }
+                              }}
+                            >
+                              Revoke
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            }
+            mobileCard={(key) => {
+              const isRevoked = Boolean(key.revoked_at);
+              return (
+                <>
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-foreground">{key.name ?? "(unnamed)"}</p>
+                    <p className="font-mono text-[11px] text-muted-foreground">{key.prefix}</p>
+                  </div>
+                  <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+                    <dt className="font-semibold uppercase tracking-wide text-muted-foreground">User</dt>
+                    <dd className="font-mono text-muted-foreground">{key.user_id}</dd>
+                    <dt className="font-semibold uppercase tracking-wide text-muted-foreground">Status</dt>
+                    <dd>
+                      <Badge variant={isRevoked ? "outline" : "secondary"}>
+                        {isRevoked ? "Revoked" : "Active"}
+                      </Badge>
+                    </dd>
+                  </dl>
+                  <div className="flex justify-end">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      disabled={!canManage || isRevoked || revokeMutation.isPending}
+                      onClick={async () => {
+                        setFeedback(null);
+                        try {
+                          await revokeMutation.mutateAsync({
+                            userId: key.user_id,
+                            apiKeyId: key.id,
+                            ifMatch: buildWeakEtag(key.id, key.revoked_at ?? key.created_at),
+                          });
+                          setFeedback({ tone: "success", message: "API key revoked." });
+                        } catch (error) {
+                          const mapped = mapUiError(error, {
+                            fallback: "Unable to revoke API key.",
+                          });
+                          setFeedback({ tone: "danger", message: mapped.message });
+                        }
+                      }}
+                    >
+                      Revoke
+                    </Button>
+                  </div>
+                </>
+              );
+            }}
+          />
+        )}
+
+        {!canManage ? (
+          <Alert tone="info">You can audit API keys, but you need API key management permission to revoke keys.</Alert>
+        ) : null}
+
+        {keysQuery.hasNextPage ? (
+          <div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => keysQuery.fetchNextPage()}
+              disabled={keysQuery.isFetchingNextPage}
+            >
+              {keysQuery.isFetchingNextPage ? "Loading more keys…" : "Load more keys"}
+            </Button>
+          </div>
+        ) : null}
+      </SettingsSection>
+    </div>
+  );
+}

--- a/frontend/src/pages/OrganizationSettings/pages/RolesSettingsPage.tsx
+++ b/frontend/src/pages/OrganizationSettings/pages/RolesSettingsPage.tsx
@@ -1,0 +1,700 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { buildWeakEtag } from "@/api/etag";
+import { mapUiError } from "@/api/uiErrors";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
+import {
+  useAdminPermissionsQuery,
+  useAdminRolesQuery,
+  useCreateAdminRoleMutation,
+  useDeleteAdminRoleMutation,
+  useUpdateAdminRoleMutation,
+} from "@/hooks/admin";
+import type { AdminPermission, AdminRole } from "@/api/admin/roles";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { SettingsDrawer } from "@/pages/Workspace/sections/Settings/components/SettingsDrawer";
+import { SettingsSection } from "@/pages/Workspace/sections/Settings/components/SettingsSection";
+import { ResponsiveAdminTable } from "../components/ResponsiveAdminTable";
+import { useOrganizationSettingsSection } from "../sectionContext";
+
+type RoleFormValues = {
+  readonly name: string;
+  readonly slug: string;
+  readonly description: string;
+  readonly permissions: string[];
+};
+
+type FeedbackTone = "success" | "danger";
+type FeedbackMessage = { tone: FeedbackTone; message: string };
+
+type PermissionGroupKey = "users" | "roles" | "apiKeys" | "system" | "workspaces" | "other";
+
+const PERMISSION_GROUP_ORDER: readonly PermissionGroupKey[] = [
+  "users",
+  "roles",
+  "apiKeys",
+  "system",
+  "workspaces",
+  "other",
+] as const;
+
+const PERMISSION_GROUP_LABELS: Record<PermissionGroupKey, string> = {
+  users: "Users",
+  roles: "Roles",
+  apiKeys: "API keys",
+  system: "System",
+  workspaces: "Workspaces",
+  other: "Other",
+};
+
+const EMPTY_COLLAPSE_STATE: Record<PermissionGroupKey, boolean> = {
+  users: false,
+  roles: false,
+  apiKeys: false,
+  system: false,
+  workspaces: false,
+  other: false,
+};
+
+export function RolesSettingsPage() {
+  const { hasPermission } = useGlobalPermissions();
+  const { params } = useOrganizationSettingsSection();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const canManageRoles = hasPermission("roles.manage_all");
+  const canReadRoles = hasPermission("roles.read_all") || canManageRoles;
+
+  const rolesQuery = useAdminRolesQuery("global");
+  const permissionsQuery = useAdminPermissionsQuery("global");
+
+  const createRole = useCreateAdminRoleMutation();
+  const updateRole = useUpdateAdminRoleMutation();
+  const deleteRole = useDeleteAdminRoleMutation();
+
+  const [feedbackMessage, setFeedbackMessage] = useState<FeedbackMessage | null>(null);
+
+  const permissions = useMemo(() => permissionsQuery.data?.items ?? [], [permissionsQuery.data]);
+
+  const roles = useMemo(() => {
+    const collator = new Intl.Collator("en", { sensitivity: "base" });
+    return (rolesQuery.data?.items ?? []).slice().sort((a, b) => collator.compare(a.name, b.name));
+  }, [rolesQuery.data]);
+
+  const roleCount = rolesQuery.data?.meta.totalCount ?? roles.length;
+  const selectedParam = params[0];
+  const isCreateOpen = selectedParam === "new";
+  const selectedRoleId = selectedParam && selectedParam !== "new" ? decodeURIComponent(selectedParam) : null;
+  const selectedRole = roles.find((role) => role.id === selectedRoleId);
+
+  const basePath = "/organization/settings/roles";
+  const suffix = `${location.search}${location.hash}`;
+  const closeDrawer = () => navigate(`${basePath}${suffix}`, { replace: true });
+  const openCreateDrawer = () => navigate(`${basePath}/new${suffix}`);
+  const openRoleDrawer = (roleId: string) => navigate(`${basePath}/${encodeURIComponent(roleId)}${suffix}`);
+
+  const handleCreateRole = async (values: RoleFormValues) => {
+    setFeedbackMessage(null);
+    await createRole.mutateAsync({
+      name: values.name.trim(),
+      slug: values.slug.trim() || undefined,
+      description: values.description.trim() || undefined,
+      permissions: values.permissions,
+      scope_type: "global",
+    });
+    setFeedbackMessage({ tone: "success", message: "Role created." });
+    closeDrawer();
+  };
+
+  const handleUpdateRole = async (roleId: string, values: RoleFormValues) => {
+    setFeedbackMessage(null);
+    const ifMatch = buildWeakEtag(roleId, selectedRole?.updated_at ?? selectedRole?.created_at ?? null);
+    await updateRole.mutateAsync({
+      roleId,
+      payload: {
+        name: values.name.trim(),
+        description: values.description.trim() || undefined,
+        permissions: values.permissions,
+      },
+      ifMatch,
+    });
+    setFeedbackMessage({ tone: "success", message: "Role updated." });
+    closeDrawer();
+  };
+
+  const handleDeleteRole = async (role: AdminRole) => {
+    setFeedbackMessage(null);
+    const ifMatch = buildWeakEtag(role.id, role.updated_at ?? role.created_at ?? null);
+    await deleteRole.mutateAsync({ roleId: role.id, ifMatch });
+    setFeedbackMessage({ tone: "success", message: `Deleted role "${role.name}".` });
+    closeDrawer();
+  };
+
+  if (!canReadRoles) {
+    return <Alert tone="danger">You do not have permission to access roles.</Alert>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {feedbackMessage ? <Alert tone={feedbackMessage.tone}>{feedbackMessage.message}</Alert> : null}
+      {rolesQuery.isError ? (
+        <Alert tone="danger">{mapUiError(rolesQuery.error, { fallback: "Unable to load roles." }).message}</Alert>
+      ) : null}
+      {permissionsQuery.isError ? (
+        <Alert tone="warning">
+          {mapUiError(permissionsQuery.error, { fallback: "Unable to load permission catalog." }).message}
+        </Alert>
+      ) : null}
+
+      <SettingsSection
+        title="Global roles"
+        description={rolesQuery.isLoading ? "Loading roles..." : `${roleCount} role${roleCount === 1 ? "" : "s"} total`}
+        actions={
+          canManageRoles ? (
+            <Button type="button" size="sm" onClick={openCreateDrawer}>
+              New role
+            </Button>
+          ) : null
+        }
+      >
+        {rolesQuery.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading roles...</p>
+        ) : roles.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
+            No global roles yet.
+          </p>
+        ) : (
+          <ResponsiveAdminTable
+            items={roles}
+            getItemKey={(role) => role.id}
+            mobileListLabel="Global roles"
+            desktopTable={
+              <div className="overflow-hidden rounded-xl border border-border">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      <TableHead className="px-4">Role</TableHead>
+                      <TableHead className="px-4">Slug</TableHead>
+                      <TableHead className="px-4">Permissions</TableHead>
+                      <TableHead className="px-4 text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {roles.map((role) => (
+                      <TableRow key={role.id} className="text-sm text-foreground">
+                        <TableCell className="space-y-1 px-4 py-3">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="font-semibold text-foreground">{role.name}</p>
+                            {role.is_system ? (
+                              <Badge variant="secondary" className="text-[11px] uppercase tracking-wide">
+                                System
+                              </Badge>
+                            ) : null}
+                            {!role.is_editable ? (
+                              <Badge
+                                variant="outline"
+                                className="border-border/60 text-[11px] uppercase tracking-wide text-muted-foreground"
+                              >
+                                Locked
+                              </Badge>
+                            ) : null}
+                          </div>
+                          {role.is_system || !role.is_editable ? (
+                            <p className="text-xs text-muted-foreground">
+                              {role.is_system
+                                ? "Built-in role maintained by ADE."
+                                : "Locked role cannot be modified."}
+                            </p>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className="px-4 py-3 font-mono text-xs text-muted-foreground">{role.slug}</TableCell>
+                        <TableCell className="px-4 py-3 text-muted-foreground">
+                          {role.permissions.length} permission{role.permissions.length === 1 ? "" : "s"}
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-right">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => openRoleDrawer(role.id)}
+                            disabled={!canManageRoles && !hasPermission("roles.read_all")}
+                          >
+                            {canManageRoles ? "Manage" : "View"}
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            }
+            mobileCard={(role) => (
+              <>
+                <div className="space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-semibold text-foreground">{role.name}</p>
+                    {role.is_system ? (
+                      <Badge variant="secondary" className="text-[11px] uppercase tracking-wide">
+                        System
+                      </Badge>
+                    ) : null}
+                    {!role.is_editable ? (
+                      <Badge
+                        variant="outline"
+                        className="border-border/60 text-[11px] uppercase tracking-wide text-muted-foreground"
+                      >
+                        Locked
+                      </Badge>
+                    ) : null}
+                  </div>
+                  {role.is_system || !role.is_editable ? (
+                    <p className="text-xs text-muted-foreground">
+                      {role.is_system ? "Built-in role maintained by ADE." : "Locked role cannot be modified."}
+                    </p>
+                  ) : null}
+                </div>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+                  <dt className="font-semibold uppercase tracking-wide text-muted-foreground">Slug</dt>
+                  <dd className="font-mono text-muted-foreground">{role.slug}</dd>
+                  <dt className="font-semibold uppercase tracking-wide text-muted-foreground">Permissions</dt>
+                  <dd className="text-muted-foreground">
+                    {role.permissions.length} permission{role.permissions.length === 1 ? "" : "s"}
+                  </dd>
+                </dl>
+                <div className="flex justify-end">
+                  <Button type="button" variant="ghost" size="sm" onClick={() => openRoleDrawer(role.id)}>
+                    {canManageRoles ? "Manage" : "View"}
+                  </Button>
+                </div>
+              </>
+            )}
+          />
+        )}
+
+        {!canManageRoles ? (
+          <Alert tone="info">You can view roles, but you need role management permission to edit them.</Alert>
+        ) : null}
+      </SettingsSection>
+
+      <RoleDrawer
+        open={isCreateOpen && canManageRoles}
+        mode="create"
+        canManage={canManageRoles}
+        permissions={permissions}
+        onClose={closeDrawer}
+        onSave={(values) => handleCreateRole(values)}
+        isSaving={createRole.isPending}
+        isDeleting={false}
+      />
+
+      <RoleDrawer
+        open={Boolean(selectedRoleId)}
+        mode="edit"
+        canManage={canManageRoles}
+        role={selectedRole}
+        permissions={permissions}
+        onClose={closeDrawer}
+        onSave={(values) => (selectedRoleId ? handleUpdateRole(selectedRoleId, values) : Promise.resolve())}
+        onDelete={selectedRole ? () => handleDeleteRole(selectedRole) : undefined}
+        isSaving={updateRole.isPending}
+        isDeleting={deleteRole.isPending}
+      />
+    </div>
+  );
+}
+
+interface RoleDrawerProps {
+  readonly open: boolean;
+  readonly mode: "create" | "edit";
+  readonly canManage: boolean;
+  readonly role?: AdminRole;
+  readonly permissions: readonly AdminPermission[];
+  readonly onClose: () => void;
+  readonly onSave: (values: RoleFormValues) => Promise<void>;
+  readonly onDelete?: () => Promise<void>;
+  readonly isSaving: boolean;
+  readonly isDeleting: boolean;
+}
+
+function RoleDrawer({
+  open,
+  mode,
+  canManage,
+  role,
+  permissions,
+  onClose,
+  onSave,
+  onDelete,
+  isSaving,
+  isDeleting,
+}: RoleDrawerProps) {
+  const [values, setValues] = useState<RoleFormValues>({
+    name: "",
+    slug: "",
+    description: "",
+    permissions: [],
+  });
+  const [permissionFilter, setPermissionFilter] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmInput, setConfirmInput] = useState("");
+  const [collapsedGroups, setCollapsedGroups] = useState<Record<PermissionGroupKey, boolean>>({
+    ...EMPTY_COLLAPSE_STATE,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setFeedback(null);
+      setPermissionFilter("");
+      setSubmitAttempted(false);
+      setConfirmDelete(false);
+      setConfirmInput("");
+      setCollapsedGroups({ ...EMPTY_COLLAPSE_STATE });
+      return;
+    }
+    if (mode === "edit" && role) {
+      setValues({
+        name: role.name,
+        slug: role.slug,
+        description: role.description ?? "",
+        permissions: role.permissions,
+      });
+    } else {
+      setValues({
+        name: "",
+        slug: "",
+        description: "",
+        permissions: [],
+      });
+    }
+  }, [mode, open, role]);
+
+  const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+  const roleMissing = mode === "edit" && !role;
+  const canEditRole = canManage && (mode === "create" || (role?.is_editable ?? false));
+  const canDeleteRole =
+    canManage && mode === "edit" && role && role.is_editable && !role.is_system && Boolean(onDelete);
+
+  const trimmedName = values.name.trim();
+  const trimmedSlug = values.slug.trim();
+  const nameError = !trimmedName ? "Role name is required." : null;
+  const slugError =
+    mode === "create" && trimmedSlug.length > 0 && !slugPattern.test(trimmedSlug)
+      ? "Use lowercase letters, numbers, and dashes for the role slug."
+      : null;
+
+  const filteredPermissions = useMemo(() => {
+    const term = permissionFilter.trim().toLowerCase();
+    if (!term) {
+      return permissions;
+    }
+    return permissions.filter((permission) => {
+      const haystack = `${permission.label} ${permission.key}`.toLowerCase();
+      return haystack.includes(term);
+    });
+  }, [permissionFilter, permissions]);
+
+  const groupedPermissions = useMemo(() => {
+    const grouped = new Map<PermissionGroupKey, AdminPermission[]>();
+    for (const groupKey of PERMISSION_GROUP_ORDER) {
+      grouped.set(groupKey, []);
+    }
+    for (const permission of filteredPermissions) {
+      const groupKey = getPermissionGroupKey(permission.key);
+      const current = grouped.get(groupKey);
+      if (current) {
+        current.push(permission);
+      }
+    }
+
+    return PERMISSION_GROUP_ORDER.map((groupKey) => ({
+      key: groupKey,
+      label: PERMISSION_GROUP_LABELS[groupKey],
+      items: grouped.get(groupKey) ?? [],
+      selectedCount: (grouped.get(groupKey) ?? []).filter((permission) =>
+        values.permissions.includes(permission.key),
+      ).length,
+      totalCount: grouped.get(groupKey)?.length ?? 0,
+    })).filter((group) => group.totalCount > 0);
+  }, [filteredPermissions, values.permissions]);
+
+  const togglePermission = (permissionKey: string, selected: boolean) => {
+    setValues((current) => ({
+      ...current,
+      permissions: selected
+        ? Array.from(new Set([...(current.permissions ?? []), permissionKey]))
+        : (current.permissions ?? []).filter((key) => key !== permissionKey),
+    }));
+  };
+
+  const handleSave = async () => {
+    setSubmitAttempted(true);
+    setFeedback(null);
+
+    if (roleMissing) {
+      setFeedback("This role could not be found.");
+      return;
+    }
+    if (nameError || slugError) {
+      return;
+    }
+
+    try {
+      await onSave({
+        ...values,
+        name: trimmedName,
+        slug: mode === "create" ? trimmedSlug : role?.slug ?? "",
+        description: values.description.trim(),
+        permissions: values.permissions,
+      });
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: mode === "create" ? "Unable to create role." : "Unable to update role.",
+      });
+      setFeedback(mapped.message);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!onDelete || !role) {
+      return;
+    }
+    setFeedback(null);
+    try {
+      await onDelete();
+    } catch (error) {
+      const mapped = mapUiError(error, { fallback: "Unable to delete role." });
+      setFeedback(mapped.message);
+    } finally {
+      setConfirmDelete(false);
+      setConfirmInput("");
+    }
+  };
+
+  const footer = (
+    <div className="flex items-center justify-between gap-2">
+      <Button type="button" variant="ghost" onClick={onClose} disabled={isSaving || isDeleting}>
+        Close
+      </Button>
+      <div className="flex items-center gap-2">
+        {canDeleteRole ? (
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={() => setConfirmDelete(true)}
+            disabled={isDeleting}
+          >
+            {isDeleting ? "Deleting..." : "Delete"}
+          </Button>
+        ) : null}
+        {canManage ? (
+          <Button type="button" onClick={handleSave} disabled={roleMissing || !canEditRole || isSaving}>
+            {isSaving ? "Saving..." : mode === "create" ? "Create role" : "Save changes"}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  const title = mode === "create" ? "New role" : role?.name ?? "Role details";
+
+  return (
+    <>
+      <SettingsDrawer
+        open={open}
+        onClose={onClose}
+        title={title}
+        description={mode === "create" ? "Create a global role." : "Edit global role details and permissions."}
+        footer={footer}
+      >
+        {feedback ? <Alert tone="danger">{feedback}</Alert> : null}
+        {mode === "edit" && role && !role.is_editable ? (
+          <Alert tone="warning">This role is locked and cannot be modified.</Alert>
+        ) : null}
+        {!canManage && mode === "edit" ? (
+          <Alert tone="info">Read-only view. You need role management permission to make changes.</Alert>
+        ) : null}
+
+        {roleMissing ? (
+          <Alert tone="warning">This role could not be found.</Alert>
+        ) : (
+          <div className="space-y-4">
+            <FormField label="Role name" required error={submitAttempted ? nameError : null}>
+              <Input
+                value={values.name}
+                onChange={(event) => setValues((current) => ({ ...current, name: event.target.value }))}
+                placeholder="Security reviewer"
+                disabled={isSaving || !canEditRole}
+              />
+            </FormField>
+
+            {mode === "create" ? (
+              <FormField
+                label="Role slug"
+                hint="Lowercase, URL-friendly identifier. Leave blank to auto-generate."
+                error={submitAttempted ? slugError : null}
+              >
+                <Input
+                  value={values.slug}
+                  onChange={(event) =>
+                    setValues((current) => ({ ...current, slug: event.target.value.toLowerCase() }))
+                  }
+                  placeholder="security-reviewer"
+                  disabled={isSaving || !canEditRole}
+                />
+              </FormField>
+            ) : (
+              <FormField label="Role slug" hint="System and locked roles preserve their current slug.">
+                <Input value={role?.slug ?? ""} disabled />
+              </FormField>
+            )}
+
+            <FormField label="Description" hint="Optional context about what this role controls.">
+              <Input
+                value={values.description}
+                onChange={(event) => setValues((current) => ({ ...current, description: event.target.value }))}
+                placeholder="What does this role control?"
+                disabled={isSaving || !canEditRole}
+              />
+            </FormField>
+
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">Permissions</p>
+                  <p className="text-xs text-muted-foreground">
+                    Select permissions included with this role. {values.permissions.length} selected.
+                  </p>
+                </div>
+                <Input
+                  value={permissionFilter}
+                  onChange={(event) => setPermissionFilter(event.target.value)}
+                  placeholder="Filter permissions"
+                  disabled={isSaving}
+                  className="w-full sm:w-64"
+                />
+              </div>
+
+              <div className="max-h-[26rem] space-y-2 overflow-y-auto rounded-lg border border-border bg-background p-3">
+                {groupedPermissions.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">No permissions match this filter.</p>
+                ) : (
+                  groupedPermissions.map((group) => {
+                    const collapsed = collapsedGroups[group.key];
+                    return (
+                      <Collapsible
+                        key={group.key}
+                        open={!collapsed}
+                        onOpenChange={(open) =>
+                          setCollapsedGroups((current) => ({ ...current, [group.key]: !open }))
+                        }
+                        className="rounded-lg border border-border"
+                      >
+                        <CollapsibleTrigger asChild>
+                          <button
+                            type="button"
+                            className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left"
+                          >
+                            <div>
+                              <p className="text-sm font-semibold text-foreground">{group.label}</p>
+                              <p className="text-xs text-muted-foreground">
+                                {group.selectedCount} of {group.totalCount} selected
+                              </p>
+                            </div>
+                            <ChevronDown className={`h-4 w-4 text-muted-foreground transition ${collapsed ? "-rotate-90" : "rotate-0"}`} />
+                          </button>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent>
+                          <div className="space-y-2 border-t border-border/70 px-3 py-3">
+                            {group.items.map((permission) => {
+                              const checkboxId = `permission-${permission.key.replaceAll(".", "-")}`;
+                              return (
+                                <label
+                                  key={permission.key}
+                                  htmlFor={checkboxId}
+                                  className="flex items-start gap-3 rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground"
+                                >
+                                  <input
+                                    id={checkboxId}
+                                    type="checkbox"
+                                    aria-label={permission.label}
+                                    className="mt-1 h-4 w-4 rounded border-border"
+                                    checked={values.permissions.includes(permission.key)}
+                                    onChange={(event) => togglePermission(permission.key, event.target.checked)}
+                                    disabled={isSaving || !canEditRole}
+                                  />
+                                  <span>
+                                    <span className="block font-semibold">{permission.label}</span>
+                                    <span className="block text-xs text-muted-foreground">{permission.description}</span>
+                                  </span>
+                                </label>
+                              );
+                            })}
+                          </div>
+                        </CollapsibleContent>
+                      </Collapsible>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </SettingsDrawer>
+
+      <ConfirmDialog
+        open={confirmDelete && Boolean(role)}
+        title="Delete this role?"
+        description="Deleting this role removes it from users currently assigned to it."
+        confirmLabel="Delete role"
+        tone="danger"
+        confirmDisabled={confirmInput.trim() !== (role?.slug ?? "")}
+        onCancel={() => {
+          setConfirmDelete(false);
+          setConfirmInput("");
+        }}
+        onConfirm={handleDelete}
+        isConfirming={isDeleting}
+      >
+        <FormField label="Type the role slug to confirm" required>
+          <Input
+            value={confirmInput}
+            onChange={(event) => setConfirmInput(event.target.value)}
+            placeholder={role?.slug ?? "role-slug"}
+            disabled={isDeleting}
+          />
+        </FormField>
+      </ConfirmDialog>
+    </>
+  );
+}
+
+function getPermissionGroupKey(permissionKey: string): PermissionGroupKey {
+  if (permissionKey.startsWith("users.")) {
+    return "users";
+  }
+  if (permissionKey.startsWith("roles.")) {
+    return "roles";
+  }
+  if (permissionKey.startsWith("api_keys.")) {
+    return "apiKeys";
+  }
+  if (permissionKey.startsWith("system.")) {
+    return "system";
+  }
+  if (permissionKey.startsWith("workspace.") || permissionKey.startsWith("workspaces.")) {
+    return "workspaces";
+  }
+  return "other";
+}

--- a/frontend/src/pages/OrganizationSettings/pages/SystemSafeModeSettingsPage.tsx
+++ b/frontend/src/pages/OrganizationSettings/pages/SystemSafeModeSettingsPage.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { mapUiError } from "@/api/uiErrors";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
+import { useSafeModeQuery, useUpdateSafeModeMutation } from "@/hooks/admin";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { SettingsSection } from "@/pages/Workspace/sections/Settings/components/SettingsSection";
+
+type FeedbackTone = "success" | "danger";
+type FeedbackMessage = { tone: FeedbackTone; message: string };
+
+export function SystemSafeModeSettingsPage() {
+  const { hasPermission } = useGlobalPermissions();
+  const canManage = hasPermission("system.settings.manage");
+  const canRead = hasPermission("system.settings.read") || canManage;
+
+  const safeModeQuery = useSafeModeQuery({ enabled: canRead });
+  const updateSafeMode = useUpdateSafeModeMutation();
+
+  const [enabled, setEnabled] = useState(false);
+  const [detail, setDetail] = useState("");
+  const [feedback, setFeedback] = useState<FeedbackMessage | null>(null);
+  const [confirmEnableOpen, setConfirmEnableOpen] = useState(false);
+
+  useEffect(() => {
+    if (!safeModeQuery.data) {
+      return;
+    }
+    setEnabled(Boolean(safeModeQuery.data.enabled));
+    setDetail(safeModeQuery.data.detail || "");
+  }, [safeModeQuery.data]);
+
+  const hasUnsavedChanges = useMemo(() => {
+    if (!safeModeQuery.data) {
+      return false;
+    }
+    const savedDetail = normalizeDetail(safeModeQuery.data.detail || "");
+    const draftDetail = normalizeDetail(detail);
+    return enabled !== Boolean(safeModeQuery.data.enabled) || draftDetail !== savedDetail;
+  }, [detail, enabled, safeModeQuery.data]);
+
+  if (!canRead) {
+    return <Alert tone="danger">You do not have permission to access safe mode settings.</Alert>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {feedback ? <Alert tone={feedback.tone}>{feedback.message}</Alert> : null}
+      {safeModeQuery.isError ? (
+        <Alert tone="danger">
+          {mapUiError(safeModeQuery.error, { fallback: "Unable to load safe mode settings." }).message}
+        </Alert>
+      ) : null}
+
+      <SettingsSection
+        title="Safe mode"
+        description="Pause engine execution during incidents or maintenance windows."
+        actions={
+          <Button
+            type="button"
+            disabled={!canManage || updateSafeMode.isPending || !hasUnsavedChanges}
+            onClick={async () => {
+              setFeedback(null);
+              try {
+                await updateSafeMode.mutateAsync({ enabled, detail: detail.trim() || null });
+                setFeedback({
+                  tone: "success",
+                  message: enabled ? "Safe mode enabled." : "Safe mode disabled.",
+                });
+              } catch (error) {
+                const mapped = mapUiError(error, {
+                  fallback: "Unable to update safe mode settings.",
+                });
+                setFeedback({ tone: "danger", message: mapped.message });
+              }
+            }}
+          >
+            {updateSafeMode.isPending ? "Saving..." : "Save"}
+          </Button>
+        }
+      >
+        <div className="rounded-lg border border-warning/30 bg-warning/10 p-4">
+          <p className="text-sm font-semibold text-warning-foreground">Operational impact</p>
+          <p className="mt-1 text-xs text-warning-foreground/90">
+            When safe mode is enabled, new engine runs are blocked. Keep the detail message clear so operators and
+            tenants understand why automation is paused.
+          </p>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm text-foreground">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-border"
+            checked={enabled}
+            onChange={(event) => {
+              const nextChecked = event.target.checked;
+              if (nextChecked && !enabled) {
+                setConfirmEnableOpen(true);
+                return;
+              }
+              setEnabled(nextChecked);
+            }}
+            disabled={!canManage || updateSafeMode.isPending || safeModeQuery.isLoading}
+          />
+          Enable safe mode
+        </label>
+
+        <FormField label="Detail" hint="Optional operator-facing message for safe mode state.">
+          <Input
+            value={detail}
+            onChange={(event) => setDetail(event.target.value)}
+            placeholder="Maintenance window"
+            disabled={!canManage || updateSafeMode.isPending}
+          />
+        </FormField>
+
+        {hasUnsavedChanges ? (
+          <p className="text-xs font-medium text-warning">You have unsaved safe mode changes.</p>
+        ) : null}
+      </SettingsSection>
+
+      <ConfirmDialog
+        open={confirmEnableOpen}
+        title="Enable safe mode?"
+        description="Enabling safe mode immediately pauses new run execution. Existing runs may continue depending on worker state."
+        confirmLabel="Enable safe mode"
+        tone="danger"
+        onCancel={() => setConfirmEnableOpen(false)}
+        onConfirm={() => {
+          setEnabled(true);
+          setConfirmEnableOpen(false);
+        }}
+      />
+    </div>
+  );
+}
+
+function normalizeDetail(value: string | null | undefined) {
+  return (value ?? "").trim().replace(/\s+/g, " ");
+}

--- a/frontend/src/pages/OrganizationSettings/pages/SystemSsoSettingsPage.tsx
+++ b/frontend/src/pages/OrganizationSettings/pages/SystemSsoSettingsPage.tsx
@@ -1,0 +1,610 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { mapUiError } from "@/api/uiErrors";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
+import {
+  useCreateSsoProviderMutation,
+  useDeleteSsoProviderMutation,
+  useSsoProvidersQuery,
+  useSsoSettingsQuery,
+  useUpdateSsoProviderMutation,
+  useUpdateSsoSettingsMutation,
+} from "@/hooks/admin";
+import type { SsoProviderAdmin } from "@/api/admin/sso";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { SettingsDrawer } from "@/pages/Workspace/sections/Settings/components/SettingsDrawer";
+import { SettingsSection } from "@/pages/Workspace/sections/Settings/components/SettingsSection";
+import { ResponsiveAdminTable } from "../components/ResponsiveAdminTable";
+
+const STATUS_OPTIONS = ["active", "disabled"] as const;
+const PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9-_]*$/;
+const DOMAIN_PATTERN = /^[a-z0-9.-]+\.[a-z]{2,}$/i;
+
+type FeedbackTone = "success" | "danger";
+type FeedbackMessage = { tone: FeedbackTone; message: string };
+
+type ProviderStatus = "active" | "disabled";
+
+type ProviderFieldErrors = {
+  readonly id?: string;
+  readonly label?: string;
+  readonly issuer?: string;
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+  readonly domains?: string;
+};
+
+export function SystemSsoSettingsPage() {
+  const { hasPermission } = useGlobalPermissions();
+  const canManage = hasPermission("system.settings.manage");
+  const canRead = hasPermission("system.settings.read") || canManage;
+
+  const providersQuery = useSsoProvidersQuery({ enabled: canRead });
+  const settingsQuery = useSsoSettingsQuery({ enabled: canRead });
+
+  const createProvider = useCreateSsoProviderMutation();
+  const updateProvider = useUpdateSsoProviderMutation();
+  const deleteProvider = useDeleteSsoProviderMutation();
+  const updateSettings = useUpdateSsoSettingsMutation();
+
+  const [feedback, setFeedback] = useState<FeedbackMessage | null>(null);
+  const [settingsEnabled, setSettingsEnabled] = useState(false);
+  const [drawerMode, setDrawerMode] = useState<"create" | "edit" | null>(null);
+  const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof settingsQuery.data?.enabled === "boolean") {
+      setSettingsEnabled(settingsQuery.data.enabled);
+    }
+  }, [settingsQuery.data?.enabled]);
+
+  const providers = providersQuery.data?.items ?? [];
+  const selectedProvider = useMemo(
+    () => providers.find((provider) => provider.id === selectedProviderId),
+    [providers, selectedProviderId],
+  );
+
+  const hasUnsavedSsoSetting =
+    typeof settingsQuery.data?.enabled === "boolean" && settingsEnabled !== settingsQuery.data.enabled;
+
+  if (!canRead) {
+    return <Alert tone="danger">You do not have permission to access SSO settings.</Alert>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {feedback ? <Alert tone={feedback.tone}>{feedback.message}</Alert> : null}
+      {providersQuery.isError ? (
+        <Alert tone="danger">
+          {mapUiError(providersQuery.error, { fallback: "Unable to load SSO providers." }).message}
+        </Alert>
+      ) : null}
+      {settingsQuery.isError ? (
+        <Alert tone="danger">
+          {mapUiError(settingsQuery.error, { fallback: "Unable to load SSO settings." }).message}
+        </Alert>
+      ) : null}
+
+      <SettingsSection
+        title="Global SSO"
+        description="Enable or disable SSO for this organization."
+        actions={
+          <Button
+            type="button"
+            disabled={!canManage || updateSettings.isPending || !hasUnsavedSsoSetting}
+            onClick={async () => {
+              setFeedback(null);
+              try {
+                await updateSettings.mutateAsync({ enabled: settingsEnabled });
+                setFeedback({ tone: "success", message: "SSO settings updated." });
+              } catch (error) {
+                const mapped = mapUiError(error, {
+                  fallback: "Unable to update SSO settings.",
+                });
+                setFeedback({ tone: "danger", message: mapped.message });
+              }
+            }}
+          >
+            {updateSettings.isPending ? "Saving..." : "Save"}
+          </Button>
+        }
+      >
+        <label className="flex items-center gap-2 text-sm text-foreground">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-border"
+            checked={settingsEnabled}
+            onChange={(event) => setSettingsEnabled(event.target.checked)}
+            disabled={!canManage || updateSettings.isPending || settingsQuery.isLoading}
+          />
+          Enable SSO
+        </label>
+
+        {hasUnsavedSsoSetting ? (
+          <p className="text-xs font-medium text-warning">You have unsaved SSO changes.</p>
+        ) : null}
+      </SettingsSection>
+
+      <SettingsSection
+        title="SSO providers"
+        description={`${providers.length} provider${providers.length === 1 ? "" : "s"}`}
+        actions={
+          canManage ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                setSelectedProviderId(null);
+                setDrawerMode("create");
+              }}
+            >
+              Add provider
+            </Button>
+          ) : null
+        }
+      >
+        {providersQuery.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading providers...</p>
+        ) : providers.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
+            No providers configured.
+          </p>
+        ) : (
+          <ResponsiveAdminTable
+            items={providers}
+            getItemKey={(provider) => provider.id}
+            mobileListLabel="SSO providers"
+            desktopTable={
+              <div className="overflow-hidden rounded-xl border border-border">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      <TableHead className="px-4">Provider</TableHead>
+                      <TableHead className="px-4">Issuer</TableHead>
+                      <TableHead className="px-4">Status</TableHead>
+                      <TableHead className="px-4 text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {providers.map((provider) => (
+                      <TableRow key={provider.id} className="text-sm text-foreground">
+                        <TableCell className="space-y-1 px-4 py-3">
+                          <p className="font-semibold text-foreground">{provider.label}</p>
+                          <p className="font-mono text-xs text-muted-foreground">{provider.id}</p>
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-muted-foreground">{provider.issuer}</TableCell>
+                        <TableCell className="px-4 py-3">
+                          <Badge variant={provider.status === "active" ? "secondary" : "outline"}>
+                            {provider.status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-right">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            disabled={!canManage}
+                            onClick={() => {
+                              setSelectedProviderId(provider.id);
+                              setDrawerMode("edit");
+                            }}
+                          >
+                            Manage
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            }
+            mobileCard={(provider) => (
+              <>
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-foreground">{provider.label}</p>
+                  <p className="font-mono text-[11px] text-muted-foreground">{provider.id}</p>
+                </div>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+                  <dt className="font-semibold uppercase tracking-wide text-muted-foreground">Issuer</dt>
+                  <dd className="break-all text-muted-foreground">{provider.issuer}</dd>
+                  <dt className="font-semibold uppercase tracking-wide text-muted-foreground">Status</dt>
+                  <dd>
+                    <Badge variant={provider.status === "active" ? "secondary" : "outline"}>
+                      {provider.status}
+                    </Badge>
+                  </dd>
+                </dl>
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    disabled={!canManage}
+                    onClick={() => {
+                      setSelectedProviderId(provider.id);
+                      setDrawerMode("edit");
+                    }}
+                  >
+                    Manage
+                  </Button>
+                </div>
+              </>
+            )}
+          />
+        )}
+
+        {!canManage ? (
+          <Alert tone="info">You can view providers, but you need system management permission to update them.</Alert>
+        ) : null}
+      </SettingsSection>
+
+      <ProviderDrawer
+        open={drawerMode === "create"}
+        mode="create"
+        provider={undefined}
+        onClose={() => setDrawerMode(null)}
+        isSubmitting={createProvider.isPending || updateProvider.isPending || deleteProvider.isPending}
+        onCreate={async (payload) => {
+          setFeedback(null);
+          await createProvider.mutateAsync(payload);
+          setFeedback({ tone: "success", message: "SSO provider created." });
+          setDrawerMode(null);
+        }}
+        onUpdate={async () => undefined}
+        onDelete={undefined}
+      />
+
+      <ProviderDrawer
+        open={drawerMode === "edit"}
+        mode="edit"
+        provider={selectedProvider}
+        onClose={() => setDrawerMode(null)}
+        isSubmitting={createProvider.isPending || updateProvider.isPending || deleteProvider.isPending}
+        onCreate={async () => undefined}
+        onUpdate={async (payload) => {
+          if (!selectedProvider) return;
+          setFeedback(null);
+          await updateProvider.mutateAsync({ id: selectedProvider.id, payload });
+          setFeedback({ tone: "success", message: "SSO provider updated." });
+          setDrawerMode(null);
+        }}
+        onDelete={
+          selectedProvider
+            ? async () => {
+                setFeedback(null);
+                await deleteProvider.mutateAsync(selectedProvider.id);
+                setFeedback({ tone: "success", message: "SSO provider disabled." });
+                setDrawerMode(null);
+              }
+            : undefined
+        }
+      />
+    </div>
+  );
+}
+
+function ProviderDrawer({
+  open,
+  mode,
+  provider,
+  onClose,
+  isSubmitting,
+  onCreate,
+  onUpdate,
+  onDelete,
+}: {
+  readonly open: boolean;
+  readonly mode: "create" | "edit";
+  readonly provider?: SsoProviderAdmin;
+  readonly onClose: () => void;
+  readonly isSubmitting: boolean;
+  readonly onCreate: (payload: {
+    id: string;
+    label: string;
+    issuer: string;
+    client_id: string;
+    client_secret: string;
+    status: ProviderStatus;
+    domains: string[];
+  }) => Promise<void>;
+  readonly onUpdate: (payload: {
+    label?: string;
+    issuer?: string;
+    client_id?: string;
+    client_secret?: string;
+    status?: ProviderStatus;
+    domains?: string[];
+  }) => Promise<void>;
+  readonly onDelete?: () => Promise<void>;
+}) {
+  const [id, setId] = useState("");
+  const [label, setLabel] = useState("");
+  const [issuer, setIssuer] = useState("");
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [status, setStatus] = useState<ProviderStatus>("active");
+  const [domains, setDomains] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<ProviderFieldErrors>({});
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setError(null);
+      setFieldErrors({});
+      setSubmitAttempted(false);
+      return;
+    }
+
+    if (mode === "edit" && provider) {
+      setId(provider.id);
+      setLabel(provider.label);
+      setIssuer(provider.issuer);
+      setClientId(provider.client_id);
+      setClientSecret("");
+      setStatus(provider.status as ProviderStatus);
+      setDomains((provider.domains ?? []).join(", "));
+      setFieldErrors({});
+      return;
+    }
+
+    setId("");
+    setLabel("");
+    setIssuer("");
+    setClientId("");
+    setClientSecret("");
+    setStatus("active");
+    setDomains("");
+    setFieldErrors({});
+  }, [mode, open, provider]);
+
+  const parsedDomains = domains
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+
+  const validationErrors = validateProviderForm({
+    mode,
+    id,
+    label,
+    issuer,
+    clientId,
+    clientSecret,
+    domains: parsedDomains,
+  });
+
+  const shouldShowValidation = submitAttempted;
+
+  const handleSave = async () => {
+    setSubmitAttempted(true);
+    setError(null);
+
+    if (Object.keys(validationErrors).length > 0) {
+      setFieldErrors(validationErrors);
+      return;
+    }
+
+    setFieldErrors({});
+
+    try {
+      if (mode === "create") {
+        await onCreate({
+          id: id.trim(),
+          label: label.trim(),
+          issuer: issuer.trim(),
+          client_id: clientId.trim(),
+          client_secret: clientSecret.trim(),
+          status,
+          domains: parsedDomains,
+        });
+      } else {
+        await onUpdate({
+          label: label.trim(),
+          issuer: issuer.trim(),
+          client_id: clientId.trim(),
+          client_secret: clientSecret.trim() || undefined,
+          status,
+          domains: parsedDomains,
+        });
+      }
+    } catch (saveError) {
+      const mapped = mapUiError(saveError, {
+        fallback: mode === "create" ? "Unable to create provider." : "Unable to update provider.",
+        statusMessages: {
+          409: "A provider with this ID already exists.",
+          422: "Some provider fields are invalid. Review and retry.",
+        },
+      });
+      setFieldErrors((current) => ({
+        ...current,
+        id: findFirstFieldError(mapped.fieldErrors, ["id", "provider_id", "body.id"]),
+        label: findFirstFieldError(mapped.fieldErrors, ["label", "body.label"]),
+        issuer: findFirstFieldError(mapped.fieldErrors, ["issuer", "body.issuer"]),
+        clientId: findFirstFieldError(mapped.fieldErrors, ["client_id", "clientId", "body.client_id"]),
+        clientSecret: findFirstFieldError(mapped.fieldErrors, ["client_secret", "body.client_secret"]),
+        domains: findFirstFieldError(mapped.fieldErrors, ["domains", "body.domains"]),
+      }));
+      setError(mapped.message);
+    }
+  };
+
+  return (
+    <SettingsDrawer
+      open={open}
+      onClose={onClose}
+      title={mode === "create" ? "Add provider" : provider?.label ?? "Provider"}
+      description="Configure OIDC provider metadata and domain restrictions."
+      footer={
+        <div className="flex items-center justify-between gap-2">
+          <Button type="button" variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            Close
+          </Button>
+          <div className="flex items-center gap-2">
+            {mode === "edit" && onDelete ? (
+              <Button type="button" variant="destructive" size="sm" disabled={isSubmitting} onClick={onDelete}>
+                Disable
+              </Button>
+            ) : null}
+            <Button type="button" disabled={isSubmitting} onClick={handleSave}>
+              {isSubmitting ? "Saving..." : mode === "create" ? "Create provider" : "Save changes"}
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        {error ? <Alert tone="danger">{error}</Alert> : null}
+
+        <FormField
+          label="Provider ID"
+          required
+          hint="Lowercase letters, numbers, dashes, and underscores only."
+          error={shouldShowValidation ? validationErrors.id ?? fieldErrors.id : fieldErrors.id}
+        >
+          <Input
+            value={id}
+            onChange={(event) => setId(event.target.value.toLowerCase())}
+            placeholder="okta"
+            disabled={mode === "edit" || isSubmitting}
+          />
+        </FormField>
+        <FormField
+          label="Label"
+          required
+          error={shouldShowValidation ? validationErrors.label ?? fieldErrors.label : fieldErrors.label}
+        >
+          <Input value={label} onChange={(event) => setLabel(event.target.value)} disabled={isSubmitting} />
+        </FormField>
+        <FormField
+          label="Issuer"
+          required
+          hint="Use the provider issuer URL (for example, https://example.okta.com/oauth2/default)."
+          error={shouldShowValidation ? validationErrors.issuer ?? fieldErrors.issuer : fieldErrors.issuer}
+        >
+          <Input value={issuer} onChange={(event) => setIssuer(event.target.value)} disabled={isSubmitting} />
+        </FormField>
+        <FormField
+          label="Client ID"
+          required
+          error={shouldShowValidation ? validationErrors.clientId ?? fieldErrors.clientId : fieldErrors.clientId}
+        >
+          <Input value={clientId} onChange={(event) => setClientId(event.target.value)} disabled={isSubmitting} />
+        </FormField>
+        <FormField
+          label={mode === "create" ? "Client secret" : "Client secret (optional)"}
+          required={mode === "create"}
+          error={
+            shouldShowValidation
+              ? validationErrors.clientSecret ?? fieldErrors.clientSecret
+              : fieldErrors.clientSecret
+          }
+        >
+          <Input
+            value={clientSecret}
+            onChange={(event) => setClientSecret(event.target.value)}
+            type="password"
+            disabled={isSubmitting}
+          />
+        </FormField>
+        <FormField label="Status">
+          <select
+            className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+            value={status}
+            onChange={(event) => setStatus(event.target.value as ProviderStatus)}
+            disabled={isSubmitting}
+          >
+            {STATUS_OPTIONS.map((entry) => (
+              <option key={entry} value={entry}>
+                {entry}
+              </option>
+            ))}
+          </select>
+        </FormField>
+        <FormField
+          label="Domains"
+          hint="Comma-separated email domains allowed for this provider."
+          error={shouldShowValidation ? validationErrors.domains ?? fieldErrors.domains : fieldErrors.domains}
+        >
+          <Input
+            value={domains}
+            onChange={(event) => setDomains(event.target.value)}
+            placeholder="example.com, subsidiary.com"
+            disabled={isSubmitting}
+          />
+        </FormField>
+      </div>
+    </SettingsDrawer>
+  );
+}
+
+function validateProviderForm(input: {
+  readonly mode: "create" | "edit";
+  readonly id: string;
+  readonly label: string;
+  readonly issuer: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly domains: readonly string[];
+}): ProviderFieldErrors {
+  const errors: Partial<ProviderFieldErrors> = {};
+
+  if (input.mode === "create") {
+    const providerId = input.id.trim();
+    if (!providerId) {
+      errors.id = "Provider ID is required.";
+    } else if (!PROVIDER_ID_PATTERN.test(providerId)) {
+      errors.id = "Use lowercase letters, numbers, dashes, or underscores.";
+    }
+  }
+
+  if (!input.label.trim()) {
+    errors.label = "Label is required.";
+  }
+
+  const issuer = input.issuer.trim();
+  if (!issuer) {
+    errors.issuer = "Issuer is required.";
+  } else {
+    try {
+      const parsedUrl = new URL(issuer);
+      if (!parsedUrl.protocol.startsWith("http")) {
+        errors.issuer = "Issuer must be a valid http/https URL.";
+      }
+    } catch {
+      errors.issuer = "Issuer must be a valid URL.";
+    }
+  }
+
+  if (!input.clientId.trim()) {
+    errors.clientId = "Client ID is required.";
+  }
+
+  if (input.mode === "create" && !input.clientSecret.trim()) {
+    errors.clientSecret = "Client secret is required when creating a provider.";
+  }
+
+  const invalidDomain = input.domains.find((domain) => !DOMAIN_PATTERN.test(domain));
+  if (invalidDomain) {
+    errors.domains = `Invalid domain: ${invalidDomain}`;
+  }
+
+  return errors;
+}
+
+function findFirstFieldError(
+  fieldErrors: Record<string, string[]>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = fieldErrors[key]?.[0];
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/frontend/src/pages/OrganizationSettings/pages/UsersSettingsPage.tsx
+++ b/frontend/src/pages/OrganizationSettings/pages/UsersSettingsPage.tsx
@@ -1,0 +1,807 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { buildWeakEtag } from "@/api/etag";
+import { mapUiError } from "@/api/uiErrors";
+import { useAuthProvidersQuery } from "@/hooks/auth/useAuthProvidersQuery";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
+import {
+  useAdminRolesQuery,
+  useAdminUserApiKeysQuery,
+  useAdminUserRolesQuery,
+  useAdminUsersQuery,
+  useAssignAdminUserRoleMutation,
+  useCreateAdminUserApiKeyMutation,
+  useCreateAdminUserMutation,
+  useDeactivateAdminUserMutation,
+  useRemoveAdminUserRoleMutation,
+  useRevokeAdminUserApiKeyMutation,
+  useUpdateAdminUserMutation,
+} from "@/hooks/admin";
+import { useSession } from "@/providers/auth/SessionContext";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { SettingsDrawer } from "@/pages/Workspace/sections/Settings/components/SettingsDrawer";
+import { SettingsSection } from "@/pages/Workspace/sections/Settings/components/SettingsSection";
+import type { ApiKeySummary } from "@/types";
+import { ResponsiveAdminTable } from "../components/ResponsiveAdminTable";
+import { useOrganizationSettingsSection } from "../sectionContext";
+
+type FeedbackMessage = { tone: "success" | "danger"; message: string };
+
+type KeyReveal = {
+  readonly id: string;
+  readonly prefix: string;
+  readonly secret: string;
+};
+
+const SIMPLE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function UsersSettingsPage() {
+  const { hasPermission } = useGlobalPermissions();
+  const { params } = useOrganizationSettingsSection();
+  const session = useSession();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const canManageUsers = hasPermission("users.manage_all");
+  const canReadUsers = hasPermission("users.read_all") || canManageUsers;
+
+  const usersQuery = useAdminUsersQuery({ enabled: canReadUsers, pageSize: 100 });
+  const rolesQuery = useAdminRolesQuery("global");
+  const authProvidersQuery = useAuthProvidersQuery();
+
+  const createUser = useCreateAdminUserMutation();
+  const updateUser = useUpdateAdminUserMutation();
+  const deactivateUser = useDeactivateAdminUserMutation();
+  const assignRole = useAssignAdminUserRoleMutation();
+  const removeRole = useRemoveAdminUserRoleMutation();
+  const createUserApiKey = useCreateAdminUserApiKeyMutation();
+  const revokeUserApiKey = useRevokeAdminUserApiKeyMutation();
+
+  const [feedbackMessage, setFeedbackMessage] = useState<FeedbackMessage | null>(null);
+
+  const users = usersQuery.users;
+  const selectedParam = params[0];
+  const isCreateOpen = selectedParam === "new";
+  const selectedUserId = selectedParam && selectedParam !== "new" ? decodeURIComponent(selectedParam) : null;
+  const selectedUser = users.find((entry) => entry.id === selectedUserId);
+
+  const providers = authProvidersQuery.data?.providers ?? [];
+  const ssoEnabled = providers.some((provider) => provider.type === "oidc");
+
+  const basePath = "/organization/settings/users";
+  const suffix = `${location.search}${location.hash}`;
+  const closeDrawer = () => navigate(`${basePath}${suffix}`, { replace: true });
+  const openCreateDrawer = () => navigate(`${basePath}/new${suffix}`);
+  const openUserDrawer = (userId: string) => navigate(`${basePath}/${encodeURIComponent(userId)}${suffix}`);
+
+  if (!canReadUsers) {
+    return (
+      <Alert tone="danger">
+        You do not have permission to access users.
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {feedbackMessage ? <Alert tone={feedbackMessage.tone}>{feedbackMessage.message}</Alert> : null}
+      {usersQuery.isError ? (
+        <Alert tone="danger">
+          {mapUiError(usersQuery.error, { fallback: "Unable to load users." }).message}
+        </Alert>
+      ) : null}
+
+      <SettingsSection
+        title="Users"
+        description={usersQuery.isLoading ? "Loading users..." : `${users.length} users`}
+        actions={
+          canManageUsers ? (
+            <Button type="button" size="sm" onClick={openCreateDrawer} disabled={!ssoEnabled}>
+              Create user
+            </Button>
+          ) : null
+        }
+      >
+        {!ssoEnabled ? (
+          <Alert tone="info">
+            User creation is available only when SSO providers are configured.
+          </Alert>
+        ) : null}
+
+        {usersQuery.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading users...</p>
+        ) : users.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
+            No users found.
+          </p>
+        ) : (
+          <ResponsiveAdminTable
+            items={users}
+            getItemKey={(user) => user.id}
+            mobileListLabel="Organization users"
+            desktopTable={
+              <div className="overflow-hidden rounded-xl border border-border">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      <TableHead className="px-4">User</TableHead>
+                      <TableHead className="px-4">Roles</TableHead>
+                      <TableHead className="px-4">Status</TableHead>
+                      <TableHead className="px-4 text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {users.map((user) => (
+                      <TableRow key={user.id} className="text-sm text-foreground">
+                        <TableCell className="px-4 py-3">
+                          <p className="font-semibold text-foreground">{user.display_name || user.email}</p>
+                          <p className="text-xs text-muted-foreground">{user.email}</p>
+                        </TableCell>
+                        <TableCell className="px-4 py-3">
+                          <div className="flex flex-wrap gap-1">
+                            {(user.roles ?? []).length === 0 ? (
+                              <span className="text-xs text-muted-foreground">No roles</span>
+                            ) : (
+                              (user.roles ?? []).map((role) => (
+                                <Badge key={`${user.id}-${role}`} variant="secondary" className="text-xs">
+                                  {role}
+                                </Badge>
+                              ))
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="px-4 py-3">
+                          <Badge variant={user.is_active ? "secondary" : "outline"}>
+                            {user.is_active ? "Active" : "Inactive"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-right">
+                          <Button type="button" variant="ghost" size="sm" onClick={() => openUserDrawer(user.id)}>
+                            {canManageUsers ? "Manage" : "View"}
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            }
+            mobileCard={(user) => (
+              <>
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-foreground">{user.display_name || user.email}</p>
+                  <p className="text-xs text-muted-foreground">{user.email}</p>
+                </div>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+                  <dt className="font-semibold uppercase tracking-wide text-muted-foreground">Roles</dt>
+                  <dd>
+                    {(user.roles ?? []).length === 0 ? (
+                      <span className="text-muted-foreground">No roles</span>
+                    ) : (
+                      <div className="flex flex-wrap gap-1">
+                        {(user.roles ?? []).map((role) => (
+                          <Badge key={`${user.id}-${role}`} variant="secondary" className="text-[11px]">
+                            {role}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                  </dd>
+                  <dt className="font-semibold uppercase tracking-wide text-muted-foreground">Status</dt>
+                  <dd>
+                    <Badge variant={user.is_active ? "secondary" : "outline"}>
+                      {user.is_active ? "Active" : "Inactive"}
+                    </Badge>
+                  </dd>
+                </dl>
+                <div className="flex justify-end">
+                  <Button type="button" variant="ghost" size="sm" onClick={() => openUserDrawer(user.id)}>
+                    {canManageUsers ? "Manage" : "View"}
+                  </Button>
+                </div>
+              </>
+            )}
+          />
+        )}
+
+        {usersQuery.hasNextPage ? (
+          <div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => usersQuery.fetchNextPage()}
+              disabled={usersQuery.isFetchingNextPage}
+            >
+              {usersQuery.isFetchingNextPage ? "Loading more users..." : "Load more users"}
+            </Button>
+          </div>
+        ) : null}
+
+        {!canManageUsers ? (
+          <Alert tone="info">You can view users, but you need user management permission to make changes.</Alert>
+        ) : null}
+      </SettingsSection>
+
+      <CreateUserDrawer
+        open={isCreateOpen && canManageUsers}
+        canCreate={ssoEnabled}
+        onClose={closeDrawer}
+        onSubmit={async ({ email, displayName }) => {
+          setFeedbackMessage(null);
+          try {
+            await createUser.mutateAsync({ email, display_name: displayName || null });
+            setFeedbackMessage({ tone: "success", message: "User created." });
+            closeDrawer();
+          } catch (error) {
+            const mapped = mapUiError(error, { fallback: "Unable to create user." });
+            setFeedbackMessage({ tone: "danger", message: mapped.message });
+          }
+        }}
+        isSubmitting={createUser.isPending}
+      />
+
+      <ManageUserDrawer
+        open={Boolean(selectedUserId)}
+        userId={selectedUserId}
+        user={selectedUser}
+        canManage={canManageUsers}
+        currentUserId={session.user.id}
+        roles={rolesQuery.data?.items ?? []}
+        onClose={closeDrawer}
+        onUpdateProfile={async (payload) => {
+          if (!selectedUserId) return;
+          setFeedbackMessage(null);
+          await updateUser.mutateAsync({ userId: selectedUserId, payload });
+          setFeedbackMessage({ tone: "success", message: "User profile updated." });
+        }}
+        onDeactivate={async () => {
+          if (!selectedUserId) return;
+          setFeedbackMessage(null);
+          await deactivateUser.mutateAsync(selectedUserId);
+          setFeedbackMessage({ tone: "success", message: "User deactivated." });
+          closeDrawer();
+        }}
+        onSaveRoles={async (draftRoleIds, currentRoleIds) => {
+          if (!selectedUserId) return;
+          setFeedbackMessage(null);
+          const toAssign = draftRoleIds.filter((roleId) => !currentRoleIds.includes(roleId));
+          const toRemove = currentRoleIds.filter((roleId) => !draftRoleIds.includes(roleId));
+
+          await Promise.all([
+            ...toAssign.map((roleId) => assignRole.mutateAsync({ userId: selectedUserId, roleId })),
+            ...toRemove.map((roleId) => removeRole.mutateAsync({ userId: selectedUserId, roleId })),
+          ]);
+          setFeedbackMessage({ tone: "success", message: "Roles updated." });
+        }}
+        onCreateApiKey={async ({ name, expiresInDays }) => {
+          if (!selectedUserId) return null;
+          setFeedbackMessage(null);
+          const created = await createUserApiKey.mutateAsync({
+            userId: selectedUserId,
+            payload: {
+              name: name || undefined,
+              expires_in_days: expiresInDays ?? undefined,
+            },
+          });
+          setFeedbackMessage({ tone: "success", message: "API key created." });
+          return created;
+        }}
+        onRevokeApiKey={async (key) => {
+          if (!selectedUserId) return;
+          setFeedbackMessage(null);
+          await revokeUserApiKey.mutateAsync({
+            userId: selectedUserId,
+            apiKeyId: key.id,
+            ifMatch: buildWeakEtag(key.id, key.revoked_at ?? key.created_at),
+          });
+          setFeedbackMessage({ tone: "success", message: "API key revoked." });
+        }}
+        isMutating={
+          updateUser.isPending ||
+          deactivateUser.isPending ||
+          assignRole.isPending ||
+          removeRole.isPending ||
+          createUserApiKey.isPending ||
+          revokeUserApiKey.isPending
+        }
+      />
+    </div>
+  );
+}
+
+function CreateUserDrawer({
+  open,
+  canCreate,
+  onClose,
+  onSubmit,
+  isSubmitting,
+}: {
+  readonly open: boolean;
+  readonly canCreate: boolean;
+  readonly onClose: () => void;
+  readonly onSubmit: (input: { email: string; displayName: string }) => Promise<void>;
+  readonly isSubmitting: boolean;
+}) {
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setEmail("");
+      setDisplayName("");
+      setError(null);
+      setEmailError(null);
+    }
+  }, [open]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setEmailError(null);
+    if (!canCreate) {
+      setError("SSO must be configured before creating users.");
+      return;
+    }
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      setEmailError("Email is required.");
+      return;
+    }
+    if (!SIMPLE_EMAIL_PATTERN.test(trimmedEmail)) {
+      setEmailError("Enter a valid email address.");
+      return;
+    }
+    try {
+      await onSubmit({ email: trimmedEmail, displayName: displayName.trim() });
+    } catch (submitError) {
+      const mapped = mapUiError(submitError, { fallback: "Unable to create user." });
+      setError(mapped.message);
+    }
+  };
+
+  return (
+    <SettingsDrawer
+      open={open}
+      onClose={onClose}
+      title="Create user"
+      description="Pre-provision an SSO user account."
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        {error ? <Alert tone="danger">{error}</Alert> : null}
+        <FormField label="Email" required error={emailError}>
+          <Input
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="user@example.com"
+            disabled={isSubmitting || !canCreate}
+          />
+        </FormField>
+        <FormField label="Display name">
+          <Input
+            value={displayName}
+            onChange={(event) => setDisplayName(event.target.value)}
+            placeholder="Optional"
+            disabled={isSubmitting || !canCreate}
+          />
+        </FormField>
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting || !canCreate}>
+            {isSubmitting ? "Creating..." : "Create user"}
+          </Button>
+        </div>
+      </form>
+    </SettingsDrawer>
+  );
+}
+
+function ManageUserDrawer({
+  open,
+  userId,
+  user,
+  canManage,
+  currentUserId,
+  roles,
+  onClose,
+  onUpdateProfile,
+  onDeactivate,
+  onSaveRoles,
+  onCreateApiKey,
+  onRevokeApiKey,
+  isMutating,
+}: {
+  readonly open: boolean;
+  readonly userId: string | null;
+  readonly user:
+    | {
+        id: string;
+        email: string;
+        display_name: string | null;
+        is_active: boolean;
+      }
+    | undefined;
+  readonly canManage: boolean;
+  readonly currentUserId?: string;
+  readonly roles: readonly { id: string; name: string }[];
+  readonly onClose: () => void;
+  readonly onUpdateProfile: (payload: { display_name?: string | null; is_active?: boolean | null }) => Promise<void>;
+  readonly onDeactivate: () => Promise<void>;
+  readonly onSaveRoles: (draftRoleIds: string[], currentRoleIds: string[]) => Promise<void>;
+  readonly onCreateApiKey: (input: { name: string; expiresInDays: number | null }) => Promise<{ id: string; prefix: string; secret: string } | null>;
+  readonly onRevokeApiKey: (key: ApiKeySummary) => Promise<void>;
+  readonly isMutating: boolean;
+}) {
+  const userRolesQuery = useAdminUserRolesQuery(userId);
+  const userApiKeysQuery = useAdminUserApiKeysQuery(userId, { includeRevoked: true, limit: 100 });
+  const [displayName, setDisplayName] = useState("");
+  const [isActive, setIsActive] = useState(true);
+  const [roleDraft, setRoleDraft] = useState<string[]>([]);
+  const [apiKeyName, setApiKeyName] = useState("");
+  const [apiKeyExpiry, setApiKeyExpiry] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [issuedKey, setIssuedKey] = useState<KeyReveal | null>(null);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle");
+  const hasExpiryInput = apiKeyExpiry.trim().length > 0;
+  const parsedExpiry = hasExpiryInput ? Number.parseInt(apiKeyExpiry.trim(), 10) : null;
+  const apiKeyExpiryError =
+    hasExpiryInput && (!Number.isInteger(parsedExpiry ?? Number.NaN) || (parsedExpiry ?? 0) <= 0)
+      ? "Expiration must be a positive whole number of days."
+      : null;
+
+  const currentRoleIds = useMemo(
+    () => (userRolesQuery.data?.roles ?? []).map((entry) => entry.role_id),
+    [userRolesQuery.data?.roles],
+  );
+
+  useEffect(() => {
+    if (!open || !user) {
+      setDisplayName("");
+      setIsActive(true);
+      setRoleDraft([]);
+      setError(null);
+      setIssuedKey(null);
+      setCopyStatus("idle");
+      return;
+    }
+
+    setDisplayName(user.display_name ?? "");
+    setIsActive(Boolean(user.is_active));
+  }, [open, user]);
+
+  useEffect(() => {
+    if (!open) return;
+    setRoleDraft(currentRoleIds);
+  }, [currentRoleIds, open]);
+
+  const disabled = !canManage || isMutating;
+
+  return (
+    <SettingsDrawer
+      open={open}
+      onClose={onClose}
+      title={user?.display_name || user?.email || "User"}
+      description="Manage profile, global roles, and API keys."
+      widthClassName="w-full max-w-2xl"
+    >
+      {!user ? (
+        <Alert tone="warning">This user could not be found.</Alert>
+      ) : (
+        <div className="space-y-6">
+          {error ? <Alert tone="danger">{error}</Alert> : null}
+          {!canManage ? (
+            <Alert tone="info">Read-only view. You need user management permission to make changes.</Alert>
+          ) : null}
+
+          {issuedKey ? (
+            <div className="space-y-2 rounded-lg border border-warning/40 bg-warning/10 px-4 py-3">
+              <p className="text-sm font-semibold text-warning-foreground">Copy this API key secret now</p>
+              <p className="text-xs text-warning-foreground/90">
+                For security, this secret is shown only once and cannot be retrieved again.
+              </p>
+              <div className="flex flex-col gap-2 rounded-md border border-warning/40 bg-background p-3 sm:flex-row sm:items-center sm:justify-between">
+                <code className="break-all text-xs text-foreground">{issuedKey.secret}</code>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(issuedKey.secret);
+                        setCopyStatus("copied");
+                      } catch {
+                        setCopyStatus("failed");
+                      }
+                    }}
+                  >
+                    Copy
+                  </Button>
+                  <Button type="button" size="sm" variant="ghost" onClick={() => setIssuedKey(null)}>
+                    Dismiss
+                  </Button>
+                </div>
+              </div>
+              {copyStatus === "copied" ? <p className="text-xs text-success">Secret copied to clipboard.</p> : null}
+              {copyStatus === "failed" ? <p className="text-xs text-destructive">Unable to copy. Copy manually.</p> : null}
+            </div>
+          ) : null}
+
+          <SettingsSection title="Profile" description="Update account details and activation status.">
+            <FormField label="Email">
+              <Input value={user.email} disabled />
+            </FormField>
+            <FormField label="Display name">
+              <Input
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+                disabled={disabled}
+              />
+            </FormField>
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border-border"
+                checked={isActive}
+                onChange={(event) => setIsActive(event.target.checked)}
+                disabled={disabled}
+              />
+              Active user
+            </label>
+            <div className="flex justify-end gap-2">
+              {user.id !== currentUserId && user.is_active ? (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  disabled={disabled}
+                  onClick={async () => {
+                    setError(null);
+                    try {
+                      await onDeactivate();
+                    } catch (deactivateError) {
+                      const mapped = mapUiError(deactivateError, { fallback: "Unable to deactivate user." });
+                      setError(mapped.message);
+                    }
+                  }}
+                >
+                  Deactivate
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                disabled={disabled}
+                onClick={async () => {
+                  setError(null);
+                  try {
+                    await onUpdateProfile({
+                      display_name: displayName.trim() || null,
+                      is_active: isActive,
+                    });
+                  } catch (saveError) {
+                    const mapped = mapUiError(saveError, { fallback: "Unable to update user." });
+                    setError(mapped.message);
+                  }
+                }}
+              >
+                Save profile
+              </Button>
+            </div>
+          </SettingsSection>
+
+          <SettingsSection title="Global roles" description="Assign global roles to this user.">
+            {roles.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No global roles available.</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {roles.map((role) => (
+                  <label key={role.id} className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-border"
+                      checked={roleDraft.includes(role.id)}
+                      onChange={(event) =>
+                        setRoleDraft((current) =>
+                          event.target.checked
+                            ? Array.from(new Set([...current, role.id]))
+                            : current.filter((id) => id !== role.id),
+                        )
+                      }
+                      disabled={disabled}
+                    />
+                    <span>{role.name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                disabled={disabled || userRolesQuery.isLoading}
+                onClick={async () => {
+                  setError(null);
+                  try {
+                    await onSaveRoles(roleDraft, currentRoleIds);
+                    await userRolesQuery.refetch();
+                  } catch (saveError) {
+                    const mapped = mapUiError(saveError, { fallback: "Unable to update roles." });
+                    setError(mapped.message);
+                  }
+                }}
+              >
+                Save roles
+              </Button>
+            </div>
+          </SettingsSection>
+
+          <SettingsSection title="API keys" description="Create and revoke API keys for this user.">
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_9rem_auto] md:items-end">
+              <FormField label="Name">
+                <Input
+                  value={apiKeyName}
+                  onChange={(event) => setApiKeyName(event.target.value)}
+                  placeholder="Optional"
+                  disabled={disabled}
+                />
+              </FormField>
+              <FormField label="Expires (days)" error={apiKeyExpiryError}>
+                <Input
+                  value={apiKeyExpiry}
+                  onChange={(event) => setApiKeyExpiry(event.target.value)}
+                  placeholder="Optional"
+                  inputMode="numeric"
+                  disabled={disabled}
+                />
+              </FormField>
+              <Button
+                type="button"
+                disabled={disabled || Boolean(apiKeyExpiryError)}
+                onClick={async () => {
+                  setError(null);
+                  if (apiKeyExpiryError) {
+                    return;
+                  }
+                  try {
+                    const created = await onCreateApiKey({
+                      name: apiKeyName.trim(),
+                      expiresInDays: hasExpiryInput ? parsedExpiry : null,
+                    });
+                    setApiKeyName("");
+                    setApiKeyExpiry("");
+                    setCopyStatus("idle");
+                    setIssuedKey(created ? { id: created.id, prefix: created.prefix, secret: created.secret } : null);
+                    await userApiKeysQuery.refetch();
+                  } catch (createError) {
+                    const mapped = mapUiError(createError, { fallback: "Unable to create API key." });
+                    setError(mapped.message);
+                  }
+                }}
+              >
+                Create key
+              </Button>
+            </div>
+
+            {userApiKeysQuery.isLoading ? (
+              <p className="text-sm text-muted-foreground">Loading API keys...</p>
+            ) : (
+              <ResponsiveAdminTable
+                items={userApiKeysQuery.data?.items ?? []}
+                getItemKey={(key) => key.id}
+                mobileListLabel="User API keys"
+                desktopTable={
+                  <div className="overflow-hidden rounded-xl border border-border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Name</TableHead>
+                          <TableHead>Prefix</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead className="text-right">Actions</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {(userApiKeysQuery.data?.items ?? []).map((key) => {
+                          const isRevoked = Boolean(key.revoked_at);
+                          return (
+                            <TableRow key={key.id}>
+                              <TableCell>{key.name ?? "(unnamed)"}</TableCell>
+                              <TableCell className="font-mono text-xs">{key.prefix}</TableCell>
+                              <TableCell>{isRevoked ? "Revoked" : "Active"}</TableCell>
+                              <TableCell className="text-right">
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="ghost"
+                                  disabled={disabled || isRevoked}
+                                  onClick={async () => {
+                                    setError(null);
+                                    try {
+                                      await onRevokeApiKey(key);
+                                      await userApiKeysQuery.refetch();
+                                    } catch (revokeError) {
+                                      const mapped = mapUiError(revokeError, {
+                                        fallback: "Unable to revoke API key.",
+                                        statusMessages: {
+                                          412: "This key changed while you were viewing it. Refresh and retry.",
+                                        },
+                                      });
+                                      setError(mapped.message);
+                                    }
+                                  }}
+                                >
+                                  Revoke
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+                }
+                mobileCard={(key) => {
+                  const isRevoked = Boolean(key.revoked_at);
+                  return (
+                    <>
+                      <div className="space-y-1">
+                        <p className="text-sm font-semibold text-foreground">{key.name ?? "(unnamed)"}</p>
+                        <p className="font-mono text-[11px] text-muted-foreground">{key.prefix}</p>
+                      </div>
+                      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+                        <dt className="font-semibold uppercase tracking-wide text-muted-foreground">Status</dt>
+                        <dd>{isRevoked ? "Revoked" : "Active"}</dd>
+                      </dl>
+                      <div className="flex justify-end">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          disabled={disabled || isRevoked}
+                          onClick={async () => {
+                            setError(null);
+                            try {
+                              await onRevokeApiKey(key);
+                              await userApiKeysQuery.refetch();
+                            } catch (revokeError) {
+                              const mapped = mapUiError(revokeError, {
+                                fallback: "Unable to revoke API key.",
+                                statusMessages: {
+                                  412: "This key changed while you were viewing it. Refresh and retry.",
+                                },
+                              });
+                              setError(mapped.message);
+                            }
+                          }}
+                        >
+                          Revoke
+                        </Button>
+                      </div>
+                    </>
+                  );
+                }}
+              />
+            )}
+          </SettingsSection>
+        </div>
+      )}
+
+      <div className="mt-6 flex justify-end">
+        <Button type="button" variant="ghost" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </SettingsDrawer>
+  );
+}

--- a/frontend/src/pages/OrganizationSettings/sectionContext.tsx
+++ b/frontend/src/pages/OrganizationSettings/sectionContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+import type { OrganizationSettingsRouteId } from "./settingsNav";
+
+type OrganizationSettingsSectionContextValue = {
+  readonly sectionId: OrganizationSettingsRouteId;
+  readonly params: readonly string[];
+};
+
+const OrganizationSettingsSectionContext = createContext<OrganizationSettingsSectionContextValue | null>(null);
+
+export function OrganizationSettingsSectionProvider({
+  value,
+  children,
+}: {
+  readonly value: OrganizationSettingsSectionContextValue;
+  readonly children: ReactNode;
+}) {
+  return (
+    <OrganizationSettingsSectionContext.Provider value={value}>
+      {children}
+    </OrganizationSettingsSectionContext.Provider>
+  );
+}
+
+export function useOrganizationSettingsSection(): OrganizationSettingsSectionContextValue {
+  const context = useContext(OrganizationSettingsSectionContext);
+  if (!context) {
+    throw new Error("useOrganizationSettingsSection must be used within OrganizationSettingsSectionProvider");
+  }
+  return context;
+}

--- a/frontend/src/pages/OrganizationSettings/settingsNav.tsx
+++ b/frontend/src/pages/OrganizationSettings/settingsNav.tsx
@@ -1,0 +1,206 @@
+import type { ReactElement } from "react";
+import type { LucideIcon } from "lucide-react";
+import { KeyRound, ShieldCheck, ShieldUser, UserRoundCog, Users } from "lucide-react";
+
+import { ApiKeysSettingsPage } from "./pages/ApiKeysSettingsPage";
+import { RolesSettingsPage } from "./pages/RolesSettingsPage";
+import { SystemSafeModeSettingsPage } from "./pages/SystemSafeModeSettingsPage";
+import { SystemSsoSettingsPage } from "./pages/SystemSsoSettingsPage";
+import { UsersSettingsPage } from "./pages/UsersSettingsPage";
+
+export type OrganizationSettingsRouteId =
+  | "identity.users"
+  | "identity.roles"
+  | "security.apiKeys"
+  | "system.sso"
+  | "system.safeMode";
+
+export type OrganizationSettingsGroupId = "identity" | "security" | "system";
+
+export type OrganizationSettingsSection = {
+  readonly id: OrganizationSettingsRouteId;
+  readonly group: OrganizationSettingsGroupId;
+  readonly groupOrder: number;
+  readonly label: string;
+  readonly shortLabel: string;
+  readonly description: string;
+  readonly path: string;
+  readonly icon: LucideIcon;
+  readonly required?: { readonly view?: string[]; readonly edit?: string[] };
+  readonly element: ReactElement;
+};
+
+export interface OrganizationSettingsNavItem {
+  readonly id: OrganizationSettingsRouteId;
+  readonly group: OrganizationSettingsGroupId;
+  readonly label: string;
+  readonly shortLabel: string;
+  readonly description: string;
+  readonly icon: LucideIcon;
+  readonly href: string;
+  readonly canView: boolean;
+  readonly canEdit: boolean;
+  readonly disabled?: boolean;
+}
+
+export interface OrganizationSettingsNavGroup {
+  readonly id: OrganizationSettingsGroupId;
+  readonly label: string;
+  readonly items: OrganizationSettingsNavItem[];
+}
+
+const GROUP_LABELS: Record<OrganizationSettingsGroupId, string> = {
+  identity: "Identity",
+  security: "Security",
+  system: "System",
+};
+
+export const organizationSettingsSections: OrganizationSettingsSection[] = [
+  {
+    id: "identity.users",
+    group: "identity",
+    groupOrder: 1,
+    label: "Users",
+    shortLabel: "Users",
+    description: "Manage user accounts and access status.",
+    path: "users",
+    icon: Users,
+    required: { view: ["users.read_all", "users.manage_all"], edit: ["users.manage_all"] },
+    element: <UsersSettingsPage />,
+  },
+  {
+    id: "identity.roles",
+    group: "identity",
+    groupOrder: 1,
+    label: "Roles",
+    shortLabel: "Roles",
+    description: "Define global roles and permission bundles.",
+    path: "roles",
+    icon: ShieldUser,
+    required: { view: ["roles.read_all", "roles.manage_all"], edit: ["roles.manage_all"] },
+    element: <RolesSettingsPage />,
+  },
+  {
+    id: "security.apiKeys",
+    group: "security",
+    groupOrder: 2,
+    label: "API Keys",
+    shortLabel: "API Keys",
+    description: "Audit and manage API keys across the organization.",
+    path: "api-keys",
+    icon: KeyRound,
+    required: { view: ["api_keys.read_all", "api_keys.manage_all"], edit: ["api_keys.manage_all"] },
+    element: <ApiKeysSettingsPage />,
+  },
+  {
+    id: "system.sso",
+    group: "system",
+    groupOrder: 3,
+    label: "SSO",
+    shortLabel: "SSO",
+    description: "Configure identity providers and SSO behavior.",
+    path: "system/sso",
+    icon: UserRoundCog,
+    required: {
+      view: ["system.settings.read", "system.settings.manage"],
+      edit: ["system.settings.manage"],
+    },
+    element: <SystemSsoSettingsPage />,
+  },
+  {
+    id: "system.safeMode",
+    group: "system",
+    groupOrder: 3,
+    label: "Safe mode",
+    shortLabel: "Safe mode",
+    description: "Control maintenance mode for run execution.",
+    path: "system/safe-mode",
+    icon: ShieldCheck,
+    required: {
+      view: ["system.settings.read", "system.settings.manage"],
+      edit: ["system.settings.manage"],
+    },
+    element: <SystemSafeModeSettingsPage />,
+  },
+] as const;
+
+export const defaultOrganizationSettingsSection = organizationSettingsSections[0];
+
+export interface OrganizationSectionAccessState {
+  readonly canView: boolean;
+  readonly canEdit: boolean;
+  readonly canAccess: boolean;
+}
+
+export function resolveOrganizationSectionByPath(pathSegments: readonly string[]): OrganizationSettingsSection | undefined {
+  const normalized = pathSegments.join("/");
+  return organizationSettingsSections.find(
+    (section) => normalized === section.path || normalized.startsWith(`${section.path}/`),
+  );
+}
+
+export function getOrganizationSectionAccessState(
+  section: OrganizationSettingsSection,
+  hasPermission: (permission: string) => boolean,
+): OrganizationSectionAccessState {
+  const viewPerms = section.required?.view ?? [];
+  const editPerms = section.required?.edit ?? [];
+  if (viewPerms.length === 0 && editPerms.length === 0) {
+    return { canView: true, canEdit: true, canAccess: true };
+  }
+
+  const canView = viewPerms.length === 0 ? false : viewPerms.some((perm) => hasPermission(perm));
+  const canEdit = editPerms.length === 0 ? false : editPerms.some((perm) => hasPermission(perm));
+  return {
+    canView,
+    canEdit,
+    canAccess: canView || canEdit,
+  };
+}
+
+export function getDefaultOrganizationSettingsSection(
+  hasPermission: (permission: string) => boolean,
+): OrganizationSettingsSection {
+  const firstAllowed = organizationSettingsSections.find(
+    (section) => getOrganizationSectionAccessState(section, hasPermission).canAccess,
+  );
+
+  return firstAllowed ?? defaultOrganizationSettingsSection;
+}
+
+export function buildOrganizationSettingsNav(
+  hasPermission: (permission: string) => boolean,
+): OrganizationSettingsNavGroup[] {
+  const items = organizationSettingsSections
+    .filter((section) => getOrganizationSectionAccessState(section, hasPermission).canAccess)
+    .map((section) => {
+      const accessState = getOrganizationSectionAccessState(section, hasPermission);
+      return {
+        id: section.id,
+        group: section.group,
+        label: section.label,
+        shortLabel: section.shortLabel,
+        description: section.description,
+        icon: section.icon,
+        href: `/organization/settings/${section.path}`,
+        canView: accessState.canView,
+        canEdit: accessState.canEdit,
+        disabled: !accessState.canAccess,
+      };
+    });
+
+  return Object.values(
+    items.reduce<Record<OrganizationSettingsGroupId, OrganizationSettingsNavGroup>>((groups, item) => {
+      const existing = groups[item.group];
+      const next: OrganizationSettingsNavGroup = existing
+        ? { ...existing, items: [...existing.items, item] }
+        : { id: item.group, label: GROUP_LABELS[item.group], items: [item] };
+      groups[item.group] = next;
+      return groups;
+    }, {} as Record<OrganizationSettingsGroupId, OrganizationSettingsNavGroup>),
+  ).sort((left, right) => {
+    const leftOrder = organizationSettingsSections.find((section) => section.group === left.id)?.groupOrder ?? 999;
+    const rightOrder = organizationSettingsSections.find((section) => section.group === right.id)?.groupOrder ?? 999;
+    return leftOrder - rightOrder;
+  });
+}

--- a/frontend/src/pages/Workspace/components/WorkspaceSidebar.tsx
+++ b/frontend/src/pages/Workspace/components/WorkspaceSidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/api/documents";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { AvatarGroup } from "@/components/ui/avatar-group";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
 import { useSession } from "@/providers/auth/SessionContext";
 import { useWorkspaceContext } from "@/pages/Workspace/context/WorkspaceContext";
 import { useWorkspacePresence } from "@/pages/Workspace/context/WorkspacePresenceContext";
@@ -107,6 +108,7 @@ type AssignedDocumentItemProps = {
 
 export function WorkspaceSidebar() {
   const session = useSession();
+  const { canAccessOrganizationSettings } = useGlobalPermissions();
   const queryClient = useQueryClient();
   const { workspace, workspaces } = useWorkspaceContext();
   const presence = useWorkspacePresence();
@@ -122,6 +124,7 @@ export function WorkspaceSidebar() {
     runs: `${base}/runs`,
     configBuilder: `${base}/config-builder`,
     settings: `${base}/settings`,
+    organizationSettings: "/organization/settings",
   } as const;
 
   const navItems = useMemo<WorkspaceNavItem[]>(
@@ -312,6 +315,16 @@ export function WorkspaceSidebar() {
               </NavLink>
             </SidebarMenuButton>
           </SidebarMenuItem>
+          {canAccessOrganizationSettings ? (
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={isActive(links.organizationSettings)}>
+                <NavLink to={links.organizationSettings}>
+                  <LayoutGrid />
+                  <span>Organization Settings</span>
+                </NavLink>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ) : null}
         </SidebarMenu>
       </SidebarFooter>
       <SidebarRail />

--- a/frontend/src/pages/Workspace/components/WorkspaceTopbarControls.tsx
+++ b/frontend/src/pages/Workspace/components/WorkspaceTopbarControls.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { Laptop, Moon, Palette, Sun } from "lucide-react";
 
 import { useSession } from "@/providers/auth/SessionContext";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
 import { BUILTIN_THEMES, MODE_OPTIONS, WORKSPACE_THEME_MODE_ANCHOR, useTheme } from "@/providers/theme";
 import { MOTION_PROFILE } from "@/providers/theme/modeTransition";
 import { openReleaseNotes } from "@/config/release-notes";
@@ -30,6 +31,8 @@ const WEB_VERSION_FALLBACK =
 
 export function WorkspaceTopbarControls() {
   const session = useSession();
+  const navigate = useNavigate();
+  const { canAccessOrganizationSettings } = useGlobalPermissions();
   const [versionsOpen, setVersionsOpen] = useState(false);
   const displayName = session.user.display_name || session.user.email || "Signed in";
   const email = session.user.email ?? "";
@@ -46,6 +49,8 @@ export function WorkspaceTopbarControls() {
         <WorkspaceProfileMenu
           displayName={displayName}
           email={email}
+          canAccessOrganizationSettings={canAccessOrganizationSettings}
+          onOpenOrganizationSettings={() => navigate("/organization/settings")}
           onOpenVersions={() => setVersionsOpen(true)}
         />
       </div>
@@ -238,10 +243,14 @@ function WorkspaceModeControl() {
 function WorkspaceProfileMenu({
   displayName,
   email,
+  canAccessOrganizationSettings,
+  onOpenOrganizationSettings,
   onOpenVersions,
 }: {
   readonly displayName: string;
   readonly email: string;
+  readonly canAccessOrganizationSettings: boolean;
+  readonly onOpenOrganizationSettings: () => void;
   readonly onOpenVersions: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -286,6 +295,14 @@ function WorkspaceProfileMenu({
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
+          {canAccessOrganizationSettings ? (
+            <DropdownMenuItem onSelect={onOpenOrganizationSettings} className="gap-2">
+              <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-muted text-[0.6rem] font-semibold text-muted-foreground">
+                O
+              </span>
+              <span>Organization Settings</span>
+            </DropdownMenuItem>
+          ) : null}
           <DropdownMenuItem onSelect={() => openReleaseNotes()} className="gap-2">
             <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-muted text-[0.6rem] font-semibold text-muted-foreground">
               R

--- a/frontend/src/pages/Workspace/sections/Settings/components/SettingsDrawer.tsx
+++ b/frontend/src/pages/Workspace/sections/Settings/components/SettingsDrawer.tsx
@@ -40,12 +40,12 @@ export function SettingsDrawer({
         <DialogPrimitive.Content
           aria-label={title}
           className={clsx(
-            "fixed inset-y-0 right-0 left-auto top-0 z-[var(--app-z-modal)] flex h-full w-full flex-col gap-0 rounded-none border-l bg-card p-0 shadow-2xl",
+            "fixed inset-y-0 right-0 left-auto top-0 z-[var(--app-z-modal)] flex h-full w-full min-h-0 flex-col gap-0 overflow-hidden rounded-none border-l bg-card p-0 shadow-2xl",
             "data-[state=closed]:slide-out-to-right-2 data-[state=open]:slide-in-from-right-2 data-[state=closed]:animate-out data-[state=open]:animate-in",
             widthClassName,
           )}
         >
-          <div className="flex items-start justify-between gap-4 px-6 py-4">
+          <div className="sticky top-0 z-10 flex items-start justify-between gap-4 border-b border-border bg-card/95 px-4 py-4 backdrop-blur sm:px-6">
             <div className="space-y-1">
               <DialogTitle className="text-lg font-semibold text-foreground">{title}</DialogTitle>
               {description ? (
@@ -66,13 +66,12 @@ export function SettingsDrawer({
             </Button>
           </div>
 
-          <Separator />
-          <div className="flex-1 overflow-y-auto px-6 py-4">{children}</div>
+          <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6">{children}</div>
 
           {footer ? (
             <>
               <Separator />
-              <div className="px-6 py-4">{footer}</div>
+              <div className="sticky bottom-0 z-10 bg-card/95 px-4 py-4 backdrop-blur sm:px-6">{footer}</div>
             </>
           ) : null}
         </DialogPrimitive.Content>

--- a/frontend/src/types/generated/openapi.d.ts
+++ b/frontend/src/types/generated/openapi.d.ts
@@ -232,6 +232,23 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/apikeys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List API keys across the tenant (admin) */
+        get: operations["list_api_keys_api_v1_apikeys_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/users/me/apikeys": {
         parameters: {
             query?: never;
@@ -314,7 +331,8 @@ export type paths = {
         /** List all users (administrator only) */
         get: operations["list_users_api_v1_users_get"];
         put?: never;
-        post?: never;
+        /** Create a user (administrator only) */
+        post: operations["create_user_api_v1_users_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3474,31 +3492,21 @@ export type components = {
                 [key: string]: unknown;
             } | null;
         };
-        /** UserCreate */
+        /**
+         * UserCreate
+         * @description Payload for pre-provisioning a user account.
+         */
         UserCreate: {
             /**
              * Email
              * Format: email
+             * @description User email.
              */
             email: string;
-            /** Password */
-            password: string;
             /**
-             * Is Active
-             * @default true
+             * Display Name
+             * @description Optional display name for the user.
              */
-            is_active: boolean | null;
-            /**
-             * Is Superuser
-             * @default false
-             */
-            is_superuser: boolean | null;
-            /**
-             * Is Verified
-             * @default false
-             */
-            is_verified: boolean | null;
-            /** Display Name */
             display_name?: string | null;
         };
         /**
@@ -3840,6 +3848,33 @@ export type components = {
              * @description Optional processing pause state for the workspace.
              */
             processing_paused?: boolean | null;
+        };
+        /** UserCreate */
+        ade_api__core__auth__users__UserCreate: {
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+            /** Password */
+            password: string;
+            /**
+             * Is Active
+             * @default true
+             */
+            is_active: boolean | null;
+            /**
+             * Is Superuser
+             * @default false
+             */
+            is_superuser: boolean | null;
+            /**
+             * Is Verified
+             * @default false
+             */
+            is_verified: boolean | null;
+            /** Display Name */
+            display_name?: string | null;
         };
         ProblemDetailsErrorItem: {
             path?: string | null;
@@ -4248,7 +4283,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["UserCreate"];
+                "application/json": components["schemas"]["ade_api__core__auth__users__UserCreate"];
             };
         };
         responses: {
@@ -4358,6 +4393,73 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuthProviderListResponse"];
+                };
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
+    list_api_keys_api_v1_apikeys_get: {
+        parameters: {
+            query?: {
+                /** @description Optional user identifier filter. */
+                userId?: string | null;
+                /** @description Items per page (max 200) */
+                limit?: number;
+                /** @description Opaque cursor token for pagination. */
+                cursor?: string | null;
+                /** @description JSON array of {id, desc}. */
+                sort?: string | null;
+                /** @description URL-encoded JSON array of filter objects. */
+                filters?: string | null;
+                /** @description Logical operator to join filters (and/or). */
+                joinOperator?: components["schemas"]["FilterJoinOperator"];
+                /** @description Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored. */
+                q?: string | null;
+                /** @description Include totalCount in the response. */
+                includeTotal?: boolean;
+                /** @description Include facet counts in the response. */
+                includeFacets?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiKeyPage"];
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Requires api_keys.read_all global permission. */
+            403: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
             default: components["responses"]["ProblemDetails"];
@@ -4888,6 +4990,68 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["UserPage"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
+    create_user_api_v1_users_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-CSRF-Token"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserOut"];
+                };
+            };
+            /** @description Authentication required to create users. */
+            401: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Global users.manage_all permission required. */
+            403: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email already in use. */
+            409: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
## Summary
- launch first-class organization settings admin UX at `/organization/settings/*`
- add admin data-layer and hooks for users, roles, API keys, SSO, and safe mode
- add backend endpoints/permission tightening needed for Stage 1 org settings
- regenerate OpenAPI + frontend generated types for Stage 1 contracts

## Included API/Contract changes (Stage 1)
- `POST /api/v1/users`
- `GET /api/v1/apikeys`
- tightened permission on `GET /api/v1/system/safemode`

## Explicitly excluded from this PR
- `/api/v1/admin/auth/policy`
- `/api/v1/me/password/change`
- `/api/v1/users/{userId}/password/reset`
- break-glass/enforced-SSO lifecycle work

## Validation run locally
- `cd backend && uv run ade api test`
- `cd backend && uv run ade web lint`
- `cd backend && uv run ade web test`
- `cd backend && uv run ade test`

All commands passed.
