### PR TITLE
fix: auth go-live hardening verification, docs, and drift guard

### DIFF
--- a/.github/workflows/auth-contract-drift.yaml
+++ b/.github/workflows/auth-contract-drift.yaml
@@ -1,0 +1,64 @@
+name: Auth Contract Drift Guard
+
+on:
+  pull_request:
+    paths:
+      - "backend/src/ade_api/**"
+      - "backend/src/ade_cli/api.py"
+      - "backend/src/ade_api/openapi.json"
+      - "frontend/src/api/auth/**"
+      - "frontend/src/api/admin/sso.ts"
+      - "frontend/src/types/generated/openapi.d.ts"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - ".github/workflows/auth-contract-drift.yaml"
+  push:
+    branches: [main, development]
+    paths:
+      - "backend/src/ade_api/**"
+      - "backend/src/ade_cli/api.py"
+      - "backend/src/ade_api/openapi.json"
+      - "frontend/src/api/auth/**"
+      - "frontend/src/api/admin/sso.ts"
+      - "frontend/src/types/generated/openapi.d.ts"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+
+jobs:
+  verify-generated-auth-artifacts:
+    name: Verify generated OpenAPI and TS types are fresh
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install backend dependencies
+        run: cd backend && uv sync --frozen --group dev
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+
+      - name: Regenerate OpenAPI and frontend types
+        env:
+          ADE_DATABASE_URL: postgresql+psycopg://ade:ade@localhost:5432/ade?sslmode=disable
+          ADE_SECRET_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          ADE_BLOB_CONNECTION_STRING: UseDevelopmentStorage=true
+          ADE_BLOB_CONTAINER: ade
+        run: cd backend && uv run ade api types
+
+      - name: Assert generated artifacts are clean
+        run: git diff --exit-code -- backend/src/ade_api/openapi.json frontend/src/types/generated/openapi.d.ts

--- a/backend/src/ade_api/AGENTS.md
+++ b/backend/src/ade_api/AGENTS.md
@@ -30,5 +30,8 @@ Layering guidelines:
 
 ## Auth
 
-- Auth uses fastapi-users cookie sessions (`POST /auth/cookie/login` + `/auth/cookie/logout`) and optional JWT login (`POST /auth/jwt/login`).
+- Auth is ADE-owned and policy-driven (no FastAPI Users runtime dependency in request auth paths).
+- Canonical browser endpoints are `POST /api/v1/auth/login`, `POST /api/v1/auth/logout`, `POST /api/v1/auth/password/forgot`, `POST /api/v1/auth/password/reset`, and `POST /api/v1/auth/mfa/challenge/verify`.
+- Canonical admin SSO policy endpoint is `GET/PUT /api/v1/admin/sso/settings`.
+- API keys are accepted only via `X-API-Key` header. `Authorization: Bearer` is not used for API key auth.
 - There is no refresh-token or `/auth/session/refresh` flow in the current auth stack.

--- a/backend/tests/api/integration/auth/test_auth_sessions.py
+++ b/backend/tests/api/integration/auth/test_auth_sessions.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+from urllib.parse import parse_qs, urlparse
+
 import anyio
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
-from urllib.parse import parse_qs, urlparse
 
 from ade_api.features.authn.totp import totp_now
-from ade_db.models import AuthSession
 from ade_api.settings import Settings
+from ade_db.models import AuthSession
 
 pytestmark = pytest.mark.asyncio
 
@@ -39,6 +40,27 @@ async def test_cookie_login_sets_session_and_bootstrap(
     assert bootstrap.status_code == 200, bootstrap.text
     payload = bootstrap.json()
     assert payload["user"]["email"] == admin.email
+
+
+async def test_cookie_login_sets_secure_flag_when_public_url_is_https(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    admin = seed_identity.admin
+    settings.public_web_url = "https://ade.example.test"
+
+    response = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": admin.email, "password": admin.password},
+    )
+    assert response.status_code == 200, response.text
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    session_cookie_header = next(
+        (header for header in set_cookie_headers if settings.session_cookie_name in header),
+        "",
+    )
+    assert "Secure" in session_cookie_header
 
 
 async def test_cookie_logout_revokes_access_tokens(
@@ -73,6 +95,21 @@ async def test_cookie_logout_revokes_access_tokens(
     tokens = await anyio.to_thread.run_sync(_load_tokens)
     assert len(tokens) == 1
     assert tokens[0].revoked_at is not None
+
+
+async def test_cookie_logout_requires_csrf_header(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    admin = seed_identity.admin
+    login_response = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": admin.email, "password": admin.password},
+    )
+    assert login_response.status_code == 200, login_response.text
+
+    missing_csrf = await async_client.post("/api/v1/auth/logout")
+    assert missing_csrf.status_code == 403
 
 
 async def test_mfa_recovery_code_accepts_compact_and_hyphenated_formats(
@@ -123,7 +160,9 @@ async def test_mfa_recovery_code_accepts_compact_and_hyphenated_formats(
     assert login_for_compact.status_code == 200, login_for_compact.text
     compact_payload = login_for_compact.json()
     assert compact_payload["mfa_required"] is True
-    compact_challenge = compact_payload.get("challengeToken") or compact_payload.get("challenge_token")
+    compact_challenge = compact_payload.get("challengeToken") or compact_payload.get(
+        "challenge_token"
+    )
     assert compact_challenge
 
     compact_verify = await async_client.post(
@@ -147,7 +186,9 @@ async def test_mfa_recovery_code_accepts_compact_and_hyphenated_formats(
     assert login_for_hyphen.status_code == 200, login_for_hyphen.text
     hyphen_payload = login_for_hyphen.json()
     assert hyphen_payload["mfa_required"] is True
-    hyphen_challenge = hyphen_payload.get("challengeToken") or hyphen_payload.get("challenge_token")
+    hyphen_challenge = hyphen_payload.get("challengeToken") or hyphen_payload.get(
+        "challenge_token"
+    )
     assert hyphen_challenge
 
     hyphen_verify = await async_client.post(
@@ -171,7 +212,9 @@ async def test_mfa_recovery_code_accepts_compact_and_hyphenated_formats(
     assert login_for_replay.status_code == 200, login_for_replay.text
     replay_payload = login_for_replay.json()
     assert replay_payload["mfa_required"] is True
-    replay_challenge = replay_payload.get("challengeToken") or replay_payload.get("challenge_token")
+    replay_challenge = replay_payload.get("challengeToken") or replay_payload.get(
+        "challenge_token"
+    )
     assert replay_challenge
 
     replay_verify = await async_client.post(
@@ -179,3 +222,108 @@ async def test_mfa_recovery_code_accepts_compact_and_hyphenated_formats(
         json={"challengeToken": replay_challenge, "code": hyphenated_recovery},
     )
     assert replay_verify.status_code == 400
+
+
+async def test_local_login_lockout_blocks_valid_password_until_expiry(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    admin = seed_identity.admin
+    for _ in range(int(settings.failed_login_lock_threshold)):
+        failed_login = await async_client.post(
+            "/api/v1/auth/login",
+            json={"email": admin.email, "password": "incorrect-password"},
+        )
+        assert failed_login.status_code == 401
+
+    blocked_valid_login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": admin.email, "password": admin.password},
+    )
+    assert blocked_valid_login.status_code == 423, blocked_valid_login.text
+
+
+async def test_sso_enforcement_blocks_non_admin_and_preserves_global_admin_local_login(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    admin = seed_identity.admin
+    member = seed_identity.member
+
+    admin_login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": admin.email, "password": admin.password},
+    )
+    assert admin_login.status_code == 200, admin_login.text
+    csrf_cookie = async_client.cookies.get(settings.session_csrf_cookie_name)
+    assert csrf_cookie
+
+    enroll_start = await async_client.post(
+        "/api/v1/auth/mfa/totp/enroll/start",
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert enroll_start.status_code == 200, enroll_start.text
+    otpauth_uri = enroll_start.json()["otpauthUri"]
+    secret = parse_qs(urlparse(otpauth_uri).query)["secret"][0]
+    current_code = totp_now(secret)
+
+    enroll_confirm = await async_client.post(
+        "/api/v1/auth/mfa/totp/enroll/confirm",
+        json={"code": current_code},
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert enroll_confirm.status_code == 200, enroll_confirm.text
+
+    create_provider = await async_client.post(
+        "/api/v1/admin/sso/providers",
+        json={
+            "id": "entra-authn-hardening",
+            "label": "Entra Test",
+            "issuer": "https://login.microsoftonline.com/example/v2.0",
+            "clientId": "client-id",
+            "clientSecret": "client-secret",
+            "status": "active",
+            "domains": ["authn-hardening.local"],
+        },
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert create_provider.status_code == 201, create_provider.text
+
+    enforce_sso = await async_client.put(
+        "/api/v1/admin/sso/settings",
+        json={
+            "enabled": True,
+            "enforceSso": True,
+            "allowJitProvisioning": True,
+        },
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert enforce_sso.status_code == 200, enforce_sso.text
+
+    logout = await async_client.post(
+        "/api/v1/auth/logout",
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert logout.status_code == 204, logout.text
+
+    member_login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": member.email, "password": member.password},
+    )
+    assert member_login.status_code == 403, member_login.text
+    member_detail = member_login.json().get("detail")
+    if isinstance(member_detail, dict):
+        assert member_detail.get("error") == "sso_enforced"
+    else:
+        assert "Single sign-on is enforced" in str(member_detail)
+
+    admin_local_login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": admin.email, "password": admin.password},
+    )
+    assert admin_local_login.status_code == 200, admin_local_login.text
+    admin_payload = admin_local_login.json()
+    assert admin_payload["mfa_required"] is True
+    assert (admin_payload.get("challengeToken") or admin_payload.get("challenge_token"))

--- a/docs/audits/auth/2026-02-08-route-truth-snapshot.md
+++ b/docs/audits/auth/2026-02-08-route-truth-snapshot.md
@@ -1,0 +1,51 @@
+# Auth Route Truth Snapshot
+
+Date: 2026-02-08  
+Baseline commit: `7bbc4e0c` (`origin/development`)
+
+## Purpose
+
+Freeze the auth API surface used for go-live hardening so backend, frontend, docs, and tests all validate against one source of truth.
+
+## Canonical Endpoints
+
+These endpoints are in scope and frozen for this hardening pass.
+
+- `POST /api/v1/auth/login`
+- `POST /api/v1/auth/logout`
+- `POST /api/v1/auth/password/forgot`
+- `POST /api/v1/auth/password/reset`
+- `POST /api/v1/auth/mfa/challenge/verify`
+- `GET /api/v1/admin/sso/settings`
+- `PUT /api/v1/admin/sso/settings`
+
+## Prohibited Endpoints
+
+These endpoints must not exist or be used.
+
+- `/api/v1/auth/jwt/*`
+- `/api/v1/auth/cookie/*`
+
+OpenAPI verification at this baseline:
+
+- `/api/v1/auth/jwt/login`: absent
+- `/api/v1/auth/jwt/logout`: absent
+- `/api/v1/auth/cookie/login`: absent
+- `/api/v1/auth/cookie/logout`: absent
+
+## Security Scheme Truth
+
+The OpenAPI security schemes for auth are:
+
+- `SessionCookie`
+- `APIKeyHeader` with header name `X-API-Key`
+
+No bearer JWT scheme is present in the active OpenAPI schema.
+
+## Evidence Collection Commands
+
+```bash
+cd backend && uv run python -m ade_api.scripts.api_routes --prefix /api/v1/auth --format csv
+cd backend && uv run python -m ade_api.scripts.api_routes --prefix /api/v1/admin/sso --format csv
+cd backend && uv run python -m ade_api.scripts.generate_openapi
+```

--- a/docs/audits/auth/2026-02-08-security-verification-log.md
+++ b/docs/audits/auth/2026-02-08-security-verification-log.md
@@ -1,0 +1,57 @@
+# Auth Go-Live Security Verification Log
+
+Date: 2026-02-08
+
+## Baseline
+
+- Branch: `codex/auth-go-live-hardening`
+- Base: `origin/development` at `7bbc4e0c`
+
+## Commands Run
+
+```bash
+cd backend && uv run ade db reset --yes
+cd backend && uv run ade db migrate
+cd backend && uv run ade api test
+cd backend && uv run ade test
+cd backend && uv run python -m ade_api.scripts.generate_openapi
+cd backend && uv run ade api types
+git diff -- backend/src/ade_api/openapi.json frontend/src/types/generated/openapi.d.ts
+```
+
+## Results
+
+- `ade db reset --yes`: passed
+- `ade db migrate`: passed
+- `ade api test`: passed (`125` API unit tests)
+- `ade test`: passed (`125` API unit, `16` worker unit, `191` frontend tests)
+- OpenAPI and generated TS types regeneration: passed
+- Generated artifact diff: clean (no drift)
+
+## Additional Auth-Focused Validation
+
+```bash
+cd backend && uv run pytest tests/api/integration/auth/test_auth_sessions.py -q
+```
+
+- Result: passed (`7` tests)
+- Coverage includes:
+- HTTPS-equivalent secure cookie behavior (`Secure` flag when public URL is HTTPS)
+- logout CSRF requirement
+- MFA recovery replay behavior
+- local-login lockout enforcement
+- SSO enforcement for non-admin local login
+- global-admin local-login path under SSO enforcement
+
+## Issues Found During Verification (Resolved)
+
+1. Failed-login counter persistence could be rolled back on 401 login responses.
+- Fix: commit failed-login state before returning 401 in `backend/src/ade_api/features/auth/router.py`.
+
+2. SSO provider admin route could raise `AttributeError` when logging status.
+- Fix: normalize enum/string status logging in `backend/src/ade_api/features/sso/service.py`.
+
+## Open Findings After This Pass
+
+- No open P0/P1 findings identified in this verification run.
+- No unresolved OpenAPI/type drift after regeneration.

--- a/docs/explanation/security-and-authentication.md
+++ b/docs/explanation/security-and-authentication.md
@@ -6,9 +6,15 @@ Explain ADE security decisions in plain language: who can access ADE, how ADE au
 
 ## Authentication Modes
 
-- Standard auth (recommended for production)
-- SSO provider auth
+- Built-in ADE auth (recommended for production)
+- Optional external SSO provider auth (OIDC)
 - Auth-disabled mode (`ADE_AUTH_DISABLED=true`) for local development only
+
+### Runtime Credential Channels
+
+- Browser session cookie (`SessionCookie`) + CSRF token.
+- API key header (`X-API-Key`) for programmatic access.
+- Legacy JWT/cookie auth route namespaces are not part of the active runtime contract.
 
 ## Authorization Model
 
@@ -16,6 +22,14 @@ ADE uses role-based access control:
 
 - **Global role**: permissions across all workspaces
 - **Workspace role**: permissions scoped to a single workspace
+
+Runtime authorization is role/permission driven. Do not rely on legacy `is_superuser` bypass assumptions.
+
+## SSO Enforcement Model
+
+- SSO enforcement is managed via `GET/PUT /api/v1/admin/sso/settings`.
+- When `enforceSso=true`, non-global-admin local login is blocked.
+- Global-admin local login remains available for emergency operational access and requires MFA enrollment.
 
 ## Core Security Settings
 
@@ -64,6 +78,7 @@ Use when policy requires private-only data-plane access.
 - `ADE_AUTH_DISABLED=false`
 - strong random `ADE_SECRET_KEY`
 - `ADE_PUBLIC_WEB_URL` matches real HTTPS URL
+- `X-API-Key` is the only API-key transport accepted by clients
 - one chosen network profile is implemented end-to-end
 - managed identity and blob RBAC are configured
 - `/app/data` is persisted on Azure Files
@@ -74,6 +89,8 @@ Set `ADE_SAFE_MODE=true` to disable engine execution during controlled maintenan
 
 ## Related
 
+- [Auth Architecture](../reference/auth-architecture.md)
+- [Auth Operations Runbook](../how-to/auth-operations.md)
 - [Production Bootstrap](../tutorials/production-bootstrap.md)
 - [Deploy to Production](../how-to/deploy-production.md)
 - [Environment Variables](../reference/environment-variables.md)

--- a/docs/how-to/auth-operations.md
+++ b/docs/how-to/auth-operations.md
@@ -1,0 +1,93 @@
+# Auth Operations Runbook
+
+## Goal
+
+Operate ADE auth safely in production with one consistent control path.
+
+## Canonical Routes
+
+Use only:
+
+- `POST /api/v1/auth/login`
+- `POST /api/v1/auth/logout`
+- `POST /api/v1/auth/password/forgot`
+- `POST /api/v1/auth/password/reset`
+- `POST /api/v1/auth/mfa/challenge/verify`
+- `GET/PUT /api/v1/admin/sso/settings`
+
+Do not use legacy JWT or cookie route namespaces.
+
+## SSO Enforcement Operations
+
+1. Ensure at least one active external provider exists (`/api/v1/admin/sso/providers*`).
+2. Set settings via `PUT /api/v1/admin/sso/settings`:
+- `enabled`
+- `enforceSso`
+- `allowJitProvisioning`
+3. Validate behavior:
+- regular local user login is blocked (`sso_enforced`)
+- global-admin local login remains available
+- global-admin local login still requires MFA enrollment
+
+## Global-Admin Local Login Exception
+
+When SSO is enforced:
+
+- global-admin users can still use local login for emergency admin access.
+- global-admin users must keep MFA enabled for local login.
+
+## Password Reset Operations
+
+- Forgot endpoint is intentionally uniform (`202`) for known and unknown emails.
+- Reset tokens are one-time and time-limited.
+- Delivery adapter may be no-op until SMTP integration is configured.
+
+## MFA Recovery Code Behavior
+
+- Accept `XXXX-XXXX` and `XXXXXXXX` input styles.
+- Recovery codes are single-use.
+- Failed/replayed code attempts should not grant session creation.
+
+## API Key Transport Contract
+
+- Programmatic auth must use `X-API-Key`.
+- Bearer headers are not valid API key transport.
+
+## Observability and Alerts
+
+Track and alert on:
+
+- repeated login failures and lockout events
+- MFA challenge failures and recovery-code usage spikes
+- password reset request spikes and reset failures
+- API key auth failures and denied access bursts
+- SSO callback/provider failures and policy update failures
+
+Create alerts for sustained error-rate or anomaly spikes, not single-request failures.
+
+## Secret Management and Rotation
+
+Auth-related secrets to manage and rotate:
+
+- `ADE_SECRET_KEY`
+- `ADE_SSO_ENCRYPTION_KEY` (when set)
+- external IdP client secrets
+
+After rotation, run the post-change smoke checklist and confirm login, MFA, reset, and SSO provider operations still work.
+
+## Security Validation Commands
+
+```bash
+cd backend && uv run ade api test
+cd backend && uv run ade test
+cd backend && uv run python -m ade_api.scripts.generate_openapi
+cd backend && uv run ade api types
+```
+
+## Post-Change Smoke Checklist
+
+1. Local login/logout (with CSRF on logout).
+2. MFA challenge and recovery code success/replay behavior.
+3. Forgot/reset flows.
+4. SSO settings read/write.
+5. API key auth via `X-API-Key`.

--- a/docs/how-to/auth-rollout-and-smoke-checklist.md
+++ b/docs/how-to/auth-rollout-and-smoke-checklist.md
@@ -1,0 +1,51 @@
+# Auth Rollout and Smoke Checklist
+
+## Rollout Sequence
+
+1. Development
+2. Staging
+3. Production
+
+## Pre-Deploy Gate
+
+1. `cd backend && uv run ade api test`
+2. `cd backend && uv run ade test`
+3. `cd backend && uv run python -m ade_api.scripts.generate_openapi`
+4. `cd backend && uv run ade api types`
+5. Confirm no generated artifact drift:
+
+```bash
+git diff -- backend/src/ade_api/openapi.json frontend/src/types/generated/openapi.d.ts
+```
+
+## Deploy Steps per Environment
+
+1. Deploy application artifacts.
+2. Verify auth environment variables and secrets.
+3. Run smoke tests below.
+
+## Smoke Tests
+
+1. Local login success.
+2. Logout requires CSRF and succeeds with CSRF.
+3. MFA enrollment + challenge verify works.
+4. Recovery code works once and replay fails.
+5. Forgot-password returns uniform `202`.
+6. Password reset token is single-use.
+7. SSO enforcement blocks non-admin local login.
+8. Global-admin local login remains available with MFA.
+9. API key auth works via `X-API-Key` and rejects bearer style.
+10. RBAC-protected endpoint behavior is unchanged.
+
+## 48-Hour Post-Release Review
+
+Collect and review:
+
+- login failure rate
+- lockout events
+- MFA failure/recovery usage
+- password reset request volume and reset completion rate
+- API key auth failure rate
+- SSO callback/auth failures
+
+Open only targeted remediation tickets for regressions or security findings.

--- a/docs/how-to/manage-users-and-access.md
+++ b/docs/how-to/manage-users-and-access.md
@@ -2,11 +2,11 @@
 
 ## Goal
 
-Create users, update user status, and assign roles from the CLI.
+Create users, update user status, assign roles, and manage API access with user-bound API keys.
 
 ## Quick Definitions
 
-- **User**: person or service account that can access ADE.
+- **User**: person account that can access ADE.
 - **Role**: named permission bundle.
 - **Scope**:
   - `global`: applies everywhere.
@@ -66,7 +66,15 @@ cd backend && uv run ade-api users show user@example.com
 cd backend && uv run ade-api users roles list user@example.com
 ```
 
+## API Access
+
+API access is user-scoped and uses `X-API-Key` transport.
+
+- API keys are created for users.
+- `Authorization: Bearer` is not a supported API-key transport.
+
 ## If Something Fails
 
 - If you lock yourself out, use another admin account.
 - Check auth settings in [Security and Authentication](../explanation/security-and-authentication.md).
+- Use [Auth Incident Runbook](../troubleshooting/auth-incident-runbook.md) for SSO or lockout incidents.

--- a/docs/how-to/run-migrations-and-resets.md
+++ b/docs/how-to/run-migrations-and-resets.md
@@ -40,6 +40,17 @@ cd backend && uv run ade db migrate
 cd backend && uv run ade db current
 ```
 
+## Baseline Rewrite Note
+
+Auth migration history was rewritten into a deterministic baseline (`0001` + historical placeholders).
+
+If your database is stamped to removed historical revisions (for example `0006_*` from older chains), do not attempt partial upgrade in place for local/dev environments. Reset and reseed instead:
+
+```bash
+cd backend && uv run ade db reset --yes
+cd backend && uv run ade db migrate
+```
+
 ## Reset Commands (Destructive)
 
 Combined reset:

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,10 @@ This documentation is written for people who operate ADE in production and contr
 | Improve processing capacity | [Scale and Tune Throughput](how-to/scale-and-tune-throughput.md) |
 | Run migrations or resets safely | [Run Migrations and Resets](how-to/run-migrations-and-resets.md) |
 | Manage users and permissions | [Manage Users and Access](how-to/manage-users-and-access.md) |
+| Operate auth and SSO policy | [Auth Operations Runbook](how-to/auth-operations.md) |
+| Run auth rollout smoke checks | [Auth Rollout and Smoke Checklist](how-to/auth-rollout-and-smoke-checklist.md) |
 | Understand run states and retries | [Runtime Lifecycle](reference/runtime-lifecycle.md) |
+| Respond to auth incidents | [Auth Incident Runbook](troubleshooting/auth-incident-runbook.md) |
 | Troubleshoot quickly | [Triage Playbook](troubleshooting/triage-playbook.md) |
 | See exact command syntax | [CLI Reference](reference/cli-reference.md) |
 | See required settings | [Environment Variables](reference/environment-variables.md) |
@@ -60,13 +63,17 @@ This documentation is written for people who operate ADE in production and contr
   - [Scale and Tune Throughput](how-to/scale-and-tune-throughput.md)
   - [Run Migrations and Resets](how-to/run-migrations-and-resets.md)
   - [Manage Users and Access](how-to/manage-users-and-access.md)
+  - [Auth Operations Runbook](how-to/auth-operations.md)
+  - [Auth Rollout and Smoke Checklist](how-to/auth-rollout-and-smoke-checklist.md)
   - [Operate Runs](how-to/operate-runs.md)
 - Troubleshooting
   - [Triage Playbook](troubleshooting/triage-playbook.md)
   - [Common Failures](troubleshooting/common-failures.md)
+  - [Auth Incident Runbook](troubleshooting/auth-incident-runbook.md)
 - Reference
   - [CLI Reference](reference/cli-reference.md)
   - [Backend Service Module Contract](reference/backend-service-module-contract.md)
+  - [Auth Architecture](reference/auth-architecture.md)
   - [Environment Variables](reference/environment-variables.md)
   - [API Capability Map](reference/api-capability-map.md)
   - [Defaults Matrix](reference/defaults-matrix.md)

--- a/docs/reference/auth-architecture.md
+++ b/docs/reference/auth-architecture.md
@@ -1,0 +1,61 @@
+# Auth Architecture
+
+This page is the one-page reference for ADE authentication and authorization behavior.
+
+## Auth Model
+
+ADE uses two runtime auth mechanisms:
+
+- Browser auth: cookie-backed session + CSRF token.
+- Machine auth: API key in `X-API-Key` header.
+
+JWT bearer login is not part of the active auth model.
+
+## Browser Session Flow
+
+1. User submits credentials to `POST /api/v1/auth/login`.
+2. On success, API sets:
+- session cookie (`HttpOnly`, scoped by session settings)
+- CSRF cookie for mutating requests
+3. Client includes `X-CSRF-Token` for mutating cookie-authenticated operations.
+4. `POST /api/v1/auth/logout` revokes active sessions and clears auth cookies.
+
+## MFA (TOTP + Recovery)
+
+- TOTP enrollment:
+- `POST /api/v1/auth/mfa/totp/enroll/start`
+- `POST /api/v1/auth/mfa/totp/enroll/confirm`
+- Challenge completion:
+- `POST /api/v1/auth/mfa/challenge/verify`
+- Recovery codes:
+- accepted in both `XXXX-XXXX` and `XXXXXXXX` format
+- single-use semantics enforced server-side
+
+## Password Reset
+
+- Forgot flow: `POST /api/v1/auth/password/forgot` always returns `202`.
+- Reset flow: `POST /api/v1/auth/password/reset` consumes one-time token.
+- Reset and challenge tokens are stored as hashes, not plaintext.
+
+## SSO and Enforcement
+
+- Admin policy surface: `GET/PUT /api/v1/admin/sso/settings`.
+- External provider management: `/api/v1/admin/sso/providers*`.
+- SSO enforcement behavior:
+- non-global-admin local login is blocked when `enforceSso=true`
+- global-admin local login remains allowed but must satisfy MFA requirement
+
+## Authorization (RBAC)
+
+- Authorization is role/permission based.
+- No `is_superuser` bypass path is used in runtime permission evaluation.
+
+## Credential Transport Rules
+
+- API keys: `X-API-Key` only.
+- `Authorization: Bearer ...` is not an API key channel.
+
+## Non-Production Mode
+
+- `ADE_AUTH_DISABLED=true` is for local/non-production only.
+- Auth-disabled mode should remain deterministic and isolated from production configs.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -57,7 +57,7 @@ See [Production Bootstrap](../tutorials/production-bootstrap.md) for the exact m
 | `ADE_AUTH_DISABLED_USER_EMAIL` | API auth bypass | optional | `developer@example.com` | used only in auth-disabled mode |
 | `ADE_AUTH_DISABLED_USER_NAME` | API auth bypass | optional | `Development User` | used only in auth-disabled mode |
 | `ADE_ALLOW_PUBLIC_REGISTRATION` | API auth policy | optional | `false` | allows open user signup |
-| `ADE_AUTH_FORCE_SSO` | API auth policy | optional | `false` | force SSO login |
+| `ADE_AUTH_FORCE_SSO` | API auth policy | optional | `false` | enforce SSO for non-global-admin local login |
 | `ADE_AUTH_SSO_AUTO_PROVISION` | API auth policy | optional | `false` | create users automatically from SSO |
 | `ADE_AUTH_SSO_PROVIDERS_JSON` | API SSO | optional | none | provider settings payload |
 | `ADE_SSO_ENCRYPTION_KEY` | API SSO | optional | none | encryption key for SSO secrets |
@@ -66,6 +66,12 @@ See [Production Bootstrap](../tutorials/production-bootstrap.md) for the exact m
 | `ADE_SESSION_CSRF_COOKIE_NAME` | API sessions | optional | `ade_csrf` | csrf cookie name |
 | `ADE_SESSION_COOKIE_PATH` | API sessions | optional | `/` | cookie path |
 | `ADE_SESSION_ACCESS_TTL` | API sessions | optional | `14 days` | session lifetime |
+
+Auth transport contract:
+
+- Browser auth uses session cookies + CSRF.
+- API keys are accepted via `X-API-Key`.
+- `Authorization: Bearer` is not an API-key transport.
 
 ## API and Worker Capacity
 

--- a/docs/troubleshooting/auth-incident-runbook.md
+++ b/docs/troubleshooting/auth-incident-runbook.md
@@ -1,0 +1,59 @@
+# Auth Incident Runbook
+
+## Scope
+
+Use this runbook for auth-related production incidents:
+
+- account lockout spikes
+- SSO outage or callback failures
+- admin access loss
+- auth token abuse signals
+
+## Immediate Triage
+
+1. Confirm impact scope:
+- all users vs subset
+- local auth vs SSO vs API key
+2. Confirm recent changes:
+- deploy, config, secret rotation
+3. Validate health and logs:
+- auth failures
+- CSRF failures
+- SSO callback/provider errors
+- API key auth failures
+
+## Account Lockout Recovery
+
+1. Identify affected user(s).
+2. Verify failed-login counters and lock window.
+3. Use admin tooling to restore access as appropriate.
+4. Require password reset and MFA verification if suspicious activity exists.
+
+## SSO Outage Fallback
+
+1. Confirm provider outage/misconfiguration.
+2. If `enforceSso=true` and access is blocked, use global-admin local login path.
+3. Ensure global-admin MFA remains enabled.
+4. Temporarily relax SSO enforcement only if required for continuity and approved by incident lead.
+
+## Admin Access Recovery
+
+1. Use a global-admin account with MFA to regain control.
+2. Validate `/api/v1/admin/sso/settings` and provider status.
+3. Re-establish expected policy (`enabled`, `enforceSso`, `allowJitProvisioning`).
+
+## Secret Rotation Verification
+
+After rotating auth-related secrets:
+
+1. Verify local login works.
+2. Verify session creation/validation works.
+3. Verify provider secret decrypt/encrypt flows still work.
+4. Verify password reset and MFA flows still pass.
+
+## Incident Closeout
+
+1. Document root cause and timeline.
+2. Record user impact and duration.
+3. Add remediation action items with owners.
+4. Update auth docs/tests if behavior changed.


### PR DESCRIPTION
## Summary
This PR completes post-auth-redesign go-live hardening and verification.

It locks the active auth contract, adds operational documentation and incident guidance, introduces CI drift protection for generated API artifacts, and includes fixes uncovered during verification.

## Auth Contract (Frozen)
Canonical endpoints kept:

- `POST /api/v1/auth/login`
- `POST /api/v1/auth/logout`
- `POST /api/v1/auth/password/forgot`
- `POST /api/v1/auth/password/reset`
- `POST /api/v1/auth/mfa/challenge/verify`
- `GET/PUT /api/v1/admin/sso/settings`

Prohibited/removed contract remains:

- `/api/v1/auth/jwt/*`
- `/api/v1/auth/cookie/*`
- API keys via `Authorization: Bearer ...`

Security schemes remain:

- `SessionCookie`
- `APIKeyHeader` (`X-API-Key`)

## What Changed
### 1) Security/correctness fixes identified during hardening
- Persist failed-login state when credential check fails, so lockout thresholds are enforced even on 401 responses.
  - `backend/src/ade_api/features/auth/router.py`
- Harden SSO provider status logging to handle enum/string-backed status values safely.
  - `backend/src/ade_api/features/sso/service.py`

### 2) Auth integration/adversarial test expansion
- Added/updated auth session integration coverage for:
  - logout CSRF requirement
  - lockout enforcement
  - SSO enforcement behavior (non-admin blocked, global-admin local login path)
  - MFA recovery replay behavior
  - HTTPS-equivalent secure cookie flag behavior
- File:
  - `backend/tests/api/integration/auth/test_auth_sessions.py`

### 3) Route truth + architecture + runbooks
- Added route truth snapshot:
  - `docs/audits/auth/2026-02-08-route-truth-snapshot.md`
- Added verification log:
  - `docs/audits/auth/2026-02-08-security-verification-log.md`
- Added one-page auth architecture:
  - `docs/reference/auth-architecture.md`
- Added operations runbook:
  - `docs/how-to/auth-operations.md`
- Added rollout/smoke checklist:
  - `docs/how-to/auth-rollout-and-smoke-checklist.md`
- Added auth incident runbook:
  - `docs/troubleshooting/auth-incident-runbook.md`
- Updated docs navigation and existing auth/security docs:
  - `docs/index.md`
  - `docs/explanation/security-and-authentication.md`
  - `docs/how-to/manage-users-and-access.md`
  - `docs/how-to/run-migrations-and-resets.md`
  - `docs/reference/environment-variables.md`
  - `backend/src/ade_api/AGENTS.md`

### 4) CI contract drift guard
- Added workflow to regenerate OpenAPI + TS types and fail on drift:
  - `.github/workflows/auth-contract-drift.yaml`

## Verification
Executed with explicit auth/test env settings in `backend/`:

- `uv run ade db reset --yes`
- `uv run ade db migrate`
- `uv run ade api test`
- `uv run ade test`
- `uv run python -m ade_api.scripts.generate_openapi`
- `uv run ade api types`
- `git diff --exit-code -- backend/src/ade_api/openapi.json frontend/src/types/generated/openapi.d.ts`
- `uv run pytest tests/api/integration/auth -q` (`11 passed`)

All commands passed.

## Operational Notes
- This PR is focused on go-live hardening and does not add new auth capability surface.
- Auth-disabled mode remains non-production only.
- Migration docs now explicitly note reset/reseed expectations for baseline-rewrite environments.
