### PR TITLE
fix: add stopgap workspace return action in organization topbar

### DIFF
--- a/frontend/src/app/layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/app/layouts/AuthenticatedLayout.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode } from "react";
-import { Outlet } from "react-router-dom";
+import { Link, Outlet, useLocation } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
 
 import {
   AuthenticatedTopbarProvider,
   useAuthenticatedTopbarConfig,
 } from "@/app/layouts/components/topbar/AuthenticatedTopbarContext";
 import { UnifiedTopbarControls } from "@/app/layouts/components/topbar/UnifiedTopbarControls";
+import { Button } from "@/components/ui/button";
 import {
   Topbar,
   TopbarCenter,
@@ -59,14 +61,28 @@ export function AuthenticatedLayout() {
 
 function AuthenticatedLayoutInner() {
   const topbarConfig = useAuthenticatedTopbarConfig();
+  const location = useLocation();
+  const isOrganizationRoute =
+    location.pathname === "/organization" || location.pathname.startsWith("/organization/");
+  const shouldRenderTopbarStart = isOrganizationRoute || Boolean(topbarConfig?.mobileAction);
 
   const topbar = (
     <Topbar className="shadow-sm">
       <SkipToContent />
       <TopbarContent maxWidth="full" className="px-4 sm:px-6 lg:px-8">
-        {topbarConfig?.mobileAction ? (
+        {shouldRenderTopbarStart ? (
           <TopbarStart className="relative z-10">
-            <div className="md:hidden">{topbarConfig.mobileAction}</div>
+            {isOrganizationRoute ? (
+              <Button asChild variant="outline" size="sm" className="h-9">
+                <Link to="/workspaces">
+                  <ArrowLeft className="size-4" />
+                  <span>Go back to workspace</span>
+                </Link>
+              </Button>
+            ) : null}
+            {topbarConfig?.mobileAction ? (
+              <div className="md:hidden">{topbarConfig.mobileAction}</div>
+            ) : null}
           </TopbarStart>
         ) : null}
         <TopbarCenter className="hidden md:flex">

--- a/frontend/src/app/layouts/__tests__/AuthenticatedLayout.test.tsx
+++ b/frontend/src/app/layouts/__tests__/AuthenticatedLayout.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import { useMemo } from "react";
+import userEvent from "@testing-library/user-event";
 import { createMemoryRouter, RouterProvider, type RouteObject } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
@@ -79,5 +80,24 @@ describe("AuthenticatedLayout", () => {
     expect(await screen.findByTestId("plain-page")).toBeInTheDocument();
     expect(screen.queryByTestId("desktop-slot")).not.toBeInTheDocument();
     expect(screen.queryByTestId("mobile-slot")).not.toBeInTheDocument();
+  });
+
+  it("renders a workspace return action on organization routes", async () => {
+    const user = userEvent.setup();
+    const router = renderRouter(
+      ["/organization/users"],
+      [
+        { path: "organization/*", element: <PlainPage /> },
+        { path: "workspaces", element: <PlainPage /> },
+      ],
+    );
+
+    expect(screen.getByRole("link", { name: "Go back to workspace" })).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(screen.getByRole("link", { name: "Go back to workspace" }));
+    });
+
+    expect(router.state.location.pathname).toBe("/workspaces");
   });
 });


### PR DESCRIPTION
## Summary
Adds a minimal stopgap navigation affordance for organization settings pages: a left-aligned `Go back to workspace` button in the global authenticated topbar.

This intentionally avoids broader navigation redesign and keeps the current structure in place while removing the immediate dead-end feeling in org/admin routes.

## Changes
- `frontend/src/app/layouts/AuthenticatedLayout.tsx`
  - Detects `/organization` and `/organization/*` routes.
  - Renders `Go back to workspace` action in `TopbarStart` when in organization context.
  - Keeps existing topbar center/end behavior unchanged.
- `frontend/src/app/layouts/__tests__/AuthenticatedLayout.test.tsx`
  - Adds coverage that the button appears on organization routes.
  - Verifies clicking it navigates to `/workspaces`.

## Scope
- No URL contract changes.
- No topbar theme/color changes.
- No sidebar/navigation information architecture changes.

## Validation
- `cd backend && uv run ade test`
- `cd backend && uv run ade web lint`

Both commands pass.
