### PR TITLE
feat: simplify workspace run streaming and publish UX

### DIFF
--- a/backend/src/ade_api/features/runs/__init__.py
+++ b/backend/src/ade_api/features/runs/__init__.py
@@ -4,7 +4,6 @@ from ade_db.models import Run, RunStatus
 
 from .schemas import (
     RunCreateOptions,
-    RunCreateRequest,
     RunResource,
 )
 from .service import RunsService
@@ -13,7 +12,6 @@ __all__ = [
     "Run",
     "RunStatus",
     "RunCreateOptions",
-    "RunCreateRequest",
     "RunResource",
     "RunsService",
 ]

--- a/backend/src/ade_api/features/runs/schemas.py
+++ b/backend/src/ade_api/features/runs/schemas.py
@@ -7,8 +7,8 @@ from typing import Literal
 
 from pydantic import Field, model_validator
 
-from ade_api.common.ids import UUIDStr
 from ade_api.common.cursor_listing import CursorPage
+from ade_api.common.ids import UUIDStr
 from ade_api.common.schema import BaseSchema
 from ade_db.models import RunOperation, RunStatus
 
@@ -17,12 +17,10 @@ RunLogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
 
 __all__ = [
     "RunBatchCreateOptions",
-    "RunBatchCreateRequest",
     "RunWorkspaceBatchCreateRequest",
     "RunBatchCreateResponse",
     "RunCreateOptionsBase",
     "RunCreateOptions",
-    "RunCreateRequest",
     "RunWorkspaceCreateRequest",
     "RunInput",
     "RunMetricsResource",
@@ -73,13 +71,6 @@ class RunCreateOptions(RunCreateOptionsBase):
         description="Document identifier to ingest.",
     )
 
-
-class RunCreateRequest(BaseSchema):
-    """Payload accepted by the run creation endpoint."""
-
-    options: RunCreateOptions = Field(default_factory=RunCreateOptions)
-
-
 class RunWorkspaceCreateRequest(BaseSchema):
     """Payload accepted by the workspace run creation endpoint."""
 
@@ -113,17 +104,6 @@ class RunBatchCreateOptions(BaseSchema):
     )
 
 
-class RunBatchCreateRequest(BaseSchema):
-    """Payload accepted by the batch run creation endpoint."""
-
-    document_ids: list[UUIDStr] = Field(
-        ...,
-        min_length=1,
-        description="Documents to enqueue as individual runs (all-or-nothing).",
-    )
-    options: RunBatchCreateOptions = Field(default_factory=RunBatchCreateOptions)
-
-
 class RunWorkspaceBatchCreateRequest(BaseSchema):
     """Payload accepted by the workspace batch run creation endpoint."""
 
@@ -151,10 +131,7 @@ class RunLinks(BaseSchema):
     self: str
     events_stream: str
     events_download: str
-    logs: str
-    input: str
     input_download: str
-    output: str
     output_download: str
     output_metadata: str
 
@@ -284,7 +261,6 @@ class RunResource(BaseSchema):
     input: RunInput = Field(default_factory=RunInput)
     output: RunOutput = Field(default_factory=RunOutput)
     links: RunLinks
-    events_download_url: str | None = None
 
 
 class RunPage(CursorPage[RunResource]):

--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -8271,114 +8271,6 @@
         ]
       }
     },
-    "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/publish": {
-      "post": {
-        "tags": [
-          "configurations"
-        ],
-        "summary": "Start a publish run for a draft configuration",
-        "operationId": "publish_configuration_endpoint_api_v1_workspaces__workspaceId__configurations__configurationId__publish_post",
-        "parameters": [
-          {
-            "name": "workspaceId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "Workspace identifier",
-              "title": "Workspaceid"
-            },
-            "description": "Workspace identifier"
-          },
-          {
-            "name": "configurationId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "Configuration identifier",
-              "title": "Configurationid"
-            },
-            "description": "Configuration identifier"
-          },
-          {
-            "name": "X-CSRF-Token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Csrf-Token"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "null",
-                "description": "Make the configuration active (archives any existing active configuration).",
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RunResource"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "default": {
-            "$ref": "#/components/responses/ProblemDetails"
-          }
-        },
-        "security": [
-          {
-            "SessionCookie": []
-          },
-          {
-            "HTTPBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/archive": {
       "post": {
         "tags": [
@@ -9665,398 +9557,6 @@
         ]
       }
     },
-    "/api/v1/configurations/{configurationId}/runs": {
-      "post": {
-        "tags": [
-          "runs"
-        ],
-        "summary": "Create Run Endpoint",
-        "description": "Create a run for ``configuration_id`` and enqueue execution.",
-        "operationId": "create_run_endpoint_api_v1_configurations__configurationId__runs_post",
-        "parameters": [
-          {
-            "name": "configurationId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "Configuration identifier",
-              "title": "Configurationid"
-            },
-            "description": "Configuration identifier"
-          },
-          {
-            "name": "X-CSRF-Token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Csrf-Token"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RunCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RunResource"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "default": {
-            "$ref": "#/components/responses/ProblemDetails"
-          }
-        },
-        "security": [
-          {
-            "SessionCookie": []
-          },
-          {
-            "HTTPBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      },
-      "get": {
-        "tags": [
-          "runs"
-        ],
-        "summary": "List Configuration Runs Endpoint",
-        "operationId": "list_configuration_runs_endpoint_api_v1_configurations__configurationId__runs_get",
-        "parameters": [
-          {
-            "name": "configurationId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "Configuration identifier",
-              "title": "Configurationid"
-            },
-            "description": "Configuration identifier"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "description": "Items per page (max 200)",
-              "default": 50,
-              "title": "Limit"
-            },
-            "description": "Items per page (max 200)"
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Opaque cursor token for pagination.",
-              "title": "Cursor"
-            },
-            "description": "Opaque cursor token for pagination."
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "JSON array of {id, desc}.",
-              "title": "Sort"
-            },
-            "description": "JSON array of {id, desc}."
-          },
-          {
-            "name": "filters",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
-              "title": "Filters"
-            },
-            "description": "URL-encoded JSON array of filter objects."
-          },
-          {
-            "name": "joinOperator",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/FilterJoinOperator",
-              "description": "Logical operator to join filters (and/or).",
-              "default": "and"
-            },
-            "description": "Logical operator to join filters (and/or)."
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
-              "title": "Q"
-            },
-            "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
-          },
-          {
-            "name": "includeTotal",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Include totalCount in the response.",
-              "default": false,
-              "title": "Includetotal"
-            },
-            "description": "Include totalCount in the response."
-          },
-          {
-            "name": "includeFacets",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Include facet counts in the response.",
-              "default": false,
-              "title": "Includefacets"
-            },
-            "description": "Include facet counts in the response."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RunPage"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "default": {
-            "$ref": "#/components/responses/ProblemDetails"
-          }
-        },
-        "security": [
-          {
-            "SessionCookie": []
-          },
-          {
-            "HTTPBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/configurations/{configurationId}/runs/batch": {
-      "post": {
-        "tags": [
-          "runs"
-        ],
-        "summary": "Create Runs Batch Endpoint",
-        "description": "Create multiple runs for ``configuration_id`` and enqueue execution.",
-        "operationId": "create_runs_batch_endpoint_api_v1_configurations__configurationId__runs_batch_post",
-        "parameters": [
-          {
-            "name": "configurationId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "Configuration identifier",
-              "title": "Configurationid"
-            },
-            "description": "Configuration identifier"
-          },
-          {
-            "name": "X-CSRF-Token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Csrf-Token"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RunBatchCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RunBatchCreateResponse"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "default": {
-            "$ref": "#/components/responses/ProblemDetails"
-          }
-        },
-        "security": [
-          {
-            "SessionCookie": []
-          },
-          {
-            "HTTPBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
     "/api/v1/workspaces/{workspaceId}/runs": {
       "post": {
         "tags": [
@@ -10449,14 +9949,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}": {
       "get": {
         "tags": [
           "runs"
         ],
-        "summary": "Get Run Endpoint",
-        "operationId": "get_run_endpoint_api_v1_runs__runId__get",
+        "summary": "Get Workspace Run Endpoint",
+        "operationId": "get_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -10518,14 +10030,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/cancel": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/cancel": {
       "post": {
         "tags": [
           "runs"
         ],
-        "summary": "Cancel Run Endpoint",
-        "operationId": "cancel_run_endpoint_api_v1_runs__runId__cancel_post",
+        "summary": "Cancel Workspace Run Endpoint",
+        "operationId": "cancel_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__cancel_post",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -10603,14 +10127,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/metrics": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/metrics": {
       "get": {
         "tags": [
           "runs"
         ],
-        "summary": "Get Run Metrics Endpoint",
-        "operationId": "get_run_metrics_endpoint_api_v1_runs__runId__metrics_get",
+        "summary": "Get Workspace Run Metrics Endpoint",
+        "operationId": "get_workspace_run_metrics_endpoint_api_v1_workspaces__workspaceId__runs__runId__metrics_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -10672,14 +10208,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/fields": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/fields": {
       "get": {
         "tags": [
           "runs"
         ],
-        "summary": "List Run Fields Endpoint",
-        "operationId": "list_run_fields_endpoint_api_v1_runs__runId__fields_get",
+        "summary": "List Workspace Run Fields Endpoint",
+        "operationId": "list_workspace_run_fields_endpoint_api_v1_workspaces__workspaceId__runs__runId__fields_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -10703,7 +10251,7 @@
                   "items": {
                     "$ref": "#/components/schemas/RunFieldResource"
                   },
-                  "title": "Response List Run Fields Endpoint Api V1 Runs  Runid  Fields Get"
+                  "title": "Response List Workspace Run Fields Endpoint Api V1 Workspaces  Workspaceid  Runs  Runid  Fields Get"
                 }
               }
             },
@@ -10745,14 +10293,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/columns": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/columns": {
       "get": {
         "tags": [
           "runs"
         ],
-        "summary": "List Run Columns Endpoint",
-        "operationId": "list_run_columns_endpoint_api_v1_runs__runId__columns_get",
+        "summary": "List Workspace Run Columns Endpoint",
+        "operationId": "list_workspace_run_columns_endpoint_api_v1_workspaces__workspaceId__runs__runId__columns_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -10862,7 +10422,7 @@
                   "items": {
                     "$ref": "#/components/schemas/RunColumnResource"
                   },
-                  "title": "Response List Run Columns Endpoint Api V1 Runs  Runid  Columns Get"
+                  "title": "Response List Workspace Run Columns Endpoint Api V1 Workspaces  Workspaceid  Runs  Runid  Columns Get"
                 }
               }
             },
@@ -10904,14 +10464,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/input": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/input": {
       "get": {
         "tags": [
           "runs"
         ],
         "summary": "Get run input metadata",
-        "operationId": "get_run_input_endpoint_api_v1_runs__runId__input_get",
+        "operationId": "get_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -10973,14 +10545,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/input/download": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/input/download": {
       "get": {
         "tags": [
           "runs"
         ],
         "summary": "Download run input file",
-        "operationId": "download_run_input_endpoint_api_v1_runs__runId__input_download_get",
+        "operationId": "download_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_download_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -11040,14 +10624,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/events/stream": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/events/stream": {
       "get": {
         "tags": [
           "runs"
         ],
         "summary": "Stream run events (SSE)",
-        "operationId": "stream_run_events_endpoint_api_v1_runs__runId__events_stream_get",
+        "operationId": "stream_workspace_run_events_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_stream_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -11065,13 +10661,19 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Byte offset cursor for resuming from a prior stream position.",
-              "default": 0,
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Byte offset cursor for resuming from a prior stream position. When Last-Event-ID is present, that value takes precedence.",
               "title": "Cursor"
             },
-            "description": "Byte offset cursor for resuming from a prior stream position."
+            "description": "Byte offset cursor for resuming from a prior stream position. When Last-Event-ID is present, that value takes precedence."
           }
         ],
         "responses": {
@@ -11128,14 +10730,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/events/download": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/events/download": {
       "get": {
         "tags": [
           "runs"
         ],
         "summary": "Download run events (NDJSON log)",
-        "operationId": "download_run_events_file_endpoint_api_v1_runs__runId__events_download_get",
+        "operationId": "download_workspace_run_events_file_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_download_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -11203,14 +10817,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/output": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/output": {
       "get": {
         "tags": [
           "runs"
         ],
         "summary": "Get run output metadata",
-        "operationId": "get_run_output_metadata_endpoint_api_v1_runs__runId__output_get",
+        "operationId": "get_workspace_run_output_metadata_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -11284,8 +10910,20 @@
           "runs"
         ],
         "summary": "Upload manual run output",
-        "operationId": "upload_run_output_endpoint_api_v1_runs__runId__output_post",
+        "operationId": "upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -11320,7 +10958,7 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Body_upload_run_output_endpoint_api_v1_runs__runId__output_post"
+                "$ref": "#/components/schemas/Body_upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post"
               }
             }
           }
@@ -11397,14 +11035,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/output/download": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/output/download": {
       "get": {
         "tags": [
           "runs"
         ],
         "summary": "Download run output file",
-        "operationId": "download_run_output_endpoint_api_v1_runs__runId__output_download_get",
+        "operationId": "download_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_download_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -11480,14 +11130,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/output/sheets": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/output/sheets": {
       "get": {
         "tags": [
           "runs"
         ],
         "summary": "List run output worksheets",
-        "operationId": "list_run_output_sheets_endpoint_api_v1_runs__runId__output_sheets_get",
+        "operationId": "list_workspace_run_output_sheets_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_sheets_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -11511,7 +11173,7 @@
                   "items": {
                     "$ref": "#/components/schemas/RunOutputSheet"
                   },
-                  "title": "Response List Run Output Sheets Endpoint Api V1 Runs  Runid  Output Sheets Get"
+                  "title": "Response List Workspace Run Output Sheets Endpoint Api V1 Workspaces  Workspaceid  Runs  Runid  Output Sheets Get"
                 }
               }
             },
@@ -11570,14 +11232,26 @@
         ]
       }
     },
-    "/api/v1/runs/{runId}/output/preview": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/output/preview": {
       "get": {
         "tags": [
           "runs"
         ],
         "summary": "Preview run output worksheet",
-        "operationId": "preview_run_output_endpoint_api_v1_runs__runId__output_preview_get",
+        "operationId": "preview_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_preview_get",
         "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
           {
             "name": "runId",
             "in": "path",
@@ -12957,7 +12631,7 @@
         ],
         "title": "Body_upload_document_version_api_v1_workspaces__workspaceId__documents__documentId__versions_post"
       },
-      "Body_upload_run_output_endpoint_api_v1_runs__runId__output_post": {
+      "Body_upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post": {
         "properties": {
           "file": {
             "type": "string",
@@ -12969,7 +12643,7 @@
         "required": [
           "file"
         ],
-        "title": "Body_upload_run_output_endpoint_api_v1_runs__runId__output_post"
+        "title": "Body_upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post"
       },
       "ConfigSourceClone": {
         "properties": {
@@ -15410,31 +15084,6 @@
         "title": "RunBatchCreateOptions",
         "description": "Execution toggles for batch ADE runs (per-document input)."
       },
-      "RunBatchCreateRequest": {
-        "properties": {
-          "document_ids": {
-            "items": {
-              "type": "string",
-              "format": "uuid",
-              "description": "UUIDv7 (RFC 9562) generated in the application layer."
-            },
-            "type": "array",
-            "minItems": 1,
-            "title": "Document Ids",
-            "description": "Documents to enqueue as individual runs (all-or-nothing)."
-          },
-          "options": {
-            "$ref": "#/components/schemas/RunBatchCreateOptions"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "document_ids"
-        ],
-        "title": "RunBatchCreateRequest",
-        "description": "Payload accepted by the batch run creation endpoint."
-      },
       "RunBatchCreateResponse": {
         "properties": {
           "runs": {
@@ -15573,91 +15222,6 @@
         "title": "RunColumnResource",
         "description": "Detected column details for a run table."
       },
-      "RunCreateOptions": {
-        "properties": {
-          "operation": {
-            "$ref": "#/components/schemas/RunOperation",
-            "default": "process"
-          },
-          "dry_run": {
-            "type": "boolean",
-            "title": "Dry Run",
-            "default": false
-          },
-          "log_level": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DEBUG",
-                  "INFO",
-                  "WARNING",
-                  "ERROR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Log Level",
-            "description": "Engine log level passed as --log-level to ade_engine."
-          },
-          "input_sheet_names": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Input Sheet Names",
-            "description": "Optional worksheet names to ingest when processing XLSX files."
-          },
-          "active_sheet_only": {
-            "type": "boolean",
-            "title": "Active Sheet Only",
-            "description": "If true, process only the active worksheet when ingesting XLSX files.",
-            "default": false
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Metadata",
-            "description": "Opaque metadata to propagate with run telemetry."
-          },
-          "input_document_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid",
-                "description": "UUIDv7 (RFC 9562) generated in the application layer."
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Input Document Id",
-            "description": "Document identifier to ingest."
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "title": "RunCreateOptions",
-        "description": "Execution toggles for a single ADE run."
-      },
       "RunCreateOptionsBase": {
         "properties": {
           "operation": {
@@ -15728,17 +15292,6 @@
         "type": "object",
         "title": "RunCreateOptionsBase",
         "description": "Optional execution toggles for ADE runs."
-      },
-      "RunCreateRequest": {
-        "properties": {
-          "options": {
-            "$ref": "#/components/schemas/RunCreateOptions"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "title": "RunCreateRequest",
-        "description": "Payload accepted by the run creation endpoint."
       },
       "RunFieldResource": {
         "properties": {
@@ -15931,21 +15484,9 @@
             "type": "string",
             "title": "Events Download"
           },
-          "logs": {
-            "type": "string",
-            "title": "Logs"
-          },
-          "input": {
-            "type": "string",
-            "title": "Input"
-          },
           "input_download": {
             "type": "string",
             "title": "Input Download"
-          },
-          "output": {
-            "type": "string",
-            "title": "Output"
           },
           "output_download": {
             "type": "string",
@@ -15962,10 +15503,7 @@
           "self",
           "events_stream",
           "events_download",
-          "logs",
-          "input",
           "input_download",
-          "output",
           "output_download",
           "output_metadata"
         ],
@@ -16533,17 +16071,6 @@
           },
           "links": {
             "$ref": "#/components/schemas/RunLinks"
-          },
-          "events_download_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Events Download Url"
           }
         },
         "additionalProperties": false,
@@ -17956,7 +17483,7 @@
   },
   "servers": [
     {
-      "url": "http://127.0.0.1:30685"
+      "url": "http://127.0.0.1:30440"
     }
   ],
   "security": [

--- a/backend/tests/api/integration/configs/test_configurations_validate.py
+++ b/backend/tests/api/integration/configs/test_configurations_validate.py
@@ -1,4 +1,4 @@
-"""Configuration publish endpoint validation contract tests."""
+"""Configuration publish-run validation contract tests."""
 
 from __future__ import annotations
 
@@ -26,11 +26,14 @@ async def test_publish_does_not_require_prior_validation_digest(
     )
 
     response = await async_client.post(
-        f"/api/v1/workspaces/{workspace_id}/configurations/{record['id']}/publish",
+        f"/api/v1/workspaces/{workspace_id}/runs",
         headers=headers,
-        json=None,
+        json={
+            "configuration_id": record["id"],
+            "options": {"operation": "publish"},
+        },
     )
-    assert response.status_code == 202, response.text
+    assert response.status_code == 201, response.text
     payload = response.json()
     assert payload["operation"] == "publish"
 
@@ -45,9 +48,12 @@ async def test_publish_missing_config_returns_not_found(
     random_id = str(generate_uuid7())
 
     response = await async_client.post(
-        f"/api/v1/workspaces/{workspace_id}/configurations/{random_id}/publish",
+        f"/api/v1/workspaces/{workspace_id}/runs",
         headers=headers,
-        json=None,
+        json={
+            "configuration_id": random_id,
+            "options": {"operation": "publish"},
+        },
     )
     assert response.status_code == 404
-    assert response.json()["detail"] == "configuration_not_found"
+    assert random_id in str(response.json().get("detail", ""))

--- a/backend/tests/api/integration/runs/test_run_events_stream.py
+++ b/backend/tests/api/integration/runs/test_run_events_stream.py
@@ -1,21 +1,29 @@
 from __future__ import annotations
 
-import anyio
 import io
 
+import anyio
 import pytest
 
 from ade_api.common.time import utc_now
-from ade_storage import build_storage_adapter
-from ade_db.models import RunStatus
 from ade_api.settings import Settings
-
-from tests.api.integration.runs.helpers import auth_headers, make_configuration, make_document, make_run
+from ade_db.models import Run, RunStatus
+from ade_storage import build_storage_adapter
+from tests.api.integration.runs.helpers import (
+    auth_headers,
+    make_configuration,
+    make_document,
+    make_run,
+)
 
 pytestmark = pytest.mark.asyncio
 
 
-async def test_run_events_stream_endpoint_returns_live_sse(
+def _join_non_empty(lines: list[str]) -> str:
+    return "\n".join(line for line in lines if line)
+
+
+async def test_run_events_stream_endpoint_returns_ready_message_and_end(
     async_client,
     seed_identity,
     db_session,
@@ -45,31 +53,29 @@ async def test_run_events_stream_endpoint_returns_live_sse(
 
     events_blob_name = f"{workspace_id}/runs/{run.id}/logs/events.ndjson"
     events_payload = (
-        '{"timestamp":"2026-01-01T00:00:00Z","event":"run.start","message":"start","data":{}}\n'
-        '{"timestamp":"2026-01-01T00:00:01Z","event":"run.complete","message":"done","data":{"status":"succeeded"}}\n'
-    ).encode("utf-8")
+        b'{"timestamp":"2026-01-01T00:00:00Z","event":"run.start","message":"start","data":{}}\n'
+        b'{"timestamp":"2026-01-01T00:00:01Z","event":"run.complete","message":"done","data":{"status":"succeeded"}}\n'
+    )
     storage = build_storage_adapter(settings)
     storage.write(events_blob_name, io.BytesIO(events_payload))
 
     headers = await auth_headers(async_client, seed_identity.workspace_owner)
-    async with async_client.stream(
-        "GET",
-        f"/api/v1/runs/{run.id}/events/stream",
-        headers=headers,
-    ) as response:
-        assert response.status_code == 200
-        lines: list[str] = []
-        async for line in response.aiter_lines():
-            if not line:
-                continue
-            lines.append(line)
-            if line == "event: run.complete":
-                break
+    with anyio.fail_after(5):
+        async with async_client.stream(
+            "GET",
+            f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/events/stream",
+            headers=headers,
+        ) as response:
+            assert response.status_code == 200
+            lines = [line async for line in response.aiter_lines() if line]
 
-    joined = "\n".join(lines)
-    assert "event: run.start" in joined
-    assert "event: run.complete" in joined
-    assert "id: " in joined
+    joined = _join_non_empty(lines)
+    assert "event: ready" in joined
+    assert "event: message" in joined
+    assert "event: end" in joined
+    assert "event: run.start" not in joined
+    assert '"event":"run.start"' in joined
+    assert '"reason":"run_complete"' in joined
 
 
 async def test_run_events_stream_endpoint_honors_cursor_offset(
@@ -100,7 +106,10 @@ async def test_run_events_stream_endpoint_honors_cursor_offset(
     db_session.add(run)
     await anyio.to_thread.run_sync(db_session.commit)
 
-    first_line = '{"timestamp":"2026-01-01T00:00:00Z","event":"run.start","message":"start","data":{}}\n'
+    first_line = (
+        '{"timestamp":"2026-01-01T00:00:00Z","event":"run.start",'
+        '"message":"start","data":{}}\n'
+    )
     second_line = (
         '{"timestamp":"2026-01-01T00:00:01Z","event":"run.complete","message":"done",'
         '"data":{"status":"succeeded"}}\n'
@@ -113,27 +122,84 @@ async def test_run_events_stream_endpoint_honors_cursor_offset(
     storage.write(events_blob_name, io.BytesIO(events_payload))
 
     headers = await auth_headers(async_client, seed_identity.workspace_owner)
-    async with async_client.stream(
-        "GET",
-        f"/api/v1/runs/{run.id}/events/stream",
-        headers=headers,
-        params={"cursor": cursor_offset},
-    ) as response:
-        assert response.status_code == 200
-        lines: list[str] = []
-        async for line in response.aiter_lines():
-            if not line:
-                continue
-            lines.append(line)
-            if line == "event: run.complete":
-                break
+    with anyio.fail_after(5):
+        async with async_client.stream(
+            "GET",
+            f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/events/stream",
+            headers=headers,
+            params={"cursor": cursor_offset},
+        ) as response:
+            assert response.status_code == 200
+            lines = [line async for line in response.aiter_lines() if line]
 
-    joined = "\n".join(lines)
-    assert "event: run.start" not in joined
-    assert "event: run.complete" in joined
+    joined = _join_non_empty(lines)
+    assert "event: ready" in joined
+    assert '"event":"run.start"' not in joined
+    assert '"event":"run.complete"' in joined
 
 
-async def test_run_events_stream_endpoint_exits_for_cancelled_run_without_logs(
+async def test_run_events_stream_endpoint_prefers_last_event_id_over_query_cursor(
+    async_client,
+    seed_identity,
+    db_session,
+    settings: Settings,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    configuration = make_configuration(
+        workspace_id=workspace_id,
+        name="SSE Header Cursor Config",
+    )
+    db_session.add(configuration)
+    await anyio.to_thread.run_sync(db_session.flush)
+
+    document = make_document(workspace_id=workspace_id, filename="input.csv")
+    db_session.add(document)
+    await anyio.to_thread.run_sync(db_session.flush)
+
+    run = make_run(
+        workspace_id=workspace_id,
+        configuration_id=configuration.id,
+        file_version_id=document.current_version_id,
+        status=RunStatus.SUCCEEDED,
+    )
+    run.completed_at = utc_now()
+    db_session.add(run)
+    await anyio.to_thread.run_sync(db_session.commit)
+
+    first_line = (
+        '{"timestamp":"2026-01-01T00:00:00Z","event":"run.start",'
+        '"message":"start","data":{}}\n'
+    )
+    second_line = (
+        '{"timestamp":"2026-01-01T00:00:01Z","event":"run.complete","message":"done",'
+        '"data":{"status":"succeeded"}}\n'
+    )
+    events_payload = (first_line + second_line).encode("utf-8")
+    header_cursor = len(first_line.encode("utf-8"))
+
+    events_blob_name = f"{workspace_id}/runs/{run.id}/logs/events.ndjson"
+    storage = build_storage_adapter(settings)
+    storage.write(events_blob_name, io.BytesIO(events_payload))
+
+    headers = await auth_headers(async_client, seed_identity.workspace_owner)
+    headers["Last-Event-ID"] = str(header_cursor)
+
+    with anyio.fail_after(5):
+        async with async_client.stream(
+            "GET",
+            f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/events/stream",
+            headers=headers,
+            params={"cursor": 0},
+        ) as response:
+            assert response.status_code == 200
+            lines = [line async for line in response.aiter_lines() if line]
+
+    joined = _join_non_empty(lines)
+    assert '"event":"run.start"' not in joined
+    assert '"event":"run.complete"' in joined
+
+
+async def test_run_events_stream_endpoint_emits_terminal_end_for_cancelled_run_without_logs(
     async_client,
     seed_identity,
     db_session,
@@ -162,13 +228,137 @@ async def test_run_events_stream_endpoint_exits_for_cancelled_run_without_logs(
     await anyio.to_thread.run_sync(db_session.commit)
 
     headers = await auth_headers(async_client, seed_identity.workspace_owner)
-    with anyio.fail_after(5):
+    with anyio.fail_after(10):
         async with async_client.stream(
             "GET",
-            f"/api/v1/runs/{run.id}/events/stream",
+            f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/events/stream",
             headers=headers,
         ) as response:
             assert response.status_code == 200
             lines = [line async for line in response.aiter_lines() if line]
 
-    assert lines == []
+    joined = _join_non_empty(lines)
+    assert "event: ready" in joined
+    assert "event: end" in joined
+    assert "event: run.complete" not in joined
+    assert '"reason":"terminal_status"' in joined
+    assert '"status":"cancelled"' in joined
+
+
+async def test_run_events_stream_endpoint_emits_terminal_end_after_status_transition(
+    async_client,
+    seed_identity,
+    db_session,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    configuration = make_configuration(
+        workspace_id=workspace_id,
+        name="SSE Transition Config",
+    )
+    db_session.add(configuration)
+    await anyio.to_thread.run_sync(db_session.flush)
+
+    document = make_document(workspace_id=workspace_id, filename="input.csv")
+    db_session.add(document)
+    await anyio.to_thread.run_sync(db_session.flush)
+
+    run = make_run(
+        workspace_id=workspace_id,
+        configuration_id=configuration.id,
+        file_version_id=document.current_version_id,
+        status=RunStatus.RUNNING,
+    )
+    db_session.add(run)
+    await anyio.to_thread.run_sync(db_session.commit)
+
+    async def _mark_terminal() -> None:
+        await anyio.sleep(0.5)
+
+        def _commit_terminal() -> None:
+            persisted = db_session.get(Run, run.id)
+            assert persisted is not None
+            persisted.status = RunStatus.CANCELLED
+            persisted.completed_at = utc_now()
+            persisted.error_message = "Run cancelled by user"
+            db_session.commit()
+
+        await anyio.to_thread.run_sync(_commit_terminal)
+
+    headers = await auth_headers(async_client, seed_identity.workspace_owner)
+    with anyio.fail_after(12):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_mark_terminal)
+            async with async_client.stream(
+                "GET",
+                f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/events/stream",
+                headers=headers,
+            ) as response:
+                assert response.status_code == 200
+                lines = [line async for line in response.aiter_lines() if line]
+
+    joined = _join_non_empty(lines)
+    assert "event: ready" in joined
+    assert "event: end" in joined
+    assert '"status":"cancelled"' in joined
+
+
+async def test_run_events_stream_requires_workspace_permission(
+    async_client,
+    seed_identity,
+    db_session,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    configuration = make_configuration(workspace_id=workspace_id, name="SSE RBAC Config")
+    db_session.add(configuration)
+    await anyio.to_thread.run_sync(db_session.flush)
+
+    document = make_document(workspace_id=workspace_id, filename="input.csv")
+    db_session.add(document)
+    await anyio.to_thread.run_sync(db_session.flush)
+
+    run = make_run(
+        workspace_id=workspace_id,
+        configuration_id=configuration.id,
+        file_version_id=document.current_version_id,
+        status=RunStatus.RUNNING,
+    )
+    db_session.add(run)
+    await anyio.to_thread.run_sync(db_session.commit)
+
+    headers = await auth_headers(async_client, seed_identity.orphan)
+    response = await async_client.get(
+        f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/events/stream",
+        headers=headers,
+    )
+    assert response.status_code == 403
+
+
+async def test_run_events_stream_returns_not_found_when_workspace_does_not_match_run(
+    async_client,
+    seed_identity,
+    db_session,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    configuration = make_configuration(workspace_id=workspace_id, name="SSE Scope Config")
+    db_session.add(configuration)
+    await anyio.to_thread.run_sync(db_session.flush)
+
+    document = make_document(workspace_id=workspace_id, filename="input.csv")
+    db_session.add(document)
+    await anyio.to_thread.run_sync(db_session.flush)
+
+    run = make_run(
+        workspace_id=workspace_id,
+        configuration_id=configuration.id,
+        file_version_id=document.current_version_id,
+        status=RunStatus.RUNNING,
+    )
+    db_session.add(run)
+    await anyio.to_thread.run_sync(db_session.commit)
+
+    headers = await auth_headers(async_client, seed_identity.admin)
+    response = await async_client.get(
+        f"/api/v1/workspaces/{seed_identity.secondary_workspace_id}/runs/{run.id}/events/stream",
+        headers=headers,
+    )
+    assert response.status_code == 404

--- a/backend/tests/api/integration/runs/test_runs_cancel.py
+++ b/backend/tests/api/integration/runs/test_runs_cancel.py
@@ -5,7 +5,6 @@ import pytest
 from sqlalchemy import select
 
 from ade_db.models import Run, RunStatus
-
 from tests.api.integration.runs.helpers import (
     auth_headers,
     make_configuration,
@@ -41,7 +40,7 @@ async def test_cancel_queued_run(
 
     headers = await auth_headers(async_client, seed_identity.workspace_owner)
     response = await async_client.post(
-        f"/api/v1/runs/{run.id}/cancel",
+        f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/cancel",
         headers=headers,
     )
     assert response.status_code == 200, response.text
@@ -90,7 +89,7 @@ async def test_cancel_running_run(
 
     headers = await auth_headers(async_client, seed_identity.workspace_owner)
     response = await async_client.post(
-        f"/api/v1/runs/{run.id}/cancel",
+        f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/cancel",
         headers=headers,
     )
     assert response.status_code == 200, response.text
@@ -138,7 +137,7 @@ async def test_cancel_terminal_run_conflicts(
 
     headers = await auth_headers(async_client, seed_identity.workspace_owner)
     response = await async_client.post(
-        f"/api/v1/runs/{run.id}/cancel",
+        f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/cancel",
         headers=headers,
     )
     assert response.status_code == 409, response.text
@@ -169,7 +168,7 @@ async def test_cancel_already_cancelled_is_idempotent(
 
     headers = await auth_headers(async_client, seed_identity.workspace_owner)
     response = await async_client.post(
-        f"/api/v1/runs/{run.id}/cancel",
+        f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/cancel",
         headers=headers,
     )
     assert response.status_code == 200, response.text

--- a/backend/tests/api/integration/runs/test_runs_output.py
+++ b/backend/tests/api/integration/runs/test_runs_output.py
@@ -1,14 +1,19 @@
-import anyio
 import io
+
+import anyio
 import pytest
 
-from ade_api.common.time import utc_now
 from ade_api.common.ids import generate_uuid7
-from ade_storage import build_storage_adapter
-from ade_db.models import File, FileKind, FileVersion, FileVersionOrigin, RunStatus
+from ade_api.common.time import utc_now
 from ade_api.settings import Settings
-
-from tests.api.integration.runs.helpers import auth_headers, make_configuration, make_document, make_run
+from ade_db.models import File, FileKind, FileVersion, FileVersionOrigin, RunStatus
+from ade_storage import build_storage_adapter
+from tests.api.integration.runs.helpers import (
+    auth_headers,
+    make_configuration,
+    make_document,
+    make_run,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -81,14 +86,19 @@ async def test_run_output_endpoint_serves_file(
 
     headers = await auth_headers(async_client, seed_identity.workspace_owner)
 
-    metadata = await async_client.get(f"/api/v1/runs/{run.id}/output", headers=headers)
+    metadata = await async_client.get(
+        f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/output",
+        headers=headers,
+    )
     assert metadata.status_code == 200
     payload = metadata.json()
     assert payload["has_output"] is True
     assert payload["ready"] is True
     assert payload["filename"] == "normalized.xlsx"
     assert payload["fileVersionId"] == str(output_version.id)
-    assert payload["download_url"].endswith(f"/api/v1/runs/{run.id}/output/download")
+    assert payload["download_url"].endswith(
+        f"/api/v1/workspaces/{workspace_id}/runs/{run.id}/output/download"
+    )
 
     download = await async_client.get(payload["download_url"], headers=headers)
     assert download.status_code == 200

--- a/docs/how-to/operate-runs.md
+++ b/docs/how-to/operate-runs.md
@@ -35,10 +35,11 @@ docker compose logs -f worker
 
 ## Useful Run Endpoints
 
-- `GET /api/v1/runs/{runId}`
-- `GET /api/v1/runs/{runId}/events/download`
-- `GET /api/v1/runs/{runId}/output`
-- `GET /api/v1/runs/{runId}/output/download`
+- `GET /api/v1/workspaces/{workspaceId}/runs/{runId}`
+- `GET /api/v1/workspaces/{workspaceId}/runs/{runId}/events/stream`
+- `GET /api/v1/workspaces/{workspaceId}/runs/{runId}/events/download`
+- `GET /api/v1/workspaces/{workspaceId}/runs/{runId}/output`
+- `GET /api/v1/workspaces/{workspaceId}/runs/{runId}/output/download`
 
 ## Event Log Location
 

--- a/frontend/src/api/configurations/api.ts
+++ b/frontend/src/api/configurations/api.ts
@@ -11,8 +11,7 @@ import type {
   FileRenameResponse,
   FileWriteResponse,
 } from "@/types/configurations";
-import type { components, paths } from "@/types";
-type RunResource = components["schemas"]["RunResource"];
+import type { paths } from "@/types";
 
 type DeleteDirectoryQuery =
   paths["/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/directories/{directoryPath}"]["delete"]["parameters"]["query"];
@@ -71,20 +70,6 @@ export async function readConfiguration(
     },
   );
   return (data ?? null) as ConfigurationRecord | null;
-}
-
-export async function publishConfiguration(workspaceId: string, configId: string): Promise<RunResource> {
-  const { data } = await client.POST(
-    "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/publish",
-    {
-      params: { path: { workspaceId, configurationId: configId } },
-      body: null,
-    },
-  );
-  if (!data) {
-    throw new Error("Expected run payload.");
-  }
-  return data as RunResource;
 }
 
 export async function archiveConfiguration(workspaceId: string, configId: string): Promise<ConfigurationRecord> {

--- a/frontend/src/api/runs/stream.ts
+++ b/frontend/src/api/runs/stream.ts
@@ -1,0 +1,222 @@
+import type { RunStreamEvent } from "@/types/runs";
+
+export type RunStreamConnectionState = "connecting" | "streaming" | "reconnecting" | "completed" | "failed";
+
+export interface EventSourceRunStreamOptions {
+  readonly afterSequence?: number;
+  readonly signal?: AbortSignal;
+  readonly onConnectionStateChange?: (state: RunStreamConnectionState) => void;
+}
+
+type QueueItem =
+  | { readonly kind: "event"; readonly event: RunStreamEvent }
+  | { readonly kind: "complete" }
+  | { readonly kind: "aborted" }
+  | { readonly kind: "failed"; readonly error: Error };
+
+type EndPayload = {
+  readonly cursor?: number | string;
+};
+
+function createQueue<T>() {
+  const items: T[] = [];
+  const waiters: Array<(value: T) => void> = [];
+
+  return {
+    push(value: T) {
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter(value);
+        return;
+      }
+      items.push(value);
+    },
+    async next(): Promise<T> {
+      const item = items.shift();
+      if (item !== undefined) {
+        return item;
+      }
+      return await new Promise<T>((resolve) => {
+        waiters.push(resolve);
+      });
+    },
+  };
+}
+
+function normalizeCursor(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.floor(value));
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : 0;
+  }
+  return 0;
+}
+
+function appendCursor(url: string, cursor: number): string {
+  if (!Number.isFinite(cursor) || cursor <= 0) {
+    return url;
+  }
+  const hasQuery = url.includes("?");
+  return `${url}${hasQuery ? "&" : "?"}cursor=${Math.floor(cursor)}`;
+}
+
+function parseRunEvent(rawLine: string): RunStreamEvent | null {
+  const trimmed = rawLine.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as RunStreamEvent;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    if (typeof parsed.event !== "string" || parsed.event.trim().length === 0) {
+      return null;
+    }
+    if (!("timestamp" in parsed)) {
+      return null;
+    }
+    (parsed as Record<string, unknown>)._raw = trimmed;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function ensureEventSource(): typeof EventSource {
+  const ctor = globalThis.EventSource;
+  if (typeof ctor !== "function") {
+    throw new Error("EventSource is unavailable in this environment.");
+  }
+  return ctor;
+}
+
+export async function* streamRunEventsWithEventSource(
+  url: string,
+  options: EventSourceRunStreamOptions = {},
+): AsyncGenerator<RunStreamEvent> {
+  const queue = createQueue<QueueItem>();
+  let closed = false;
+  let cursor = normalizeCursor(options.afterSequence);
+
+  const EventSourceCtor = ensureEventSource();
+  options.onConnectionStateChange?.("connecting");
+  const source = new EventSourceCtor(appendCursor(url, cursor), {
+    withCredentials: true,
+  });
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    source.close();
+    options.signal?.removeEventListener("abort", onAbort);
+  };
+
+  const onAbort = () => {
+    queue.push({ kind: "aborted" });
+  };
+
+  const handleOpen = () => {
+    options.onConnectionStateChange?.("streaming");
+  };
+
+  const handleReady = (event: MessageEvent) => {
+    const eventCursor = normalizeCursor(event.lastEventId);
+    if (eventCursor > cursor) {
+      cursor = eventCursor;
+    }
+  };
+
+  const handleMessage = (event: MessageEvent) => {
+    if (typeof event.data !== "string") {
+      return;
+    }
+    const parsed = parseRunEvent(event.data);
+    if (!parsed) {
+      return;
+    }
+
+    const nextCursor = normalizeCursor(event.lastEventId);
+    if (nextCursor > cursor) {
+      cursor = nextCursor;
+    }
+
+    const withEventId =
+      nextCursor > 0 && (!parsed.event_id || !String(parsed.event_id).trim())
+        ? { ...parsed, event_id: String(nextCursor) }
+        : parsed;
+    queue.push({ kind: "event", event: withEventId });
+  };
+
+  const handleEnd = (event: MessageEvent) => {
+    if (typeof event.data === "string") {
+      try {
+        const payload = JSON.parse(event.data) as EndPayload;
+        const payloadCursor = normalizeCursor(payload?.cursor);
+        if (payloadCursor > cursor) {
+          cursor = payloadCursor;
+        }
+      } catch {
+        // Best-effort control payload parsing.
+      }
+    }
+
+    const nextCursor = normalizeCursor(event.lastEventId);
+    if (nextCursor > cursor) {
+      cursor = nextCursor;
+    }
+
+    options.onConnectionStateChange?.("completed");
+    queue.push({ kind: "complete" });
+  };
+
+  const handleError = () => {
+    if (closed) {
+      return;
+    }
+
+    if (source.readyState === EventSource.CONNECTING) {
+      options.onConnectionStateChange?.("reconnecting");
+      return;
+    }
+
+    options.onConnectionStateChange?.("failed");
+    queue.push({ kind: "failed", error: new Error("Run events stream disconnected.") });
+  };
+
+  source.addEventListener("open", handleOpen);
+  source.addEventListener("ready", handleReady);
+  source.addEventListener("message", handleMessage);
+  source.addEventListener("end", handleEnd);
+  source.addEventListener("error", handleError);
+
+  if (options.signal) {
+    if (options.signal.aborted) {
+      close();
+      throw new DOMException("Aborted", "AbortError");
+    }
+    options.signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  try {
+    while (true) {
+      const item = await queue.next();
+      if (item.kind === "event") {
+        yield item.event;
+        continue;
+      }
+      if (item.kind === "complete") {
+        return;
+      }
+      if (item.kind === "aborted") {
+        throw new DOMException("Aborted", "AbortError");
+      }
+      throw item.error;
+    }
+  } finally {
+    close();
+  }
+}

--- a/frontend/src/pages/Workspace/hooks/configurations/useConfigurationFiles.ts
+++ b/frontend/src/pages/Workspace/hooks/configurations/useConfigurationFiles.ts
@@ -69,7 +69,8 @@ export function useConfigurationFilesQuery({
         signal,
       }),
     enabled: enabled && workspaceId.length > 0 && configId.length > 0,
-    staleTime: 5_000,
+    staleTime: 0,
+    refetchOnMount: "always",
   });
 }
 

--- a/frontend/src/pages/Workspace/hooks/configurations/useConfigurationLifecycle.ts
+++ b/frontend/src/pages/Workspace/hooks/configurations/useConfigurationLifecycle.ts
@@ -1,22 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { archiveConfiguration, createConfiguration, publishConfiguration } from "@/api/configurations/api";
+import { archiveConfiguration, createConfiguration } from "@/api/configurations/api";
 import { configurationKeys } from "./keys";
 import type { ConfigurationRecord } from "@/types/configurations";
-import type { RunResource } from "@/types";
-
-export function usePublishConfigurationMutation(workspaceId: string) {
-  const queryClient = useQueryClient();
-
-  return useMutation<RunResource, Error, { configurationId: string }>({
-    mutationFn: ({ configurationId }) => publishConfiguration(workspaceId, configurationId),
-    async onSuccess() {
-      await queryClient.invalidateQueries({ queryKey: configurationKeys.root(workspaceId) });
-    },
-  });
-}
-
-export const useMakeActiveConfigurationMutation = usePublishConfigurationMutation;
 
 export function useArchiveConfigurationMutation(workspaceId: string) {
   const queryClient = useQueryClient();

--- a/frontend/src/pages/Workspace/hooks/configurations/useConfigurationsQuery.ts
+++ b/frontend/src/pages/Workspace/hooks/configurations/useConfigurationsQuery.ts
@@ -51,6 +51,7 @@ export function useConfigurationQuery({ workspaceId, configurationId, enabled = 
       return readConfiguration(workspaceId, configurationId, signal);
     },
     enabled: enabled && workspaceId.length > 0 && Boolean(configurationId),
-    staleTime: 10_000,
+    staleTime: 0,
+    refetchOnMount: "always",
   });
 }

--- a/frontend/src/pages/Workspace/sections/ConfigBuilder/detail/__tests__/ConfigurationDetailScreen.test.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigBuilder/detail/__tests__/ConfigurationDetailScreen.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ConfigurationDetailScreen from "../index";
+
+const navigateMock = vi.fn();
+
+type MockConfig = {
+  id: string;
+  display_name: string;
+  status: string;
+  updated_at: string;
+  activated_at?: string | null;
+};
+
+let mockConfig: MockConfig | null = {
+  id: "cfg-1",
+  display_name: "Config One",
+  status: "draft",
+  updated_at: "2026-02-07T10:00:00.000Z",
+  activated_at: null,
+};
+let mockConfigLoading = false;
+let mockConfigError = false;
+let mockConfigFetchedAfterMount = true;
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/pages/Workspace/context/WorkspaceContext", () => ({
+  useWorkspaceContext: () => ({
+    workspace: {
+      id: "ws-1",
+      name: "Workspace One",
+    },
+  }),
+}));
+
+vi.mock("@/providers/notifications", () => ({
+  useNotifications: () => ({
+    notifyToast: vi.fn(),
+  }),
+}));
+
+vi.mock("@/pages/Workspace/hooks/configurations", () => ({
+  useConfigurationQuery: () => ({
+    data: mockConfig,
+    isLoading: mockConfigLoading,
+    isError: mockConfigError,
+    isSuccess: !mockConfigLoading && !mockConfigError,
+    isFetchedAfterMount: mockConfigFetchedAfterMount,
+    refetch: vi.fn(),
+  }),
+  useConfigurationsQuery: () => ({
+    data: {
+      items: [
+        { id: "cfg-1", display_name: "Config One", status: "active" },
+        { id: "cfg-2", display_name: "Config Two", status: "draft" },
+      ],
+    },
+    refetch: vi.fn(),
+  }),
+  useArchiveConfigurationMutation: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+  useDuplicateConfigurationMutation: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("@/api/configurations/api", () => ({
+  exportConfiguration: vi.fn(),
+}));
+
+describe("ConfigurationDetailScreen", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    mockConfig = {
+      id: "cfg-1",
+      display_name: "Config One",
+      status: "draft",
+      updated_at: "2026-02-07T10:00:00.000Z",
+      activated_at: null,
+    };
+    mockConfigLoading = false;
+    mockConfigError = false;
+    mockConfigFetchedAfterMount = true;
+  });
+
+  it("waits for a fresh configuration snapshot before rendering status-driven actions", () => {
+    mockConfigFetchedAfterMount = false;
+    mockConfig = {
+      id: "cfg-1",
+      display_name: "Config One",
+      status: "draft",
+      updated_at: "2026-02-07T10:00:00.000Z",
+      activated_at: null,
+    };
+
+    render(<ConfigurationDetailScreen params={{ configId: "cfg-1" }} />);
+
+    expect(screen.getByText("Refreshing configuration")).toBeInTheDocument();
+  });
+
+  it("shows read-only guidance for active configurations", () => {
+    mockConfig = {
+      id: "cfg-1",
+      display_name: "Config One",
+      status: "active",
+      updated_at: "2026-02-07T10:00:00.000Z",
+      activated_at: "2026-02-07T10:01:00.000Z",
+    };
+
+    render(<ConfigurationDetailScreen params={{ configId: "cfg-1" }} />);
+
+    expect(screen.getByText("Read-only configuration")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Duplicate to edit" }).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/pages/Workspace/sections/ConfigBuilder/detail/index.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigBuilder/detail/index.tsx
@@ -34,6 +34,7 @@ export default function ConfigurationDetailScreen({ params }: ConfigurationDetai
   const lastSelectionStorage = useMemo(() => createLastSelectionStorage(workspace.id), [workspace.id]);
 
   const configQuery = useConfigurationQuery({ workspaceId: workspace.id, configurationId: configId });
+  const awaitingFreshConfigSnapshot = Boolean(configId) && !configQuery.isError && !configQuery.isFetchedAfterMount;
   const { refetch: refetchConfig } = configQuery;
   const configurationsQuery = useConfigurationsQuery({ workspaceId: workspace.id });
   const { refetch: refetchConfigurations } = configurationsQuery;
@@ -203,12 +204,12 @@ export default function ConfigurationDetailScreen({ params }: ConfigurationDetai
     );
   }
 
-  if (configQuery.isLoading) {
+  if (configQuery.isLoading || awaitingFreshConfigSnapshot) {
     return (
       <PageState
         variant="loading"
-        title="Loading configuration"
-        description="Fetching configuration details."
+        title="Refreshing configuration"
+        description="Checking the latest configuration status."
       />
     );
   }

--- a/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/__tests__/Workbench.publish-flow.test.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/__tests__/Workbench.publish-flow.test.tsx
@@ -1,0 +1,444 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RunCompletionInfo } from "../state/useRunSessionModel";
+import type { WorkbenchFileTab } from "../types";
+import { WorkbenchConsoleStore } from "../state/consoleStore";
+
+const invalidateQueriesMock = vi.fn();
+const navigateMock = vi.fn();
+
+let onRunCompleteCallback: ((info: RunCompletionInfo) => void) | undefined;
+const startRunMock = vi.fn(async () => ({ runId: "run-123", startedAt: "2026-02-07T10:00:00.000Z" }));
+let mockConfigStatus: "draft" | "active" | "archived" = "draft";
+let mockEditableCapability = true;
+let mockFilesFetchedAfterMount = true;
+let mockConfigFetchedAfterMount = true;
+
+const filesQueryRefetchMock = vi.fn(async () => ({
+  data: {
+    status: "active",
+    capabilities: { editable: false },
+  },
+}));
+const configurationsQueryRefetchMock = vi.fn(async () => ({ data: { items: [] } }));
+
+const baseTab: WorkbenchFileTab = {
+  id: "manifest.toml",
+  name: "manifest.toml",
+  initialContent: "name='demo'\n",
+  content: "name='demo'\n",
+  status: "ready",
+  etag: null,
+  error: null,
+  saving: false,
+  saveError: null,
+  lastSavedAt: null,
+  metadata: null,
+};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: invalidateQueriesMock,
+  }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("../state/useWorkbenchUrlState", () => ({
+  useWorkbenchUrlState: () => ({
+    fileId: "manifest.toml",
+    pane: "terminal",
+    console: "closed",
+    consoleExplicit: false,
+    setFileId: vi.fn(),
+    setPane: vi.fn(),
+    setConsole: vi.fn(),
+  }),
+}));
+
+vi.mock("@/pages/Workspace/hooks/configurations", () => ({
+  configurationKeys: {
+    files: (workspaceId: string, configId: string) => ["workspaces", workspaceId, "configurations", configId, "files"],
+    detail: (workspaceId: string, configId: string) => ["workspaces", workspaceId, "configurations", configId],
+    root: (workspaceId: string) => ["workspaces", workspaceId, "configurations"],
+    file: (workspaceId: string, configId: string, path: string) => [
+      "workspaces",
+      workspaceId,
+      "configurations",
+      configId,
+      "files",
+      path,
+    ],
+  },
+  useConfigurationFilesQuery: () => ({
+    data: {
+      status: mockConfigStatus,
+      fileset_hash: "fileset",
+      capabilities: { editable: mockEditableCapability },
+      entries: [],
+    },
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    isFetchedAfterMount: mockFilesFetchedAfterMount,
+    refetch: filesQueryRefetchMock,
+  }),
+  useConfigurationQuery: () => ({
+    data: {
+      id: "cfg-1",
+      display_name: "Config",
+      status: mockConfigStatus,
+      updated_at: "2026-02-07T10:00:00.000Z",
+    },
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    isFetchedAfterMount: mockConfigFetchedAfterMount,
+    refetch: vi.fn(),
+  }),
+  useConfigurationsQuery: () => ({
+    data: {
+      items: [
+        { id: "active-1", display_name: "Active Config", status: "active" },
+        { id: "draft-1", display_name: "Draft Config", status: "draft" },
+      ],
+    },
+    refetch: configurationsQueryRefetchMock,
+  }),
+  useDuplicateConfigurationMutation: () => ({
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+  }),
+  useReplaceConfigurationMutation: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useSaveConfigurationFileMutation: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock("../state/useWorkbenchFiles", () => ({
+  useWorkbenchFiles: () => ({
+    tabs: [baseTab],
+    activeTab: baseTab,
+    activeTabId: baseTab.id,
+    isDirty: false,
+    updateContent: vi.fn(),
+    replaceTabContent: vi.fn(),
+    beginSavingTab: vi.fn(),
+    completeSavingTab: vi.fn(),
+    failSavingTab: vi.fn(),
+    openFile: vi.fn(),
+    selectTab: vi.fn(),
+    closeTab: vi.fn(),
+    closeOtherTabs: vi.fn(),
+    closeTabsToRight: vi.fn(),
+    closeAllTabs: vi.fn(),
+    moveTab: vi.fn(),
+    reloadTab: vi.fn(),
+    pinTab: vi.fn(),
+    unpinTab: vi.fn(),
+    selectRecentTab: vi.fn(),
+  }),
+}));
+
+vi.mock("../state/useUnsavedChangesGuard", () => ({
+  useUnsavedChangesGuard: vi.fn(),
+}));
+
+vi.mock("../utils/tree", () => ({
+  createWorkbenchTreeFromListing: () => ({
+    id: "root",
+    name: "root",
+    kind: "folder",
+    children: [{ id: "manifest.toml", name: "manifest.toml", kind: "file" }],
+  }),
+  findFileNode: () => ({ id: "manifest.toml" }),
+  findFirstFile: () => ({ id: "manifest.toml" }),
+}));
+
+vi.mock("../utils/workbenchHelpers", () => ({
+  decodeFileContent: () => "",
+  describeError: () => "error",
+  formatRelative: () => "now",
+  formatWorkspaceLabel: () => "workspace",
+}));
+
+vi.mock("@/providers/theme", () => ({
+  useTheme: () => ({ resolvedMode: "light" }),
+  isDarkMode: () => false,
+}));
+
+vi.mock("@/providers/notifications", () => ({
+  useNotifications: () => ({
+    notifyBanner: vi.fn(),
+    dismissScope: vi.fn(),
+    notifyToast: vi.fn(),
+  }),
+}));
+
+vi.mock("@/api/configurations/api", () => ({
+  exportConfiguration: vi.fn(),
+  readConfigurationFileJson: vi.fn(),
+}));
+
+vi.mock("../components/BottomPanel", () => ({
+  BottomPanel: () => <div data-testid="bottom-panel" />,
+}));
+
+vi.mock("../components/EditorArea", () => ({
+  EditorArea: () => <div data-testid="editor-area" />,
+}));
+
+vi.mock("../components/RunExtractionDialog", () => ({
+  RunExtractionDialog: () => <div data-testid="run-extraction-dialog" />,
+}));
+
+vi.mock("../components/WorkbenchLayoutSync", () => ({
+  WorkbenchLayoutSync: () => null,
+}));
+
+vi.mock("../components/WorkbenchSidebar", () => ({
+  WorkbenchSidebar: () => <div data-testid="workbench-sidebar" />,
+}));
+
+vi.mock("../components/WorkbenchSidebarResizeHandle", () => ({
+  WorkbenchSidebarResizeHandle: () => <div data-testid="sidebar-resize-handle" />,
+}));
+
+vi.mock("../components/WorkbenchChrome", () => ({
+  WorkbenchChrome: ({
+    canPublish,
+    onPublish,
+    consoleToggleDisabled,
+  }: {
+    canPublish: boolean;
+    onPublish: () => void;
+    consoleToggleDisabled?: boolean;
+  }) => (
+    <div>
+      <button data-testid="chrome-publish" onClick={onPublish} disabled={!canPublish}>
+        Publish
+      </button>
+      <span data-testid="console-toggle-disabled">{consoleToggleDisabled ? "yes" : "no"}</span>
+    </div>
+  ),
+}));
+
+vi.mock("../components/PublishConfigurationDialog", () => ({
+  PublishConfigurationDialog: ({
+    open,
+    phase,
+    errorMessage,
+    onStartPublish,
+    onRetryPublish,
+    onDone,
+  }: {
+    open: boolean;
+    phase: string;
+    errorMessage?: string | null;
+    onStartPublish: () => void;
+    onRetryPublish: () => void;
+    onDone: () => void;
+  }) =>
+    open ? (
+      <div data-testid="publish-dialog" data-phase={phase}>
+        {errorMessage ? <p>{errorMessage}</p> : null}
+        <button onClick={onStartPublish}>Start publish</button>
+        <button onClick={onRetryPublish}>Retry publish</button>
+        <button onClick={onDone}>Done</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/context-menu-simple", () => ({
+  ContextMenu: () => null,
+}));
+
+vi.mock("@/components/ui/confirm-dialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("@/components/layout", () => ({
+  PageState: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../state/useRunSessionModel", () => ({
+  useRunSessionModel: (options: { onRunComplete?: (info: RunCompletionInfo) => void }) => {
+    onRunCompleteCallback = options.onRunComplete;
+    return {
+      runStatus: "idle",
+      runConnectionState: "connecting",
+      runMode: undefined,
+      runInProgress: false,
+      validation: { status: "idle", messages: [], lastRunAt: undefined, error: null, digest: null },
+      console: new WorkbenchConsoleStore(128),
+      latestRun: null,
+      clearConsole: vi.fn(),
+      startRun: startRunMock,
+    };
+  },
+}));
+
+import { Workbench } from "../Workbench";
+
+describe("Workbench publish flow", () => {
+  beforeEach(() => {
+    onRunCompleteCallback = undefined;
+    startRunMock.mockClear();
+    invalidateQueriesMock.mockClear();
+    filesQueryRefetchMock.mockClear();
+    configurationsQueryRefetchMock.mockClear();
+    mockConfigStatus = "draft";
+    mockEditableCapability = true;
+    mockFilesFetchedAfterMount = true;
+    mockConfigFetchedAfterMount = true;
+  });
+
+  it("opens publish dialog, starts publish, and flips to read-only on success", async () => {
+    render(
+      <Workbench
+        workspaceId="ws-1"
+        configId="cfg-1"
+        configName="Workspace · Draft"
+        configDisplayName="Draft"
+        windowState="restored"
+        onMinimizeWindow={vi.fn()}
+        onMaximizeWindow={vi.fn()}
+        onRestoreWindow={vi.fn()}
+        onCloseWorkbench={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("chrome-publish")).toBeEnabled();
+    fireEvent.click(screen.getByTestId("chrome-publish"));
+    expect(screen.getByTestId("publish-dialog")).toHaveAttribute("data-phase", "confirm");
+
+    fireEvent.click(screen.getByText("Start publish"));
+    await waitFor(() => {
+      expect(startRunMock).toHaveBeenCalledWith({ operation: "publish" }, { mode: "publish" });
+    });
+
+    await act(async () => {
+      onRunCompleteCallback?.({
+        runId: "run-123",
+        status: "succeeded",
+        mode: "publish",
+        payload: { status: "succeeded" },
+      });
+    });
+
+    expect(screen.getByTestId("publish-dialog")).toHaveAttribute("data-phase", "succeeded");
+    expect(screen.getByText("Read-only configuration")).toBeInTheDocument();
+    expect(screen.getByTestId("chrome-publish")).toBeDisabled();
+    expect(screen.getByTestId("console-toggle-disabled").textContent).toBe("yes");
+  });
+
+  it("shows failure and keeps draft editable with retry support", async () => {
+    render(
+      <Workbench
+        workspaceId="ws-1"
+        configId="cfg-1"
+        configName="Workspace · Draft"
+        configDisplayName="Draft"
+        windowState="restored"
+        onMinimizeWindow={vi.fn()}
+        onMaximizeWindow={vi.fn()}
+        onRestoreWindow={vi.fn()}
+        onCloseWorkbench={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("chrome-publish"));
+    fireEvent.click(screen.getByText("Start publish"));
+
+    await act(async () => {
+      onRunCompleteCallback?.({
+        runId: "run-123",
+        status: "failed",
+        mode: "publish",
+        payload: { error_message: "stale snapshot" },
+      });
+    });
+
+    expect(screen.getByTestId("publish-dialog")).toHaveAttribute("data-phase", "failed");
+    expect(screen.getByText("Publish failed: stale snapshot")).toBeInTheDocument();
+    expect(screen.getByTestId("chrome-publish")).toBeEnabled();
+
+    fireEvent.click(screen.getByText("Retry publish"));
+    await waitFor(() => {
+      expect(startRunMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("treats active configs as read-only even if editable capability drifts true", () => {
+    mockConfigStatus = "active";
+    mockEditableCapability = true;
+
+    render(
+      <Workbench
+        workspaceId="ws-1"
+        configId="cfg-1"
+        configName="Workspace · Active"
+        configDisplayName="Active"
+        windowState="restored"
+        onMinimizeWindow={vi.fn()}
+        onMaximizeWindow={vi.fn()}
+        onRestoreWindow={vi.fn()}
+        onCloseWorkbench={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Read-only configuration")).toBeInTheDocument();
+    expect(screen.getByTestId("chrome-publish")).toBeDisabled();
+  });
+
+  it("waits for a fresh file status snapshot before showing editor actions", () => {
+    mockFilesFetchedAfterMount = false;
+
+    render(
+      <Workbench
+        workspaceId="ws-1"
+        configId="cfg-1"
+        configName="Workspace · Draft"
+        configDisplayName="Draft"
+        windowState="restored"
+        onMinimizeWindow={vi.fn()}
+        onMaximizeWindow={vi.fn()}
+        onRestoreWindow={vi.fn()}
+        onCloseWorkbench={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Refreshing configuration")).toBeInTheDocument();
+  });
+
+  it("waits for a fresh configuration status snapshot before showing editor actions", () => {
+    mockConfigFetchedAfterMount = false;
+
+    render(
+      <Workbench
+        workspaceId="ws-1"
+        configId="cfg-1"
+        configName="Workspace · Draft"
+        configDisplayName="Draft"
+        windowState="restored"
+        onMinimizeWindow={vi.fn()}
+        onMaximizeWindow={vi.fn()}
+        onRestoreWindow={vi.fn()}
+        onCloseWorkbench={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Refreshing configuration")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/components/BottomPanel.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/components/BottomPanel.tsx
@@ -4,6 +4,7 @@ import type { WorkbenchPane } from "../state/workbenchSearchParams";
 import type { JobStreamStatus } from "../state/useJobStreamController";
 import type { WorkbenchConsoleStore } from "../state/consoleStore";
 import type { WorkbenchRunSummary, WorkbenchValidationState } from "../types";
+import type { RunStreamConnectionState } from "@/api/runs/api";
 
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from "@/components/ui/tabs";
 
@@ -19,6 +20,7 @@ interface BottomPanelProps {
   readonly latestRun?: WorkbenchRunSummary | null;
   readonly onClearConsole?: () => void;
   readonly runStatus?: JobStreamStatus;
+  readonly runConnectionState?: RunStreamConnectionState;
   readonly onToggleCollapse?: () => void;
   readonly appearance?: "light" | "dark";
 }
@@ -32,6 +34,7 @@ export function BottomPanel({
   latestRun,
   onClearConsole,
   runStatus,
+  runConnectionState,
   onToggleCollapse,
   appearance = "light",
 }: BottomPanelProps) {
@@ -103,6 +106,7 @@ export function BottomPanel({
             latestRun={latestRun}
             onClearConsole={onClearConsole}
             runStatus={runStatus}
+            runConnectionState={runConnectionState}
           />
         </TabsContent>
 

--- a/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/components/PublishConfigurationDialog.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/components/PublishConfigurationDialog.tsx
@@ -1,0 +1,371 @@
+import clsx from "clsx";
+import { createPortal } from "react-dom";
+import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { RunStreamConnectionState } from "@/api/runs/api";
+
+import type { WorkbenchConsoleStore } from "../state/consoleStore";
+import type { WorkbenchConsoleLine } from "../types";
+import { renderConsoleLine } from "./consoleFormatting";
+
+export type PublishDialogPhase = "confirm" | "running" | "succeeded" | "failed";
+
+interface PublishConfigurationDialogProps {
+  readonly open: boolean;
+  readonly phase: PublishDialogPhase;
+  readonly isDirty: boolean;
+  readonly canPublish: boolean;
+  readonly isSubmitting?: boolean;
+  readonly runId?: string | null;
+  readonly activeConfigurationName?: string | null;
+  readonly connectionState?: RunStreamConnectionState | null;
+  readonly errorMessage?: string | null;
+  readonly console: WorkbenchConsoleStore;
+  readonly onCancel: () => void;
+  readonly onStartPublish: () => void;
+  readonly onDone: () => void;
+  readonly onRetryPublish: () => void;
+  readonly onDuplicateToEdit: () => void;
+}
+
+export function PublishConfigurationDialog({
+  open,
+  phase,
+  isDirty,
+  canPublish,
+  isSubmitting = false,
+  runId,
+  activeConfigurationName,
+  connectionState,
+  errorMessage,
+  console,
+  onCancel,
+  onStartPublish,
+  onDone,
+  onRetryPublish,
+  onDuplicateToEdit,
+}: PublishConfigurationDialogProps) {
+  const canClose = phase !== "running";
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
+  const retryButtonRef = useRef<HTMLButtonElement | null>(null);
+  const doneButtonRef = useRef<HTMLButtonElement | null>(null);
+  const logsRef = useRef<HTMLDivElement | null>(null);
+
+  const snapshot = useSyncExternalStore(console.subscribe.bind(console), console.getSnapshot, console.getSnapshot);
+  const lines = useMemo(() => {
+    const entries: WorkbenchConsoleLine[] = [];
+    for (let index = 0; index < snapshot.length; index += 1) {
+      const line = console.getLine(index);
+      if (line) {
+        entries.push(line);
+      }
+    }
+    return entries;
+  }, [console, snapshot]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && canClose) {
+        onCancel();
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      const root = dialogRef.current;
+      if (!root) {
+        return;
+      }
+      const focusable = Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (focusable.length === 0) {
+        return;
+      }
+      const currentIndex = focusable.indexOf(document.activeElement as HTMLElement);
+      const nextIndex = event.shiftKey
+        ? currentIndex <= 0
+          ? focusable.length - 1
+          : currentIndex - 1
+        : currentIndex === focusable.length - 1
+          ? 0
+          : currentIndex + 1;
+      focusable[nextIndex]?.focus();
+      event.preventDefault();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [canClose, onCancel, open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    if (phase === "confirm") {
+      confirmButtonRef.current?.focus();
+      return;
+    }
+    if (phase === "failed") {
+      retryButtonRef.current?.focus();
+      return;
+    }
+    if (phase === "succeeded") {
+      doneButtonRef.current?.focus();
+    }
+  }, [open, phase]);
+
+  useEffect(() => {
+    if (!open || lines.length === 0) {
+      return;
+    }
+    const container = logsRef.current;
+    if (!container) {
+      return;
+    }
+    container.scrollTop = container.scrollHeight;
+  }, [lines.length, open, snapshot.version, phase]);
+
+  if (!open) {
+    return null;
+  }
+
+  const title =
+    phase === "confirm"
+      ? "Publish this draft configuration?"
+      : phase === "running"
+        ? "Publishing configuration"
+        : phase === "succeeded"
+          ? "Publish complete"
+          : "Publish failed";
+  const stateLabel =
+    phase === "confirm"
+      ? "Review"
+      : phase === "running"
+        ? "Running"
+        : phase === "succeeded"
+          ? "Success"
+          : "Failure";
+  const stateClass =
+    phase === "succeeded"
+      ? "bg-emerald-100 text-emerald-900"
+      : phase === "failed"
+        ? "bg-destructive/15 text-destructive"
+        : phase === "running"
+          ? "bg-accent text-accent-foreground"
+          : "bg-muted text-foreground";
+
+  return createPortal(
+    <div className="fixed inset-0 z-[var(--app-z-modal)] px-4">
+      <button
+        type="button"
+        className="absolute inset-0 bg-overlay"
+        onClick={() => {
+          if (canClose) {
+            onCancel();
+          }
+        }}
+        aria-label="Close publish dialog"
+        disabled={!canClose}
+      />
+      <div className="relative flex min-h-full items-center justify-center">
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="publish-dialog-title"
+          className="w-full max-w-4xl rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        >
+          <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-2">
+              <div className={clsx("inline-flex rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.25em]", stateClass)}>
+                {stateLabel}
+              </div>
+              <h2 id="publish-dialog-title" className="text-xl font-semibold text-foreground">
+                {title}
+              </h2>
+              {phase === "confirm" ? (
+                <p className="text-sm text-muted-foreground">
+                  Publishing promotes this draft to active for your workspace.
+                </p>
+              ) : null}
+            </div>
+            {runId ? (
+              <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                Run {runId}
+              </div>
+            ) : null}
+          </div>
+
+          {phase === "confirm" ? (
+            <div className="space-y-3">
+              <div className="rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+                <p className="font-medium text-foreground">After publish:</p>
+                <ul className="mt-2 list-disc space-y-1 pl-5">
+                  <li>This configuration becomes active for newly uploaded documents by default.</li>
+                  <li>This configuration becomes read-only. Duplicate it to continue editing.</li>
+                  {activeConfigurationName ? (
+                    <li>The current active configuration “{activeConfigurationName}” will be archived.</li>
+                  ) : null}
+                </ul>
+              </div>
+              {isDirty ? (
+                <p className="rounded-md border border-accent/40 bg-accent/15 px-3 py-2 text-sm font-medium text-accent-foreground">
+                  Unsaved changes will be saved before publish starts.
+                </p>
+              ) : null}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/20 px-3 py-2">
+                <p className="text-sm font-medium text-foreground" aria-live="polite">
+                  {phase === "running"
+                    ? "Streaming live publish logs."
+                    : phase === "succeeded"
+                      ? "Publish completed successfully."
+                      : "Publish ended with an error."}
+                </p>
+                {phase === "running" || connectionState === "reconnecting" ? (
+                  <span className="rounded border border-border bg-background px-2 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {formatConnectionState(connectionState)}
+                  </span>
+                ) : null}
+              </div>
+              {phase === "failed" && errorMessage ? (
+                <p className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm font-medium text-destructive">
+                  {errorMessage}
+                </p>
+              ) : null}
+              <div
+                ref={logsRef}
+                className="h-72 overflow-auto rounded-md border border-border bg-card/40 p-3 font-mono text-[12px] leading-relaxed"
+              >
+                {lines.length === 0 ? (
+                  <p className="text-muted-foreground">
+                    {phase === "running" ? "Waiting for publish events…" : "No publish logs were captured."}
+                  </p>
+                ) : (
+                  <ul className="space-y-1.5">
+                    {lines.map((line, index) => (
+                      <li key={line.id ?? `${index}-${line.timestamp ?? ""}-${line.message}`}>
+                        <div className="flex items-start gap-2">
+                          <span className="min-w-[72px] pt-[2px] text-[10px] uppercase tracking-wide text-muted-foreground">
+                            {formatTimestamp(line.timestamp)}
+                          </span>
+                          <span className={clsx("min-w-[58px] pt-[2px] text-[10px] uppercase tracking-wide", levelClass(line.level))}>
+                            {line.level}
+                          </span>
+                          <span className="min-w-0 flex-1 break-words text-foreground">{renderConsoleLine(line)}</span>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="mt-6 flex flex-wrap justify-end gap-2">
+            {phase === "confirm" ? (
+              <>
+                <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+                  Keep editing draft
+                </Button>
+                <Button
+                  ref={confirmButtonRef}
+                  type="button"
+                  onClick={onStartPublish}
+                  disabled={!canPublish || isSubmitting}
+                >
+                  {isSubmitting ? "Publishing…" : "Publish configuration"}
+                </Button>
+              </>
+            ) : null}
+            {phase === "running" ? (
+              <Button type="button" disabled>
+                Publishing…
+              </Button>
+            ) : null}
+            {phase === "succeeded" ? (
+              <>
+                <Button type="button" variant="ghost" onClick={onDuplicateToEdit}>
+                  Duplicate to edit
+                </Button>
+                <Button ref={doneButtonRef} type="button" onClick={onDone}>
+                  Done
+                </Button>
+              </>
+            ) : null}
+            {phase === "failed" ? (
+              <>
+                <Button type="button" variant="ghost" onClick={onCancel}>
+                  Close
+                </Button>
+                <Button
+                  ref={retryButtonRef}
+                  type="button"
+                  onClick={onRetryPublish}
+                  disabled={!canPublish || isSubmitting}
+                >
+                  {isSubmitting ? "Retrying…" : "Retry publish"}
+                </Button>
+              </>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function formatTimestamp(timestamp?: string): string {
+  if (!timestamp) {
+    return "--:--:--";
+  }
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return "--:--:--";
+  }
+  return date.toLocaleTimeString([], { hour12: false });
+}
+
+function formatConnectionState(state?: RunStreamConnectionState | null): string {
+  if (!state) {
+    return "Connecting";
+  }
+  if (state === "streaming") {
+    return "Streaming";
+  }
+  if (state === "reconnecting") {
+    return "Reconnecting";
+  }
+  if (state === "failed") {
+    return "Disconnected";
+  }
+  if (state === "completed") {
+    return "Completed";
+  }
+  return "Connecting";
+}
+
+function levelClass(level: WorkbenchConsoleLine["level"]): string {
+  if (level === "error") {
+    return "text-destructive";
+  }
+  if (level === "warning") {
+    return "text-amber-700";
+  }
+  if (level === "success") {
+    return "text-emerald-700";
+  }
+  if (level === "debug") {
+    return "text-muted-foreground";
+  }
+  return "text-sky-700";
+}

--- a/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/components/WorkbenchChrome.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/components/WorkbenchChrome.tsx
@@ -36,6 +36,7 @@ interface WorkbenchChromeProps {
   readonly onRunExtraction: () => void;
   readonly consoleOpen: boolean;
   readonly onToggleConsole: () => void;
+  readonly consoleToggleDisabled?: boolean;
   readonly appearance: "light" | "dark";
   readonly windowState: "restored" | "maximized";
   readonly onMinimizeWindow: () => void;
@@ -64,6 +65,7 @@ export function WorkbenchChrome({
   onRunExtraction,
   consoleOpen,
   onToggleConsole,
+  consoleToggleDisabled = false,
   appearance,
   windowState,
   onMinimizeWindow,
@@ -161,6 +163,7 @@ export function WorkbenchChrome({
             onClick={onToggleConsole}
             appearance={appearance}
             active={consoleOpen}
+            disabled={consoleToggleDisabled}
             icon={<ConsoleIcon className="h-3.5 w-3.5" />}
           />
         </div>

--- a/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/components/__tests__/PublishConfigurationDialog.test.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/components/__tests__/PublishConfigurationDialog.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PublishConfigurationDialog } from "../PublishConfigurationDialog";
+import { WorkbenchConsoleStore } from "../../state/consoleStore";
+
+function buildConsoleStore() {
+  const store = new WorkbenchConsoleStore(64);
+  store.append({
+    level: "info",
+    message: "Publish started",
+    timestamp: "2026-02-07T10:00:00.000Z",
+    origin: "run",
+  });
+  return store;
+}
+
+describe("PublishConfigurationDialog", () => {
+  it("renders confirm phase details", () => {
+    render(
+      <PublishConfigurationDialog
+        open
+        phase="confirm"
+        isDirty
+        canPublish
+        console={buildConsoleStore()}
+        activeConfigurationName="Current Active"
+        onCancel={vi.fn()}
+        onStartPublish={vi.fn()}
+        onDone={vi.fn()}
+        onRetryPublish={vi.fn()}
+        onDuplicateToEdit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Publish this draft configuration?")).toBeInTheDocument();
+    expect(screen.getByText("This configuration becomes active for newly uploaded documents by default.")).toBeInTheDocument();
+    expect(screen.getByText("Unsaved changes will be saved before publish starts.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Publish configuration" })).toBeEnabled();
+  });
+
+  it("renders running phase stream status and blocks close actions", () => {
+    const onCancel = vi.fn();
+    render(
+      <PublishConfigurationDialog
+        open
+        phase="running"
+        isDirty={false}
+        canPublish={false}
+        runId="run-123"
+        connectionState="reconnecting"
+        console={buildConsoleStore()}
+        onCancel={onCancel}
+        onStartPublish={vi.fn()}
+        onDone={vi.fn()}
+        onRetryPublish={vi.fn()}
+        onDuplicateToEdit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Publishing configuration")).toBeInTheDocument();
+    expect(screen.getByText("Reconnecting")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for publish events…")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close publish dialog" }));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("renders succeeded phase actions", () => {
+    const onDone = vi.fn();
+    const onDuplicateToEdit = vi.fn();
+    render(
+      <PublishConfigurationDialog
+        open
+        phase="succeeded"
+        isDirty={false}
+        canPublish={false}
+        console={buildConsoleStore()}
+        onCancel={vi.fn()}
+        onStartPublish={vi.fn()}
+        onDone={onDone}
+        onRetryPublish={vi.fn()}
+        onDuplicateToEdit={onDuplicateToEdit}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate to edit" }));
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onDuplicateToEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders failure message and retry action", () => {
+    const onRetryPublish = vi.fn();
+    render(
+      <PublishConfigurationDialog
+        open
+        phase="failed"
+        isDirty={false}
+        canPublish
+        errorMessage="Publish failed: stale snapshot"
+        console={buildConsoleStore()}
+        onCancel={vi.fn()}
+        onStartPublish={vi.fn()}
+        onDone={vi.fn()}
+        onRetryPublish={onRetryPublish}
+        onDuplicateToEdit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Publish failed: stale snapshot")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry publish" }));
+    expect(onRetryPublish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/state/useRunSessionModel.ts
+++ b/frontend/src/pages/Workspace/sections/ConfigBuilder/workbench/state/useRunSessionModel.ts
@@ -59,6 +59,7 @@ export function useRunSessionModel({
     console,
     jobId,
     jobMode,
+    jobConnectionState,
     jobStatus,
     jobInProgress,
     completedDetails,
@@ -147,7 +148,7 @@ export function useRunSessionModel({
 
     void (async () => {
       try {
-        const resource = await fetchRun(resolvedRunId);
+        const resource = await fetchRun(workspaceId, resolvedRunId);
         const outputUrl = runOutputUrl(resource) ?? undefined;
         const logsUrl = runLogsUrl(resource) ?? undefined;
         const inputUrl = runInputUrl(resource) ?? undefined;
@@ -169,7 +170,7 @@ export function useRunSessionModel({
         );
       }
     })();
-  }, [resolvedRunId, jobStatus, completedDetails, onRunComplete, runMode]);
+  }, [workspaceId, resolvedRunId, jobStatus, completedDetails, onRunComplete, runMode]);
 
   const startRun = useCallback(
     async (
@@ -192,6 +193,7 @@ export function useRunSessionModel({
   return useMemo(
     () => ({
       runStatus,
+      runConnectionState: jobConnectionState ?? undefined,
       runMode: runMode ?? undefined,
       runInProgress: jobInProgress,
       validation,
@@ -200,7 +202,7 @@ export function useRunSessionModel({
       clearConsole,
       startRun,
     }),
-    [runStatus, runMode, jobInProgress, validation, console, latestRun, clearConsole, startRun],
+    [runStatus, jobConnectionState, runMode, jobInProgress, validation, console, latestRun, clearConsole, startRun],
   );
 }
 

--- a/frontend/src/pages/Workspace/sections/Documents/detail/DocumentsDetailPage.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/DocumentsDetailPage.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchWorkspaceDocumentRowById } from "@/api/documents";
 import { ApiError } from "@/api/errors";
 import { cancelRun, createRun } from "@/api/runs/api";
+import type { RunStreamOptions } from "@/api/runs/api";
 import { PageState } from "@/components/layout";
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from "@/components/ui/tabs";
 import { useWorkspaceContext } from "@/pages/Workspace/context/WorkspaceContext";
@@ -130,7 +131,7 @@ export function DocumentsDetailPage({ documentId }: { documentId: string }) {
 
     setIsRunActionPending(true);
     try {
-      await cancelRun(runId);
+      await cancelRun(workspace.id, runId);
       notifyToast({
         title: "Run cancelled",
         description: `${documentRow.name} was cancelled.`,
@@ -154,10 +155,10 @@ export function DocumentsDetailPage({ documentId }: { documentId: string }) {
     } finally {
       setIsRunActionPending(false);
     }
-  }, [documentQuery, documentRow, isRunActive, notifyToast]);
+  }, [documentQuery, documentRow, isRunActive, notifyToast, workspace.id]);
 
   const onReprocessConfirm = useCallback(
-    async (runOptions: { active_sheet_only?: boolean; input_sheet_names?: string[] }) => {
+    async (runOptions: Pick<RunStreamOptions, "active_sheet_only" | "input_sheet_names">) => {
       if (!documentRow) return;
       setIsRunActionPending(true);
       try {

--- a/frontend/src/pages/Workspace/sections/Documents/detail/components/DocumentTicketHeader.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/components/DocumentTicketHeader.tsx
@@ -23,7 +23,7 @@ function formatRunStatus(value: RunStatus) {
   return normalized[0]?.toUpperCase() + normalized.slice(1);
 }
 
-function resolveNormalizedDownloadState(document: DocumentRow): {
+function resolveNormalizedDownloadState(workspaceId: string, document: DocumentRow): {
   href: string | null;
   label: string;
 } {
@@ -32,7 +32,7 @@ function resolveNormalizedDownloadState(document: DocumentRow): {
 
   if (status === "succeeded" && runId) {
     return {
-      href: resolveApiUrl(`/api/v1/runs/${runId}/output/download`),
+      href: resolveApiUrl(`/api/v1/workspaces/${workspaceId}/runs/${runId}/output/download`),
       label: "Download normalized output",
     };
   }
@@ -70,8 +70,8 @@ export function DocumentTicketHeader({
   isRunActionPending?: boolean;
 }) {
   const normalizedDownload = useMemo(
-    () => resolveNormalizedDownloadState(document),
-    [document],
+    () => resolveNormalizedDownloadState(workspaceId, document),
+    [document, workspaceId],
   );
   const originalHref = resolveApiUrl(
     `/api/v1/workspaces/${workspaceId}/documents/${document.id}/download`,

--- a/frontend/src/pages/Workspace/sections/Documents/detail/tabs/activity/model.test.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/tabs/activity/model.test.ts
@@ -30,9 +30,10 @@ function makeDocument(): DocumentRow {
 function makeRun(): RunResource {
   return {
     id: "run_1",
+    object: "ade.run",
     workspace_id: "ws_1",
-    document_ids: ["doc_1"],
-    config_id: null,
+    configuration_id: "config_1",
+    operation: "process",
     status: "succeeded",
     created_at: "2026-01-02T00:00:00Z",
     started_at: "2026-01-02T00:00:05Z",
@@ -40,6 +41,14 @@ function makeRun(): RunResource {
     duration_seconds: 7,
     failure_message: null,
     exit_code: 0,
+    links: {
+      self: "/api/v1/workspaces/ws_1/runs/run_1",
+      events_stream: "/api/v1/workspaces/ws_1/runs/run_1/events/stream",
+      events_download: "/api/v1/workspaces/ws_1/runs/run_1/events/download",
+      input_download: "/api/v1/workspaces/ws_1/runs/run_1/input/download",
+      output_download: "/api/v1/workspaces/ws_1/runs/run_1/output/download",
+      output_metadata: "/api/v1/workspaces/ws_1/runs/run_1/output",
+    },
   } as RunResource;
 }
 

--- a/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/DocumentPreviewTab.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/DocumentPreviewTab.tsx
@@ -41,7 +41,7 @@ export function DocumentPreviewTab({
 
       {!model.canLoadSelectedSource ? (
         <DocumentPreviewUnavailableState
-          reason={model.normalizedState.reason}
+          reason={model.normalizedState.reason ?? "Normalized output is unavailable for this document."}
           onSwitchToOriginal={() => onSourceChange("original")}
         />
       ) : (

--- a/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/components/DocumentPreviewGrid.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/components/DocumentPreviewGrid.tsx
@@ -87,9 +87,9 @@ export function DocumentPreviewGrid({
                     <TableCell
                       key={`cell-${rowIndex}-${colIndex}`}
                       className={cn("max-w-64 truncate")}
-                      title={String(cells[colIndex] ?? "")}
+                      title={renderPreviewCell(cells[colIndex])}
                     >
-                      {cells[colIndex] ?? ""}
+                      {renderPreviewCell(cells[colIndex])}
                     </TableCell>
                   ))}
                 </TableRow>
@@ -115,4 +115,25 @@ function LoadingState() {
       ))}
     </div>
   );
+}
+
+function renderPreviewCell(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (
+    typeof value === "number"
+    || typeof value === "boolean"
+    || typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }

--- a/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/hooks/useDocumentPreviewModel.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/hooks/useDocumentPreviewModel.ts
@@ -73,7 +73,7 @@ export function useDocumentPreviewModel({
     queryFn: ({ signal }) =>
       source === "original"
         ? fetchDocumentSheets(workspaceId, document.id, signal)
-        : fetchRunOutputSheets(normalizedRunId as string, signal),
+        : fetchRunOutputSheets(workspaceId, normalizedRunId as string, signal),
     enabled: Boolean(workspaceId && document.id && canLoadSelectedSource),
     staleTime: 30_000,
   });
@@ -135,7 +135,7 @@ export function useDocumentPreviewModel({
         return fetchDocumentPreview(workspaceId, document.id, options, signal);
       }
 
-      return fetchRunOutputPreview(normalizedRunId as string, options, signal);
+      return fetchRunOutputPreview(workspaceId, normalizedRunId as string, options, signal);
     },
     enabled: Boolean(workspaceId && document.id && canLoadSelectedSource && selectedSheet),
     staleTime: 30_000,

--- a/frontend/src/pages/Workspace/sections/Runs/components/table/cells/RunActionsCell.tsx
+++ b/frontend/src/pages/Workspace/sections/Runs/components/table/cells/RunActionsCell.tsx
@@ -14,10 +14,8 @@ export function RunActionsCell({
   isActive: boolean;
   onTogglePreview: () => void;
 }) {
-  const logsHref = run.raw.links?.logs ?? null;
-  const outputHref = run.raw.output?.ready
-    ? run.raw.links?.output_download ?? run.raw.links?.output ?? null
-    : null;
+  const logsHref = run.raw.links?.events_download ?? null;
+  const outputHref = run.raw.output?.ready ? run.raw.links?.output_download ?? null : null;
 
   return (
     <div className="flex items-center justify-end gap-2">

--- a/frontend/src/pages/Workspace/sections/Runs/hooks/useRunsView.ts
+++ b/frontend/src/pages/Workspace/sections/Runs/hooks/useRunsView.ts
@@ -100,7 +100,8 @@ export function useRunsView({
 
   const metricsQuery = useQuery({
     queryKey: activeRunId ? runsKeys.metrics(activeRunId) : [...runsKeys.root(), "metrics", "none"],
-    queryFn: ({ signal }) => (activeRunId ? fetchRunMetrics(activeRunId, signal) : Promise.resolve(null)),
+    queryFn: ({ signal }) =>
+      activeRunId ? fetchRunMetrics(workspaceId, activeRunId, signal) : Promise.resolve(null),
     enabled: shouldFetchDetails,
     staleTime: 30_000,
     refetchInterval: shouldPollDetails ? 10_000 : false,
@@ -108,7 +109,8 @@ export function useRunsView({
 
   const fieldsQuery = useQuery({
     queryKey: activeRunId ? runsKeys.fields(activeRunId) : [...runsKeys.root(), "fields", "none"],
-    queryFn: ({ signal }) => (activeRunId ? fetchRunFields(activeRunId, signal) : Promise.resolve(null)),
+    queryFn: ({ signal }) =>
+      activeRunId ? fetchRunFields(workspaceId, activeRunId, signal) : Promise.resolve(null),
     enabled: shouldFetchDetails,
     staleTime: 30_000,
     refetchInterval: shouldPollDetails ? 10_000 : false,
@@ -116,7 +118,8 @@ export function useRunsView({
 
   const columnsQuery = useQuery({
     queryKey: activeRunId ? runsKeys.columns(activeRunId, null) : [...runsKeys.root(), "columns", "none"],
-    queryFn: ({ signal }) => (activeRunId ? fetchRunColumns(activeRunId, null, signal) : Promise.resolve(null)),
+    queryFn: ({ signal }) =>
+      activeRunId ? fetchRunColumns(workspaceId, activeRunId, null, signal) : Promise.resolve(null),
     enabled: shouldFetchDetails,
     staleTime: 30_000,
     refetchInterval: shouldPollDetails ? 10_000 : false,

--- a/frontend/src/types/generated/openapi.d.ts
+++ b/frontend/src/types/generated/openapi.d.ts
@@ -961,23 +961,6 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/publish": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Start a publish run for a draft configuration */
-        post: operations["publish_configuration_endpoint_api_v1_workspaces__workspaceId__configurations__configurationId__publish_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/archive": {
         parameters: {
             query?: never;
@@ -1085,47 +1068,6 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/configurations/{configurationId}/runs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List Configuration Runs Endpoint */
-        get: operations["list_configuration_runs_endpoint_api_v1_configurations__configurationId__runs_get"];
-        put?: never;
-        /**
-         * Create Run Endpoint
-         * @description Create a run for ``configuration_id`` and enqueue execution.
-         */
-        post: operations["create_run_endpoint_api_v1_configurations__configurationId__runs_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/configurations/{configurationId}/runs/batch": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Runs Batch Endpoint
-         * @description Create multiple runs for ``configuration_id`` and enqueue execution.
-         */
-        post: operations["create_runs_batch_endpoint_api_v1_configurations__configurationId__runs_batch_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/workspaces/{workspaceId}/runs": {
         parameters: {
             query?: never;
@@ -1167,15 +1109,15 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Run Endpoint */
-        get: operations["get_run_endpoint_api_v1_runs__runId__get"];
+        /** Get Workspace Run Endpoint */
+        get: operations["get_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1184,7 +1126,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/cancel": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/cancel": {
         parameters: {
             query?: never;
             header?: never;
@@ -1193,23 +1135,23 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Cancel Run Endpoint */
-        post: operations["cancel_run_endpoint_api_v1_runs__runId__cancel_post"];
+        /** Cancel Workspace Run Endpoint */
+        post: operations["cancel_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__cancel_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/metrics": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/metrics": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Run Metrics Endpoint */
-        get: operations["get_run_metrics_endpoint_api_v1_runs__runId__metrics_get"];
+        /** Get Workspace Run Metrics Endpoint */
+        get: operations["get_workspace_run_metrics_endpoint_api_v1_workspaces__workspaceId__runs__runId__metrics_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1218,15 +1160,15 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/fields": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/fields": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** List Run Fields Endpoint */
-        get: operations["list_run_fields_endpoint_api_v1_runs__runId__fields_get"];
+        /** List Workspace Run Fields Endpoint */
+        get: operations["list_workspace_run_fields_endpoint_api_v1_workspaces__workspaceId__runs__runId__fields_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1235,15 +1177,15 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/columns": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/columns": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** List Run Columns Endpoint */
-        get: operations["list_run_columns_endpoint_api_v1_runs__runId__columns_get"];
+        /** List Workspace Run Columns Endpoint */
+        get: operations["list_workspace_run_columns_endpoint_api_v1_workspaces__workspaceId__runs__runId__columns_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1252,7 +1194,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/input": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/input": {
         parameters: {
             query?: never;
             header?: never;
@@ -1260,7 +1202,7 @@ export type paths = {
             cookie?: never;
         };
         /** Get run input metadata */
-        get: operations["get_run_input_endpoint_api_v1_runs__runId__input_get"];
+        get: operations["get_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1269,7 +1211,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/input/download": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/input/download": {
         parameters: {
             query?: never;
             header?: never;
@@ -1277,7 +1219,7 @@ export type paths = {
             cookie?: never;
         };
         /** Download run input file */
-        get: operations["download_run_input_endpoint_api_v1_runs__runId__input_download_get"];
+        get: operations["download_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_download_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1286,7 +1228,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/events/stream": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/events/stream": {
         parameters: {
             query?: never;
             header?: never;
@@ -1294,7 +1236,7 @@ export type paths = {
             cookie?: never;
         };
         /** Stream run events (SSE) */
-        get: operations["stream_run_events_endpoint_api_v1_runs__runId__events_stream_get"];
+        get: operations["stream_workspace_run_events_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_stream_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1303,7 +1245,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/events/download": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/events/download": {
         parameters: {
             query?: never;
             header?: never;
@@ -1311,7 +1253,7 @@ export type paths = {
             cookie?: never;
         };
         /** Download run events (NDJSON log) */
-        get: operations["download_run_events_file_endpoint_api_v1_runs__runId__events_download_get"];
+        get: operations["download_workspace_run_events_file_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_download_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1320,7 +1262,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/output": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/output": {
         parameters: {
             query?: never;
             header?: never;
@@ -1328,17 +1270,17 @@ export type paths = {
             cookie?: never;
         };
         /** Get run output metadata */
-        get: operations["get_run_output_metadata_endpoint_api_v1_runs__runId__output_get"];
+        get: operations["get_workspace_run_output_metadata_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_get"];
         put?: never;
         /** Upload manual run output */
-        post: operations["upload_run_output_endpoint_api_v1_runs__runId__output_post"];
+        post: operations["upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/output/download": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/output/download": {
         parameters: {
             query?: never;
             header?: never;
@@ -1346,7 +1288,7 @@ export type paths = {
             cookie?: never;
         };
         /** Download run output file */
-        get: operations["download_run_output_endpoint_api_v1_runs__runId__output_download_get"];
+        get: operations["download_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_download_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1355,7 +1297,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/output/sheets": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/output/sheets": {
         parameters: {
             query?: never;
             header?: never;
@@ -1363,7 +1305,7 @@ export type paths = {
             cookie?: never;
         };
         /** List run output worksheets */
-        get: operations["list_run_output_sheets_endpoint_api_v1_runs__runId__output_sheets_get"];
+        get: operations["list_workspace_run_output_sheets_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_sheets_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1372,7 +1314,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/runs/{runId}/output/preview": {
+    "/api/v1/workspaces/{workspaceId}/runs/{runId}/output/preview": {
         parameters: {
             query?: never;
             header?: never;
@@ -1380,7 +1322,7 @@ export type paths = {
             cookie?: never;
         };
         /** Preview run output worksheet */
-        get: operations["preview_run_output_endpoint_api_v1_runs__runId__output_preview_get"];
+        get: operations["preview_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_preview_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1753,8 +1695,8 @@ export type components = {
             /** Metadata */
             metadata?: string | null;
         };
-        /** Body_upload_run_output_endpoint_api_v1_runs__runId__output_post */
-        Body_upload_run_output_endpoint_api_v1_runs__runId__output_post: {
+        /** Body_upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post */
+        Body_upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post: {
             /**
              * File
              * Format: binary
@@ -2883,18 +2825,6 @@ export type components = {
             } | null;
         };
         /**
-         * RunBatchCreateRequest
-         * @description Payload accepted by the batch run creation endpoint.
-         */
-        RunBatchCreateRequest: {
-            /**
-             * Document Ids
-             * @description Documents to enqueue as individual runs (all-or-nothing).
-             */
-            document_ids: string[];
-            options?: components["schemas"]["RunBatchCreateOptions"];
-        };
-        /**
          * RunBatchCreateResponse
          * @description Response envelope for batch run creation.
          */
@@ -2940,47 +2870,6 @@ export type components = {
             unmapped_reason?: string | null;
         };
         /**
-         * RunCreateOptions
-         * @description Execution toggles for a single ADE run.
-         */
-        RunCreateOptions: {
-            /** @default process */
-            operation: components["schemas"]["RunOperation"];
-            /**
-             * Dry Run
-             * @default false
-             */
-            dry_run: boolean;
-            /**
-             * Log Level
-             * @description Engine log level passed as --log-level to ade_engine.
-             */
-            log_level?: ("DEBUG" | "INFO" | "WARNING" | "ERROR") | null;
-            /**
-             * Input Sheet Names
-             * @description Optional worksheet names to ingest when processing XLSX files.
-             */
-            input_sheet_names?: string[] | null;
-            /**
-             * Active Sheet Only
-             * @description If true, process only the active worksheet when ingesting XLSX files.
-             * @default false
-             */
-            active_sheet_only: boolean;
-            /**
-             * Metadata
-             * @description Opaque metadata to propagate with run telemetry.
-             */
-            metadata?: {
-                [key: string]: string;
-            } | null;
-            /**
-             * Input Document Id
-             * @description Document identifier to ingest.
-             */
-            input_document_id?: string | null;
-        };
-        /**
          * RunCreateOptionsBase
          * @description Optional execution toggles for ADE runs.
          */
@@ -3015,13 +2904,6 @@ export type components = {
             metadata?: {
                 [key: string]: string;
             } | null;
-        };
-        /**
-         * RunCreateRequest
-         * @description Payload accepted by the run creation endpoint.
-         */
-        RunCreateRequest: {
-            options?: components["schemas"]["RunCreateOptions"];
         };
         /**
          * RunFieldResource
@@ -3078,14 +2960,8 @@ export type components = {
             events_stream: string;
             /** Events Download */
             events_download: string;
-            /** Logs */
-            logs: string;
-            /** Input */
-            input: string;
             /** Input Download */
             input_download: string;
-            /** Output */
-            output: string;
             /** Output Download */
             output_download: string;
             /** Output Metadata */
@@ -3266,8 +3142,6 @@ export type components = {
             input?: components["schemas"]["RunInput"];
             output?: components["schemas"]["RunOutput"];
             links: components["schemas"]["RunLinks"];
-            /** Events Download Url */
-            events_download_url?: string | null;
         };
         /**
          * RunStatus
@@ -7698,49 +7572,6 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    publish_configuration_endpoint_api_v1_workspaces__workspaceId__configurations__configurationId__publish_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-CSRF-Token"?: string | null;
-            };
-            path: {
-                /** @description Workspace identifier */
-                workspaceId: string;
-                /** @description Configuration identifier */
-                configurationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RunResource"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            default: components["responses"]["ProblemDetails"];
-        };
-    };
     archive_configuration_endpoint_api_v1_workspaces__workspaceId__configurations__configurationId__archive_post: {
         parameters: {
             query?: never;
@@ -8234,140 +8065,6 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    list_configuration_runs_endpoint_api_v1_configurations__configurationId__runs_get: {
-        parameters: {
-            query?: {
-                /** @description Items per page (max 200) */
-                limit?: number;
-                /** @description Opaque cursor token for pagination. */
-                cursor?: string | null;
-                /** @description JSON array of {id, desc}. */
-                sort?: string | null;
-                /** @description URL-encoded JSON array of filter objects. */
-                filters?: string | null;
-                /** @description Logical operator to join filters (and/or). */
-                joinOperator?: components["schemas"]["FilterJoinOperator"];
-                /** @description Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored. */
-                q?: string | null;
-                /** @description Include totalCount in the response. */
-                includeTotal?: boolean;
-                /** @description Include facet counts in the response. */
-                includeFacets?: boolean;
-            };
-            header?: never;
-            path: {
-                /** @description Configuration identifier */
-                configurationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RunPage"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            default: components["responses"]["ProblemDetails"];
-        };
-    };
-    create_run_endpoint_api_v1_configurations__configurationId__runs_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-CSRF-Token"?: string | null;
-            };
-            path: {
-                /** @description Configuration identifier */
-                configurationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RunCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RunResource"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            default: components["responses"]["ProblemDetails"];
-        };
-    };
-    create_runs_batch_endpoint_api_v1_configurations__configurationId__runs_batch_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-CSRF-Token"?: string | null;
-            };
-            path: {
-                /** @description Configuration identifier */
-                configurationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RunBatchCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RunBatchCreateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            default: components["responses"]["ProblemDetails"];
-        };
-    };
     list_workspace_runs_endpoint_api_v1_workspaces__workspaceId__runs_get: {
         parameters: {
             query?: {
@@ -8502,11 +8199,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    get_run_endpoint_api_v1_runs__runId__get: {
+    get_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8537,13 +8236,15 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    cancel_run_endpoint_api_v1_runs__runId__cancel_post: {
+    cancel_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__cancel_post: {
         parameters: {
             query?: never;
             header?: {
                 "X-CSRF-Token"?: string | null;
             };
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8574,11 +8275,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    get_run_metrics_endpoint_api_v1_runs__runId__metrics_get: {
+    get_workspace_run_metrics_endpoint_api_v1_workspaces__workspaceId__runs__runId__metrics_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8609,11 +8312,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    list_run_fields_endpoint_api_v1_runs__runId__fields_get: {
+    list_workspace_run_fields_endpoint_api_v1_workspaces__workspaceId__runs__runId__fields_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8644,7 +8349,7 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    list_run_columns_endpoint_api_v1_runs__runId__columns_get: {
+    list_workspace_run_columns_endpoint_api_v1_workspaces__workspaceId__runs__runId__columns_get: {
         parameters: {
             query?: {
                 sheet_name?: string | null;
@@ -8655,6 +8360,8 @@ export interface operations {
             };
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8685,11 +8392,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    get_run_input_endpoint_api_v1_runs__runId__input_get: {
+    get_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8720,11 +8429,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    download_run_input_endpoint_api_v1_runs__runId__input_download_get: {
+    download_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_download_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8755,14 +8466,16 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    stream_run_events_endpoint_api_v1_runs__runId__events_stream_get: {
+    stream_workspace_run_events_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_stream_get: {
         parameters: {
             query?: {
-                /** @description Byte offset cursor for resuming from a prior stream position. */
-                cursor?: number;
+                /** @description Byte offset cursor for resuming from a prior stream position. When Last-Event-ID is present, that value takes precedence. */
+                cursor?: number | null;
             };
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8801,11 +8514,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    download_run_events_file_endpoint_api_v1_runs__runId__events_download_get: {
+    download_workspace_run_events_file_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_download_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8844,11 +8559,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    get_run_output_metadata_endpoint_api_v1_runs__runId__output_get: {
+    get_workspace_run_output_metadata_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8887,13 +8604,15 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    upload_run_output_endpoint_api_v1_runs__runId__output_post: {
+    upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post: {
         parameters: {
             query?: never;
             header?: {
                 "X-CSRF-Token"?: string | null;
             };
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -8901,7 +8620,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "multipart/form-data": components["schemas"]["Body_upload_run_output_endpoint_api_v1_runs__runId__output_post"];
+                "multipart/form-data": components["schemas"]["Body_upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post"];
             };
         };
         responses: {
@@ -8952,11 +8671,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    download_run_output_endpoint_api_v1_runs__runId__output_download_get: {
+    download_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_download_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -9003,11 +8724,13 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    list_run_output_sheets_endpoint_api_v1_runs__runId__output_sheets_get: {
+    list_workspace_run_output_sheets_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_sheets_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };
@@ -9060,7 +8783,7 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
-    preview_run_output_endpoint_api_v1_runs__runId__output_preview_get: {
+    preview_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_preview_get: {
         parameters: {
             query?: {
                 /** @description Maximum rows per sheet to include in the preview. */
@@ -9078,6 +8801,8 @@ export interface operations {
             };
             header?: never;
             path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
                 /** @description Run identifier */
                 runId: string;
             };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -21,9 +21,8 @@ export type User = GeneratedComponents["schemas"]["UserOut"];
 export type UserPage = GeneratedComponents["schemas"]["UserPage"];
 export type RunResource = GeneratedComponents["schemas"]["RunResource"];
 export type RunStatus = RunResource["status"];
-export type RunCreateOptions = GeneratedComponents["schemas"]["RunCreateOptions"];
+export type RunCreateOptions = GeneratedComponents["schemas"]["RunCreateOptionsBase"];
 export type RunBatchCreateOptions = GeneratedComponents["schemas"]["RunBatchCreateOptions"];
-export type RunBatchCreateRequest = GeneratedComponents["schemas"]["RunBatchCreateRequest"];
 export type RunBatchCreateResponse = GeneratedComponents["schemas"]["RunBatchCreateResponse"];
 export type { RunSummary } from "./runSummary";
 


### PR DESCRIPTION
## Summary
This PR delivers a ground-up simplification of run streaming and config publish UX while standardizing auth/routing on workspace-scoped run APIs.

### Key outcomes
- Converges run endpoints and authorization to workspace scope.
- Simplifies SSE streaming contract and frontend stream client behavior.
- Replaces publish confirm + terminal split with a polished modal-embedded publish experience.
- Enforces deterministic read-only behavior for active/archived configurations, including stale-cache hardening.

## Backend changes
- Removed legacy config-scoped and global run API routes; standardized workspace-scoped run routes.
- Standardized run RBAC usage for read/manage operations.
- Simplified run event streaming behavior and payload handling.
- Updated run links/schema outputs to canonical workspace-scoped URLs.
- Hardened configuration file-listing ETag behavior so status/capability transitions cannot return stale draft responses.
- Regenerated OpenAPI schema.

## Frontend changes
- Unified run creation and stream usage paths across publish/validate/process.
- Added EventSource-based stream utility and removed manual parser/fallback complexity.
- Introduced `PublishConfigurationDialog` with explicit phases: confirm, running, succeeded, failed.
- Embedded publish console stream in the dialog with clear success/failure UX and connection state cues.
- Enforced one clear editability model:
  - `capabilities.editable` remains canonical,
  - active/archived are fail-closed read-only,
  - freshness gates prevent stale on-mount state from showing draft controls.
- Updated document/runs callsites to workspace-scoped run URLs and APIs.
- Regenerated frontend OpenAPI types.

## Tests
### Backend
- Updated run streaming integration coverage (ready/message/end, resume behavior, deterministic terminal handling).
- Updated/expanded configuration editing capability coverage, including conditional request behavior across status transitions.
- Updated route/schema integration tests for workspace-scoped runs.

### Frontend
- Added publish dialog component tests.
- Added workbench publish-flow tests (read-only latch, retry flow, fresh snapshot gating).
- Added config detail read-only/freshness regression tests.
- Updated run API tests for new stream/client behavior.

## Validation performed
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test`
- `cd backend && uv run pytest tests/api/integration/configs/test_configurations_editing.py -q`
- `cd backend && uv run ade test`
