### PR TITLE
feat: first-class account center + reusable MFA onboarding

### DIFF
--- a/backend/src/ade_api/core/auth/principal.py
+++ b/backend/src/ade_api/core/auth/principal.py
@@ -31,3 +31,4 @@ class AuthenticatedPrincipal:
     auth_via: AuthVia
     api_key_id: UUID | None = None
     email: str | None = None
+    session_auth_method: str | None = None

--- a/backend/src/ade_api/features/api_keys/router.py
+++ b/backend/src/ade_api/features/api_keys/router.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response, Security, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    Response,
+    Security,
+    status,
+)
 
 from ade_api.api.deps import get_api_keys_service, get_api_keys_service_read
 from ade_api.common.concurrency import require_if_match
@@ -143,9 +153,13 @@ def list_api_keys(
     summary="List API keys for the current user",
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Authentication required."},
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Requires api_keys.manage_all global permission."
+        },
     },
 )
 def list_my_api_keys(
+    _: Annotated[None, Security(require_global("api_keys.manage_all"))],
     principal: Annotated[AuthenticatedPrincipal, Depends(get_current_principal)],
     service: ApiKeysServiceReadDep,
     list_query: Annotated[CursorQueryParams, Depends(cursor_query_params)],
@@ -180,11 +194,15 @@ def list_my_api_keys(
     summary="Create an API key for the current user",
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Authentication required."},
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Requires api_keys.manage_all global permission."
+        },
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid API key payload."},
     },
 )
 def create_my_api_key(
     payload: ApiKeyCreateRequest,
+    _: Annotated[None, Security(require_global("api_keys.manage_all"))],
     principal: Annotated[AuthenticatedPrincipal, Depends(get_current_principal)],
     service: ApiKeysServiceDep,
 ) -> ApiKeyCreateResponse:
@@ -209,12 +227,15 @@ def create_my_api_key(
     summary="Retrieve one of the current user's API keys",
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Authentication required."},
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Requires api_keys.manage_all global permission."
+        },
         status.HTTP_404_NOT_FOUND: {"description": "API key not found."},
-        status.HTTP_403_FORBIDDEN: {"description": "API key not owned by caller."},
     },
 )
 def read_my_api_key(
     api_key_id: ApiKeyPath,
+    _: Annotated[None, Security(require_global("api_keys.manage_all"))],
     principal: Annotated[AuthenticatedPrincipal, Depends(get_current_principal)],
     service: ApiKeysServiceReadDep,
     response: Response,
@@ -239,12 +260,15 @@ def read_my_api_key(
     summary="Revoke one of the current user's API keys",
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Authentication required."},
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Requires api_keys.manage_all global permission."
+        },
         status.HTTP_404_NOT_FOUND: {"description": "API key not found."},
-        status.HTTP_403_FORBIDDEN: {"description": "API key not owned by caller."},
     },
 )
 def revoke_my_api_key(
     api_key_id: ApiKeyPath,
+    _: Annotated[None, Security(require_global("api_keys.manage_all"))],
     principal: Annotated[AuthenticatedPrincipal, Depends(get_current_principal)],
     service: ApiKeysServiceDep,
     request: Request,

--- a/backend/src/ade_api/features/auth/sso_router.py
+++ b/backend/src/ade_api/features/auth/sso_router.py
@@ -502,7 +502,10 @@ def callback_sso(
             extra=log_context(provider_id=provider.id, user_id=str(user.id)),
         )
 
-        session_token = AuthnService(session=db, settings=settings).create_session(user_id=user.id)
+        session_token = AuthnService(session=db, settings=settings).create_session(
+            user_id=user.id,
+            auth_method="sso",
+        )
         db.commit()
 
         response = _success_response(request, settings, return_to=sanitized_return_to)

--- a/backend/src/ade_api/features/authn/schemas.py
+++ b/backend/src/ade_api/features/authn/schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import EmailStr, Field, SecretStr
 
 from ade_api.common.schema import BaseSchema
@@ -15,6 +17,8 @@ class AuthLoginRequest(BaseSchema):
 class AuthLoginSuccess(BaseSchema):
     ok: bool = True
     mfa_required: bool = False
+    mfa_setup_recommended: bool = Field(default=False, alias="mfaSetupRecommended")
+    mfa_setup_required: bool = Field(default=False, alias="mfaSetupRequired")
 
 
 class AuthLoginMfaRequired(BaseSchema):
@@ -46,6 +50,24 @@ class AuthMfaEnrollConfirmResponse(BaseSchema):
     recovery_codes: list[str] = Field(..., alias="recoveryCodes")
 
 
+class AuthMfaStatusResponse(BaseSchema):
+    enabled: bool
+    enrolled_at: datetime | None = Field(default=None, alias="enrolledAt")
+    recovery_codes_remaining: int | None = Field(
+        default=None,
+        alias="recoveryCodesRemaining",
+    )
+    onboarding_recommended: bool = Field(
+        default=False,
+        alias="onboardingRecommended",
+    )
+    onboarding_required: bool = Field(
+        default=False,
+        alias="onboardingRequired",
+    )
+    skip_allowed: bool = Field(default=False, alias="skipAllowed")
+
+
 class AuthMfaChallengeVerifyRequest(BaseSchema):
     challenge_token: str = Field(..., alias="challengeToken")
     code: str = Field(
@@ -67,6 +89,14 @@ class AuthPolicyUpdateRequest(BaseSchema):
     allow_jit_provisioning: bool = Field(alias="allowJitProvisioning")
 
 
+class AuthMfaRecoveryRegenerateRequest(BaseSchema):
+    code: str = Field(
+        min_length=6,
+        max_length=9,
+        pattern=r"^(?:\d{6}|[A-Za-z0-9]{8}|[A-Za-z0-9]{4}-[A-Za-z0-9]{4})$",
+    )
+
+
 __all__ = [
     "AuthLoginMfaRequired",
     "AuthLoginRequest",
@@ -74,6 +104,8 @@ __all__ = [
     "AuthMfaChallengeVerifyRequest",
     "AuthMfaEnrollConfirmRequest",
     "AuthMfaEnrollConfirmResponse",
+    "AuthMfaRecoveryRegenerateRequest",
+    "AuthMfaStatusResponse",
     "AuthMfaEnrollStartResponse",
     "AuthPasswordForgotRequest",
     "AuthPasswordResetRequest",

--- a/backend/src/ade_api/features/me/schemas.py
+++ b/backend/src/ade_api/features/me/schemas.py
@@ -42,6 +42,16 @@ class MeProfile(BaseSchema):
     )
 
 
+class MeProfileUpdateRequest(BaseSchema):
+    """Payload for updating editable fields on the caller profile."""
+
+    display_name: str | None = Field(
+        default=None,
+        alias="display_name",
+        description="Optional display name shown in the ADE user interface.",
+    )
+
+
 class MeWorkspaceSummary(BaseSchema):
     """Lightweight view of a workspace visible to the current principal."""
 
@@ -121,6 +131,7 @@ __all__ = [
     "EffectivePermissions",
     "MeContext",
     "MeProfile",
+    "MeProfileUpdateRequest",
     "MeWorkspaceSummary",
     "PermissionCheckRequest",
     "PermissionCheckResponse",

--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -632,6 +632,104 @@
         ]
       }
     },
+    "/api/v1/auth/mfa/totp": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Read TOTP MFA status for the current user",
+        "operationId": "mfa_status_api_v1_auth_mfa_totp_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthMfaStatusResponse"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Disable TOTP for the current user",
+        "operationId": "mfa_disable_api_v1_auth_mfa_totp_delete",
+        "parameters": [
+          {
+            "name": "X-CSRF-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      }
+    },
     "/api/v1/auth/mfa/totp/enroll/confirm": {
       "post": {
         "tags": [
@@ -663,6 +761,86 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AuthMfaEnrollConfirmRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthMfaEnrollConfirmResponse"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/mfa/totp/recovery/regenerate": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Regenerate recovery codes for current user",
+        "operationId": "mfa_regenerate_recovery_codes_api_v1_auth_mfa_totp_recovery_regenerate_post",
+        "parameters": [
+          {
+            "name": "X-CSRF-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthMfaRecoveryRegenerateRequest"
               }
             }
           }
@@ -765,69 +943,6 @@
           }
         },
         "security": []
-      }
-    },
-    "/api/v1/auth/mfa/totp": {
-      "delete": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Disable TOTP for the current user",
-        "operationId": "mfa_disable_api_v1_auth_mfa_totp_delete",
-        "parameters": [
-          {
-            "name": "X-CSRF-Token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Csrf-Token"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response",
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "default": {
-            "$ref": "#/components/responses/ProblemDetails"
-          }
-        },
-        "security": [
-          {
-            "SessionCookie": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
       }
     },
     "/api/v1/apikeys": {
@@ -1218,6 +1333,14 @@
               }
             }
           },
+          "403": {
+            "description": "Requires api_keys.manage_all global permission.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1298,6 +1421,14 @@
           },
           "401": {
             "description": "Authentication required.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "403": {
+            "description": "Requires api_keys.manage_all global permission.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
@@ -1389,16 +1520,16 @@
               }
             }
           },
-          "404": {
-            "description": "API key not found.",
+          "403": {
+            "description": "Requires api_keys.manage_all global permission.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
               }
             }
           },
-          "403": {
-            "description": "API key not owned by caller.",
+          "404": {
+            "description": "API key not found.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
@@ -1489,16 +1620,16 @@
               }
             }
           },
-          "404": {
-            "description": "API key not found.",
+          "403": {
+            "description": "Requires api_keys.manage_all global permission.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
               }
             }
           },
-          "403": {
-            "description": "API key not owned by caller.",
+          "404": {
+            "description": "API key not found.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
@@ -3895,6 +4026,94 @@
           },
           "404": {
             "description": "User record not found.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "me"
+        ],
+        "summary": "Update editable fields on the authenticated user's profile",
+        "description": "Patch mutable fields for the current principal.",
+        "operationId": "patch_me_api_v1_me_patch",
+        "parameters": [
+          {
+            "name": "X-CSRF-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeProfileUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeProfile"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required to update the profile.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "403": {
+            "description": "Service account principals cannot access this endpoint.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "description": "No editable fields provided or payload validation failed.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
@@ -12349,6 +12568,16 @@
             "type": "boolean",
             "title": "Mfa Required",
             "default": false
+          },
+          "mfaSetupRecommended": {
+            "type": "boolean",
+            "title": "Mfasetuprecommended",
+            "default": false
+          },
+          "mfaSetupRequired": {
+            "type": "boolean",
+            "title": "Mfasetuprequired",
+            "default": false
           }
         },
         "additionalProperties": false,
@@ -12433,6 +12662,75 @@
           "accountName"
         ],
         "title": "AuthMfaEnrollStartResponse"
+      },
+      "AuthMfaRecoveryRegenerateRequest": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": 9,
+            "minLength": 6,
+            "pattern": "^(?:\\d{6}|[A-Za-z0-9]{8}|[A-Za-z0-9]{4}-[A-Za-z0-9]{4})$",
+            "title": "Code"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "title": "AuthMfaRecoveryRegenerateRequest"
+      },
+      "AuthMfaStatusResponse": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "enrolledAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enrolledat"
+          },
+          "recoveryCodesRemaining": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recoverycodesremaining"
+          },
+          "onboardingRecommended": {
+            "type": "boolean",
+            "title": "Onboardingrecommended",
+            "default": false
+          },
+          "onboardingRequired": {
+            "type": "boolean",
+            "title": "Onboardingrequired",
+            "default": false
+          },
+          "skipAllowed": {
+            "type": "boolean",
+            "title": "Skipallowed",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "title": "AuthMfaStatusResponse"
       },
       "AuthPasswordForgotRequest": {
         "properties": {
@@ -14579,6 +14877,26 @@
         ],
         "title": "MeProfile",
         "description": "Profile for the authenticated principal."
+      },
+      "MeProfileUpdateRequest": {
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name",
+            "description": "Optional display name shown in the ADE user interface."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "MeProfileUpdateRequest",
+        "description": "Payload for updating editable fields on the caller profile."
       },
       "MeWorkspaceSummary": {
         "properties": {
@@ -17465,7 +17783,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8000"
+      "url": "http://127.0.0.1:30267"
     }
   ],
   "security": [

--- a/backend/src/ade_api/settings.py
+++ b/backend/src/ade_api/settings.py
@@ -106,6 +106,7 @@ class Settings(
     auth_disabled_user_email: str = "developer@example.com"
     auth_disabled_user_name: str | None = "Development User"
     auth_force_sso: bool = False
+    auth_enforce_local_mfa: bool = False
     auth_sso_auto_provision: bool = False
     auth_sso_providers_json: str | None = None
     sso_encryption_key: SecretStr | None = None

--- a/backend/src/ade_db/migrations/versions/0004_auth_session_auth_method.py
+++ b/backend/src/ade_db/migrations/versions/0004_auth_session_auth_method.py
@@ -1,0 +1,41 @@
+"""Add auth_method metadata to auth_sessions."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+
+# Revision identifiers, used by Alembic.
+revision = "0004_auth_session_auth_method"
+down_revision: Optional[str] = "0003_authn_rework"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "auth_sessions",
+        sa.Column(
+            "auth_method",
+            sa.String(length=32),
+            nullable=False,
+            server_default="unknown",
+        ),
+    )
+    op.execute(
+        """
+        ALTER TABLE auth_sessions
+        ADD CONSTRAINT ck_auth_sessions_auth_method
+        CHECK (auth_method IN ('password', 'sso', 'unknown'))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE auth_sessions DROP CONSTRAINT IF EXISTS ck_auth_sessions_auth_method"
+    )
+    op.drop_column("auth_sessions", "auth_method")
+

--- a/backend/src/ade_db/models/__init__.py
+++ b/backend/src/ade_db/models/__init__.py
@@ -1,7 +1,13 @@
 """Central exports for ADE SQLAlchemy models."""
 
 from .api_key import ApiKey
-from .authn import AuthSession, MfaChallenge, PasswordResetToken, UserMfaTotp
+from .authn import (
+    AUTH_SESSION_AUTH_METHOD_VALUES,
+    AuthSession,
+    MfaChallenge,
+    PasswordResetToken,
+    UserMfaTotp,
+)
 from .configuration import Configuration, ConfigurationStatus
 from .file import (
     FILE_KIND_VALUES,
@@ -34,6 +40,7 @@ from .workspace import Workspace, WorkspaceMembership
 
 __all__ = [
     "ApiKey",
+    "AUTH_SESSION_AUTH_METHOD_VALUES",
     "AuthSession",
     "Configuration",
     "ConfigurationStatus",

--- a/backend/src/ade_db/models/authn.py
+++ b/backend/src/ade_db/models/authn.py
@@ -16,6 +16,8 @@ from ade_db import GUID, Base, UTCDateTime, UUIDPrimaryKeyMixin
 if TYPE_CHECKING:
     from .user import User
 
+AUTH_SESSION_AUTH_METHOD_VALUES = ("password", "sso", "unknown")
+
 
 class AuthSession(UUIDPrimaryKeyMixin, Base):
     """Hashed browser session token."""
@@ -28,6 +30,12 @@ class AuthSession(UUIDPrimaryKeyMixin, Base):
         nullable=False,
     )
     token_hash: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    auth_method: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="unknown",
+        server_default="unknown",
+    )
     created_at: Mapped[datetime] = mapped_column(
         UTCDateTime(),
         nullable=False,
@@ -127,6 +135,7 @@ class MfaChallenge(UUIDPrimaryKeyMixin, Base):
 
 
 __all__ = [
+    "AUTH_SESSION_AUTH_METHOD_VALUES",
     "AuthSession",
     "PasswordResetToken",
     "UserMfaTotp",

--- a/backend/tests/api/integration/auth/test_auth_sessions.py
+++ b/backend/tests/api/integration/auth/test_auth_sessions.py
@@ -7,6 +7,8 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 
+from ade_api.common.time import utc_now
+from ade_api.core.security import hash_opaque_token, mint_opaque_token
 from ade_api.features.authn.totp import totp_now
 from ade_api.settings import Settings
 from ade_db.models import AuthSession
@@ -35,11 +37,130 @@ async def test_cookie_login_sets_session_and_bootstrap(
     tokens = await anyio.to_thread.run_sync(_load_tokens)
     assert len(tokens) == 1
     assert tokens[0].user_id == admin.id
+    assert tokens[0].auth_method == "password"
 
     bootstrap = await async_client.get("/api/v1/me/bootstrap")
     assert bootstrap.status_code == 200, bootstrap.text
     payload = bootstrap.json()
     assert payload["user"]["email"] == admin.email
+
+
+async def test_local_login_reports_recommended_mfa_setup_when_optional(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+
+    response = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": member.email, "password": member.password},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["mfa_required"] is False
+    assert payload["mfaSetupRecommended"] is True
+    assert payload["mfaSetupRequired"] is False
+
+
+async def test_local_login_reports_required_mfa_setup_when_enforced(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    member = seed_identity.member
+    settings.auth_enforce_local_mfa = True
+
+    response = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": member.email, "password": member.password},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["mfa_required"] is False
+    assert payload["mfaSetupRecommended"] is False
+    assert payload["mfaSetupRequired"] is True
+
+
+async def test_local_mfa_enforcement_blocks_profile_until_enrolled(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    member = seed_identity.member
+    settings.auth_enforce_local_mfa = True
+
+    login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": member.email, "password": member.password},
+    )
+    assert login.status_code == 200, login.text
+    csrf_cookie = async_client.cookies.get(settings.session_csrf_cookie_name)
+    assert csrf_cookie
+
+    blocked_profile = await async_client.get("/api/v1/me")
+    assert blocked_profile.status_code == 403, blocked_profile.text
+    blocked_payload = blocked_profile.json()
+    error_codes = {
+        item.get("code")
+        for item in blocked_payload.get("errors", [])
+        if isinstance(item, dict)
+    }
+    assert "mfa_setup_required" in error_codes
+
+    bootstrap = await async_client.get("/api/v1/me/bootstrap")
+    assert bootstrap.status_code == 200, bootstrap.text
+    refreshed_csrf = async_client.cookies.get(settings.session_csrf_cookie_name)
+    assert refreshed_csrf
+
+    mfa_status = await async_client.get("/api/v1/auth/mfa/totp")
+    assert mfa_status.status_code == 200, mfa_status.text
+    status_payload = mfa_status.json()
+    assert status_payload["onboardingRequired"] is True
+    assert status_payload["skipAllowed"] is False
+
+    enroll_start = await async_client.post(
+        "/api/v1/auth/mfa/totp/enroll/start",
+        headers={"X-CSRF-Token": refreshed_csrf},
+    )
+    assert enroll_start.status_code == 200, enroll_start.text
+    otpauth_uri = enroll_start.json()["otpauthUri"]
+    secret = parse_qs(urlparse(otpauth_uri).query)["secret"][0]
+
+    enroll_confirm = await async_client.post(
+        "/api/v1/auth/mfa/totp/enroll/confirm",
+        json={"code": totp_now(secret)},
+        headers={"X-CSRF-Token": refreshed_csrf},
+    )
+    assert enroll_confirm.status_code == 200, enroll_confirm.text
+
+    unblocked_profile = await async_client.get("/api/v1/me")
+    assert unblocked_profile.status_code == 200, unblocked_profile.text
+
+
+async def test_local_mfa_enforcement_does_not_apply_to_sso_sessions(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+    db_session,
+) -> None:
+    settings.auth_enforce_local_mfa = True
+    member = seed_identity.member
+
+    raw_token = mint_opaque_token()
+    db_session.add(
+        AuthSession(
+            user_id=member.id,
+            token_hash=hash_opaque_token(raw_token),
+            auth_method="sso",
+            expires_at=utc_now() + settings.session_access_ttl,
+            revoked_at=None,
+        )
+    )
+    db_session.flush()
+    async_client.cookies.set(settings.session_cookie_name, raw_token)
+
+    response = await async_client.get("/api/v1/me")
+    assert response.status_code == 200, response.text
 
 
 async def test_cookie_login_sets_secure_flag_when_public_url_is_https(
@@ -327,3 +448,109 @@ async def test_sso_enforcement_blocks_non_admin_and_preserves_global_admin_local
     admin_payload = admin_local_login.json()
     assert admin_payload["mfa_required"] is True
     assert (admin_payload.get("challengeToken") or admin_payload.get("challenge_token"))
+
+
+async def test_mfa_status_and_recovery_regeneration(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    admin = seed_identity.admin
+
+    login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": admin.email, "password": admin.password},
+    )
+    assert login.status_code == 200, login.text
+    csrf_cookie = async_client.cookies.get(settings.session_csrf_cookie_name)
+    assert csrf_cookie
+
+    status_before = await async_client.get("/api/v1/auth/mfa/totp")
+    assert status_before.status_code == 200, status_before.text
+    before_payload = status_before.json()
+    assert before_payload["enabled"] is False
+    assert before_payload["recoveryCodesRemaining"] is None
+    assert before_payload["onboardingRecommended"] is True
+    assert before_payload["onboardingRequired"] is False
+    assert before_payload["skipAllowed"] is True
+
+    enroll_start = await async_client.post(
+        "/api/v1/auth/mfa/totp/enroll/start",
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert enroll_start.status_code == 200, enroll_start.text
+    otpauth_uri = enroll_start.json()["otpauthUri"]
+    secret = parse_qs(urlparse(otpauth_uri).query)["secret"][0]
+
+    enroll_confirm = await async_client.post(
+        "/api/v1/auth/mfa/totp/enroll/confirm",
+        json={"code": totp_now(secret)},
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert enroll_confirm.status_code == 200, enroll_confirm.text
+    original_recovery_codes = enroll_confirm.json()["recoveryCodes"]
+    assert len(original_recovery_codes) >= 2
+
+    status_after_enroll = await async_client.get("/api/v1/auth/mfa/totp")
+    assert status_after_enroll.status_code == 200, status_after_enroll.text
+    enrolled_payload = status_after_enroll.json()
+    assert enrolled_payload["enabled"] is True
+    assert enrolled_payload["enrolledAt"]
+    assert enrolled_payload["recoveryCodesRemaining"] == len(original_recovery_codes)
+    assert enrolled_payload["onboardingRecommended"] is False
+    assert enrolled_payload["onboardingRequired"] is False
+    assert enrolled_payload["skipAllowed"] is False
+
+    regenerate = await async_client.post(
+        "/api/v1/auth/mfa/totp/recovery/regenerate",
+        json={"code": totp_now(secret)},
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert regenerate.status_code == 200, regenerate.text
+    regenerated_codes = regenerate.json()["recoveryCodes"]
+    assert regenerated_codes
+    assert regenerated_codes != original_recovery_codes
+
+    status_after_regenerate = await async_client.get("/api/v1/auth/mfa/totp")
+    assert status_after_regenerate.status_code == 200, status_after_regenerate.text
+    regenerated_payload = status_after_regenerate.json()
+    assert regenerated_payload["enabled"] is True
+    assert regenerated_payload["recoveryCodesRemaining"] == len(regenerated_codes)
+
+
+async def test_mfa_recovery_regeneration_rejects_invalid_code(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    admin = seed_identity.admin
+
+    login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": admin.email, "password": admin.password},
+    )
+    assert login.status_code == 200, login.text
+    csrf_cookie = async_client.cookies.get(settings.session_csrf_cookie_name)
+    assert csrf_cookie
+
+    enroll_start = await async_client.post(
+        "/api/v1/auth/mfa/totp/enroll/start",
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert enroll_start.status_code == 200, enroll_start.text
+    otpauth_uri = enroll_start.json()["otpauthUri"]
+    secret = parse_qs(urlparse(otpauth_uri).query)["secret"][0]
+
+    enroll_confirm = await async_client.post(
+        "/api/v1/auth/mfa/totp/enroll/confirm",
+        json={"code": totp_now(secret)},
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert enroll_confirm.status_code == 200, enroll_confirm.text
+
+    regenerate = await async_client.post(
+        "/api/v1/auth/mfa/totp/recovery/regenerate",
+        json={"code": "ZZZZ-ZZZZ"},
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert regenerate.status_code == 400, regenerate.text

--- a/backend/tests/api/integration/auth/test_me_profile.py
+++ b/backend/tests/api/integration/auth/test_me_profile.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from ade_api.settings import Settings
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_patch_me_updates_display_name(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    member = seed_identity.member
+
+    login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": member.email, "password": member.password},
+    )
+    assert login.status_code == 200, login.text
+    csrf_cookie = async_client.cookies.get(settings.session_csrf_cookie_name)
+    assert csrf_cookie
+
+    update = await async_client.patch(
+        "/api/v1/me",
+        json={"display_name": "Data Ops Specialist"},
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert update.status_code == 200, update.text
+    payload = update.json()
+    assert payload["display_name"] == "Data Ops Specialist"
+
+    me = await async_client.get("/api/v1/me")
+    assert me.status_code == 200, me.text
+    assert me.json()["display_name"] == "Data Ops Specialist"
+
+
+async def test_patch_me_requires_editable_fields(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    member = seed_identity.member
+    login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": member.email, "password": member.password},
+    )
+    assert login.status_code == 200, login.text
+    csrf_cookie = async_client.cookies.get(settings.session_csrf_cookie_name)
+    assert csrf_cookie
+
+    update = await async_client.patch(
+        "/api/v1/me",
+        json={},
+        headers={"X-CSRF-Token": csrf_cookie},
+    )
+    assert update.status_code == 422, update.text
+
+
+async def test_patch_me_requires_csrf_for_cookie_auth(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    login = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": member.email, "password": member.password},
+    )
+    assert login.status_code == 200, login.text
+
+    update = await async_client.patch(
+        "/api/v1/me",
+        json={"display_name": "No CSRF"},
+    )
+    assert update.status_code == 403, update.text

--- a/backend/tests/api/unit/settings/conftest.py
+++ b/backend/tests/api/unit/settings/conftest.py
@@ -72,6 +72,7 @@ def reset_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         "ADE_WORKER_MEM_MB",
         "ADE_WORKER_FSIZE_MB",
         "ADE_AUTH_FORCE_SSO",
+        "ADE_AUTH_ENFORCE_LOCAL_MFA",
         "ADE_AUTH_SSO_AUTO_PROVISION",
         "ADE_SSO_ENCRYPTION_KEY",
     ):

--- a/backend/tests/api/unit/settings/test_settings_defaults.py
+++ b/backend/tests/api/unit/settings/test_settings_defaults.py
@@ -54,6 +54,7 @@ def test_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.blob_prefix == "workspaces"
     assert settings.blob_versioning_mode == "auto"
     assert settings.database_connection_budget is None
+    assert settings.auth_enforce_local_mfa is False
 
 
 def test_data_dir_propagates_defaults(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/api/unit/settings/test_settings_env.py
+++ b/backend/tests/api/unit/settings/test_settings_env.py
@@ -82,6 +82,7 @@ def test_api_runtime_tuning_env_overrides(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv("ADE_API_FORWARDED_ALLOW_IPS", "10.0.0.1,10.0.0.2")
     monkeypatch.setenv("ADE_API_THREADPOOL_TOKENS", "64")
     monkeypatch.setenv("ADE_DATABASE_CONNECTION_BUDGET", "120")
+    monkeypatch.setenv("ADE_AUTH_ENFORCE_LOCAL_MFA", "true")
 
     settings = Settings(_env_file=None)
 
@@ -89,6 +90,7 @@ def test_api_runtime_tuning_env_overrides(monkeypatch: pytest.MonkeyPatch) -> No
     assert settings.api_forwarded_allow_ips == "10.0.0.1,10.0.0.2"
     assert settings.api_threadpool_tokens == 64
     assert settings.database_connection_budget == 120
+    assert settings.auth_enforce_local_mfa is True
 
 
 def test_api_forwarded_allow_ips_must_not_be_empty(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/api/utils.py
+++ b/backend/tests/api/utils.py
@@ -3,10 +3,52 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
 
 from httpx import AsyncClient
 
+from ade_api.features.api_keys.service import ApiKeyService
 from ade_api.settings import get_settings
+
+
+def _resolve_test_app(client: AsyncClient):
+    transport = getattr(client, "_transport", None)
+    return getattr(transport, "app", None)
+
+
+async def _mint_api_key_directly(
+    client: AsyncClient,
+    *,
+    user_id: UUID,
+) -> tuple[str, dict[str, Any]]:
+    app = _resolve_test_app(client)
+    assert app is not None, "Unable to resolve ASGI app from test client."
+
+    db_sessionmaker = getattr(app.state, "db_sessionmaker", None)
+    assert db_sessionmaker is not None, "Test DB sessionmaker was not attached to app.state."
+
+    settings = getattr(app.state, "settings", None) or get_settings()
+    session = db_sessionmaker()
+    try:
+        service = ApiKeyService(session=session, settings=settings)
+        result = service.create_for_user(
+            user_id=user_id,
+            name="test-login-key",
+            expires_in_days=None,
+        )
+        session.commit()
+        payload = {
+            "id": str(result.api_key.id),
+            "prefix": result.api_key.prefix,
+            "secret": result.secret,
+        }
+        return result.secret, payload
+    except BaseException:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
 
 async def login(
     client: AsyncClient,
@@ -31,11 +73,20 @@ async def login(
         json={"name": "test-login-key"},
         headers={"X-CSRF-Token": csrf_cookie},
     )
-    assert key_response.status_code == 201, key_response.text
-    payload = key_response.json()
-    token = payload.get("secret")
-    assert token, "API key secret missing"
-    return token, payload
+    if key_response.status_code == 201:
+        payload = key_response.json()
+        token = payload.get("secret")
+        assert token, "API key secret missing"
+        return token, payload
+
+    assert key_response.status_code == 403, key_response.text
+
+    me_response = await client.get("/api/v1/me")
+    assert me_response.status_code == 200, me_response.text
+    me_payload = me_response.json()
+    user_id_raw = me_payload.get("id")
+    assert isinstance(user_id_raw, str) and user_id_raw.strip(), "User id missing from /api/v1/me response."
+    return await _mint_api_key_directly(client, user_id=UUID(user_id_raw))
 
 
 __all__ = ["login"]

--- a/docs/explanation/security-and-authentication.md
+++ b/docs/explanation/security-and-authentication.md
@@ -31,12 +31,19 @@ Runtime authorization is role/permission driven. Do not rely on legacy `is_super
 - When `enforceSso=true`, non-global-admin local login is blocked.
 - Global-admin local login remains available for emergency operational access and requires MFA enrollment.
 
+## Local MFA Enforcement Model
+
+- `ADE_AUTH_ENFORCE_LOCAL_MFA=true` enforces MFA onboarding for password-authenticated sessions.
+- When enabled, users signed in with built-in auth must complete TOTP enrollment before most protected endpoints are accessible.
+- SSO and API key sessions are not forced by this setting.
+
 ## Core Security Settings
 
 - `ADE_SECRET_KEY`
 - `ADE_PUBLIC_WEB_URL`
 - `ADE_AUTH_DISABLED`
 - `ADE_AUTH_FORCE_SSO`
+- `ADE_AUTH_ENFORCE_LOCAL_MFA`
 - `ADE_SSO_ENCRYPTION_KEY`
 - `ADE_BLOB_ACCOUNT_URL` or `ADE_BLOB_CONNECTION_STRING`
 - `ADE_DATABASE_AUTH_MODE`

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -58,6 +58,7 @@ See [Production Bootstrap](../tutorials/production-bootstrap.md) for the exact m
 | `ADE_AUTH_DISABLED_USER_NAME` | API auth bypass | optional | `Development User` | used only in auth-disabled mode |
 | `ADE_ALLOW_PUBLIC_REGISTRATION` | API auth policy | optional | `false` | allows open user signup |
 | `ADE_AUTH_FORCE_SSO` | API auth policy | optional | `false` | enforce SSO for non-global-admin local login |
+| `ADE_AUTH_ENFORCE_LOCAL_MFA` | API auth policy | optional | `false` | require MFA enrollment for password-authenticated sessions before protected API access |
 | `ADE_AUTH_SSO_AUTO_PROVISION` | API auth policy | optional | `false` | create users automatically from SSO |
 | `ADE_AUTH_SSO_PROVIDERS_JSON` | API SSO | optional | none | provider settings payload |
 | `ADE_SSO_ENCRYPTION_KEY` | API SSO | optional | none | encryption key for SSO secrets |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "@tanstack/react-query-devtools": "^5.91.3",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.18",
+        "@types/qrcode": "^1.5.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -45,6 +46,7 @@
         "nuqs": "^2.8.7",
         "openapi-fetch": "^0.15.0",
         "openapi-typescript-helpers": "^0.0.15",
+        "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-day-picker": "^9.13.0",
         "react-dom": "^19.2.4",
@@ -4421,11 +4423,18 @@
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -4945,7 +4954,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4955,7 +4963,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5346,6 +5353,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001766",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
@@ -5431,6 +5447,17 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5469,7 +5496,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5482,7 +5508,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -5711,6 +5736,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -5785,6 +5819,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -6724,6 +6764,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -7244,6 +7293,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -8442,6 +8500,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8519,6 +8586,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8642,6 +8718,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/react": {
@@ -8932,6 +9025,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8941,6 +9043,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -9103,6 +9211,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
@@ -9321,6 +9435,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -9432,6 +9566,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-indent": {
@@ -9833,7 +9979,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -10229,6 +10374,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -10296,6 +10447,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -10356,12 +10521,105 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "@tanstack/react-query-devtools": "^5.91.3",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.18",
+    "@types/qrcode": "^1.5.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -54,6 +55,7 @@
     "nuqs": "^2.8.7",
     "openapi-fetch": "^0.15.0",
     "openapi-typescript-helpers": "^0.0.15",
+    "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-day-picker": "^9.13.0",
     "react-dom": "^19.2.4",
@@ -75,6 +77,7 @@
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.2",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
@@ -87,7 +90,6 @@
     "typescript-eslint": "^8.54.0",
     "vite": "^7.3.1",
     "vite-tsconfig-paths": "^6.0.5",
-    "@vitest/coverage-v8": "^4.0.18",
     "vitest": "^4.0.18"
   }
 }

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -6,7 +6,9 @@ import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { appRoutes } from "@/app/routes";
 
 vi.mock("@/pages/Home", () => ({ default: () => <div data-testid="home-screen">home</div> }));
+vi.mock("@/pages/Account", () => ({ default: () => <div data-testid="account-screen">account</div> }));
 vi.mock("@/pages/Login", () => ({ default: () => <div data-testid="login-screen">login</div> }));
+vi.mock("@/pages/MfaSetup", () => ({ default: () => <div data-testid="mfa-setup-screen">mfa-setup</div> }));
 vi.mock("@/pages/Setup", () => ({ default: () => <div data-testid="setup-screen">setup</div> }));
 vi.mock("@/pages/OrganizationSettings", () => ({ default: () => <div data-testid="org-settings-screen">org-settings</div> }));
 vi.mock("@/pages/Workspaces", () => ({ default: () => <div data-testid="workspaces-screen">workspaces</div> }));
@@ -34,7 +36,12 @@ function renderAt(path: string) {
 describe("App routes", () => {
   const cases: Array<{ path: string; testId: string }> = [
     { path: "/", testId: "home-screen" },
+    { path: "/account", testId: "account-screen" },
+    { path: "/account/security", testId: "account-screen" },
+    { path: "/account/profile", testId: "account-screen" },
+    { path: "/account/api-keys", testId: "account-screen" },
     { path: "/login", testId: "login-screen" },
+    { path: "/mfa/setup", testId: "mfa-setup-screen" },
     { path: "/setup", testId: "setup-screen" },
     { path: "/organization", testId: "org-settings-screen" },
     { path: "/organization/users", testId: "org-settings-screen" },

--- a/frontend/src/api/auth/__tests__/api.test.ts
+++ b/frontend/src/api/auth/__tests__/api.test.ts
@@ -57,6 +57,31 @@ describe("auth api", () => {
     expect(result.kind).toBe("session");
     if (result.kind === "session") {
       expect(result.session.user.email).toBe("user@example.com");
+      expect(result.mfaSetupRecommended).toBe(false);
+      expect(result.mfaSetupRequired).toBe(false);
+    }
+  });
+
+  it("returns setup guidance flags when login indicates onboarding", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          mfa_required: false,
+          mfaSetupRecommended: true,
+          mfaSetupRequired: false,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { createSession } = await import("../api");
+    const result = await createSession({ email: "user@example.com", password: "pass" });
+
+    expect(result.kind).toBe("session");
+    if (result.kind === "session") {
+      expect(result.mfaSetupRecommended).toBe(true);
+      expect(result.mfaSetupRequired).toBe(false);
     }
   });
 
@@ -87,5 +112,120 @@ describe("auth api", () => {
       "/api/v1/auth/logout",
       expect.objectContaining({ method: "POST", signal: undefined }),
     );
+  });
+
+  it("starts MFA enrollment and returns setup details", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          otpauthUri: "otpauth://totp/ADE:user@example.com?secret=ABC123&issuer=ADE",
+          issuer: "ADE",
+          accountName: "user@example.com",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { startMfaEnrollment } = await import("../api");
+    const payload = await startMfaEnrollment();
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/auth/mfa/totp/enroll/start",
+      expect.objectContaining({ method: "POST", signal: undefined }),
+    );
+    expect(payload).toEqual({
+      otpauthUri: "otpauth://totp/ADE:user@example.com?secret=ABC123&issuer=ADE",
+      issuer: "ADE",
+      accountName: "user@example.com",
+    });
+  });
+
+  it("confirms MFA enrollment and returns recovery codes", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          recoveryCodes: ["ABCD-EFGH", "IJKL-MNOP"],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { confirmMfaEnrollment } = await import("../api");
+    const payload = await confirmMfaEnrollment({ code: "123456" });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/auth/mfa/totp/enroll/confirm",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ code: "123456" }),
+      }),
+    );
+    expect(payload).toEqual({ recoveryCodes: ["ABCD-EFGH", "IJKL-MNOP"] });
+  });
+
+  it("disables MFA with the expected endpoint", async () => {
+    mockApiFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const { disableMfa } = await import("../api");
+    await disableMfa();
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/auth/mfa/totp",
+      expect.objectContaining({ method: "DELETE", signal: undefined }),
+    );
+  });
+
+  it("reads MFA status from the status endpoint", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          enabled: true,
+          enrolledAt: "2026-02-01T09:00:00Z",
+          recoveryCodesRemaining: 5,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { fetchMfaStatus } = await import("../api");
+    const payload = await fetchMfaStatus();
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/auth/mfa/totp",
+      expect.objectContaining({ method: "GET", signal: undefined }),
+    );
+    expect(payload).toEqual({
+      enabled: true,
+      enrolledAt: "2026-02-01T09:00:00Z",
+      recoveryCodesRemaining: 5,
+      onboardingRecommended: false,
+      onboardingRequired: false,
+      skipAllowed: false,
+    });
+  });
+
+  it("regenerates MFA recovery codes", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          recoveryCodes: ["QWER-TYUI", "ASDF-GHJK"],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { regenerateMfaRecoveryCodes } = await import("../api");
+    const payload = await regenerateMfaRecoveryCodes({ code: "654321" });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/auth/mfa/totp/recovery/regenerate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ code: "654321" }),
+      }),
+    );
+    expect(payload).toEqual({
+      recoveryCodes: ["QWER-TYUI", "ASDF-GHJK"],
+    });
   });
 });

--- a/frontend/src/api/me/__tests__/api.test.ts
+++ b/frontend/src/api/me/__tests__/api.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchMyProfile, updateMyProfile } from "../api";
+import { client } from "@/api/client";
+
+vi.mock("@/api/client", () => ({
+  client: {
+    GET: vi.fn(),
+    PATCH: vi.fn(),
+  },
+}));
+
+const sampleProfile = {
+  id: "user-1",
+  email: "user@example.com",
+  display_name: "User",
+  is_service_account: false,
+  preferred_workspace_id: null,
+  roles: [],
+  permissions: [],
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+describe("me api", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches the current profile", async () => {
+    (client.GET as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: sampleProfile });
+
+    const profile = await fetchMyProfile();
+
+    expect(client.GET).toHaveBeenCalledWith("/api/v1/me", { signal: undefined });
+    expect(profile).toEqual(sampleProfile);
+  });
+
+  it("patches profile display name", async () => {
+    const updated = { ...sampleProfile, display_name: "Data Operations" };
+    (client.PATCH as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ data: updated });
+
+    const profile = await updateMyProfile({ display_name: "Data Operations" });
+
+    expect(client.PATCH).toHaveBeenCalledWith("/api/v1/me", {
+      body: { display_name: "Data Operations" },
+    });
+    expect(profile).toEqual(updated);
+  });
+});

--- a/frontend/src/api/me/api.ts
+++ b/frontend/src/api/me/api.ts
@@ -1,0 +1,34 @@
+import { client } from "@/api/client";
+import type { MeProfile } from "@/types";
+
+export interface MeRequestOptions {
+  readonly signal?: AbortSignal;
+}
+
+export interface UpdateMyProfileRequest {
+  readonly display_name?: string | null;
+}
+
+export async function fetchMyProfile(options: MeRequestOptions = {}): Promise<MeProfile> {
+  const { data } = await client.GET("/api/v1/me", {
+    signal: options.signal,
+  });
+
+  if (!data) {
+    throw new Error("Expected profile payload.");
+  }
+
+  return data;
+}
+
+export async function updateMyProfile(payload: UpdateMyProfileRequest): Promise<MeProfile> {
+  const { data } = await client.PATCH("/api/v1/me", {
+    body: payload,
+  });
+
+  if (!data) {
+    throw new Error("Expected updated profile payload.");
+  }
+
+  return data;
+}

--- a/frontend/src/app/layouts/components/topbar/UnifiedTopbarControls.tsx
+++ b/frontend/src/app/layouts/components/topbar/UnifiedTopbarControls.tsx
@@ -51,6 +51,7 @@ export function UnifiedTopbarControls() {
           displayName={displayName}
           email={email}
           canAccessOrganizationSettings={canAccessOrganizationSettings}
+          onOpenAccountSettings={() => navigate("/account")}
           onOpenOrganizationSettings={() => navigate("/organization")}
           onOpenVersions={() => setVersionsOpen(true)}
         />
@@ -245,12 +246,14 @@ function ProfileMenu({
   displayName,
   email,
   canAccessOrganizationSettings,
+  onOpenAccountSettings,
   onOpenOrganizationSettings,
   onOpenVersions,
 }: {
   readonly displayName: string;
   readonly email: string;
   readonly canAccessOrganizationSettings: boolean;
+  readonly onOpenAccountSettings: () => void;
   readonly onOpenOrganizationSettings: () => void;
   readonly onOpenVersions: () => void;
 }) {
@@ -296,6 +299,12 @@ function ProfileMenu({
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
+          <DropdownMenuItem onSelect={onOpenAccountSettings} className="gap-2">
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-muted text-[0.6rem] font-semibold text-muted-foreground">
+              A
+            </span>
+            <span>Account Settings</span>
+          </DropdownMenuItem>
           {canAccessOrganizationSettings ? (
             <DropdownMenuItem onSelect={onOpenOrganizationSettings} className="gap-2">
               <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-muted text-[0.6rem] font-semibold text-muted-foreground">

--- a/frontend/src/app/layouts/components/topbar/__tests__/UnifiedTopbarControls.test.tsx
+++ b/frontend/src/app/layouts/components/topbar/__tests__/UnifiedTopbarControls.test.tsx
@@ -8,6 +8,7 @@ const mockSetModePreference = vi.fn();
 const mockSetPreviewTheme = vi.fn();
 const mockSetTheme = vi.fn();
 const mockUseTheme = vi.fn();
+const mockNavigate = vi.fn();
 
 vi.mock("@/providers/auth/SessionContext", () => ({
   useSession: () => ({
@@ -28,7 +29,7 @@ vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
   };
 });
 
@@ -64,6 +65,7 @@ vi.mock("@/hooks/system", () => ({
 describe("UnifiedTopbarControls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockNavigate.mockReset();
     mockUseTheme.mockReturnValue({
       theme: "default",
       modePreference: "light",
@@ -188,5 +190,15 @@ describe("UnifiedTopbarControls", () => {
         origin: { x: 40, y: 55 },
       }),
     );
+  });
+
+  it("navigates to account settings from the profile menu", async () => {
+    const user = userEvent.setup();
+    render(<UnifiedTopbarControls />);
+
+    await user.click(screen.getByRole("button", { name: "Open profile menu" }));
+    await user.click(screen.getByRole("menuitem", { name: /Account Settings/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/account");
   });
 });

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -10,6 +10,8 @@ const HomeScreen = lazy(() => import("@/pages/Home"));
 const LoginScreen = lazy(() => import("@/pages/Login"));
 const LogoutScreen = lazy(() => import("@/pages/Logout"));
 const NotFoundScreen = lazy(() => import("@/pages/NotFound"));
+const AccountCenterScreen = lazy(() => import("@/pages/Account"));
+const MfaSetupScreen = lazy(() => import("@/pages/MfaSetup"));
 const OrganizationSettingsScreen = lazy(() => import("@/pages/OrganizationSettings"));
 const SetupScreen = lazy(() => import("@/pages/Setup"));
 const WorkspaceScreen = lazy(() => import("@/pages/Workspace"));
@@ -45,6 +47,8 @@ export const appRoutes: RouteObject[] = [
             element: <AuthenticatedLayout />,
             children: [
               { index: true, element: withRouteSuspense(<HomeScreen />) },
+              { path: "account/*", element: withRouteSuspense(<AccountCenterScreen />) },
+              { path: "mfa/setup", element: withRouteSuspense(<MfaSetupScreen />) },
               { path: "organization/*", element: withRouteSuspense(<OrganizationSettingsScreen />) },
               { path: "workspaces", element: withRouteSuspense(<WorkspacesScreen />) },
               { path: "workspaces/new", element: withRouteSuspense(<WorkspaceCreateScreen />) },

--- a/frontend/src/features/mfa-setup/MfaSetupFlow.tsx
+++ b/frontend/src/features/mfa-setup/MfaSetupFlow.tsx
@@ -1,0 +1,650 @@
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import QRCode from "qrcode";
+import { CheckCircle2, Lock, Smartphone } from "lucide-react";
+
+import {
+  confirmMfaEnrollment,
+  disableMfa,
+  regenerateMfaRecoveryCodes,
+  startMfaEnrollment,
+  type MfaEnrollStartResponse,
+  type MfaStatusResponse,
+} from "@/api/auth/api";
+import { mapUiError } from "@/api/uiErrors";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { formatDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+interface MfaSetupFlowProps {
+  readonly mfaStatus: MfaStatusResponse | null;
+  readonly isMfaStatusLoading: boolean;
+  readonly mfaStatusError: string | null;
+  readonly onRefreshMfaStatus: () => Promise<void>;
+  readonly allowSkip?: boolean;
+  readonly onboardingRequired?: boolean;
+  readonly onSkip?: () => void;
+  readonly onFlowComplete?: () => void;
+  readonly showStatusCard?: boolean;
+  readonly className?: string;
+}
+
+type Feedback =
+  | { tone: "success"; message: string }
+  | { tone: "danger"; message: string }
+  | { tone: "info"; message: string }
+  | null;
+
+type WizardStep = "welcome" | "apps" | "scan" | "manual" | "verify" | "recovery" | "complete";
+
+type EnrollmentState = Readonly<MfaEnrollStartResponse & { secret: string | null }>;
+
+const AUTH_APP_OPTIONS = [
+  {
+    name: "Microsoft Authenticator",
+    description: "Great choice for Microsoft or enterprise accounts.",
+  },
+  {
+    name: "Google Authenticator",
+    description: "Simple and widely used for TOTP codes.",
+  },
+  {
+    name: "Authy",
+    description: "Supports multi-device sync and secure backups.",
+  },
+  {
+    name: "Duo Mobile",
+    description: "Popular in IT-managed environments.",
+  },
+] as const;
+
+const PROGRESS_STEPS = ["welcome", "apps", "scan", "verify", "recovery", "complete"] as const;
+
+export function MfaSetupFlow({
+  mfaStatus,
+  isMfaStatusLoading,
+  mfaStatusError,
+  onRefreshMfaStatus,
+  allowSkip = false,
+  onboardingRequired = false,
+  onSkip,
+  onFlowComplete,
+  showStatusCard = true,
+  className,
+}: MfaSetupFlowProps) {
+  const initializedFromStatus = useRef(false);
+  const [wizardActive, setWizardActive] = useState(false);
+  const [wizardStep, setWizardStep] = useState<WizardStep>("welcome");
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [enrollment, setEnrollment] = useState<EnrollmentState | null>(null);
+  const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string | null>(null);
+  const [verificationCode, setVerificationCode] = useState("");
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [recoveryAcknowledged, setRecoveryAcknowledged] = useState(false);
+  const [regenerateDialogOpen, setRegenerateDialogOpen] = useState(false);
+  const [disableDialogOpen, setDisableDialogOpen] = useState(false);
+  const [regenerationCode, setRegenerationCode] = useState("");
+
+  const [isStartingEnrollment, setIsStartingEnrollment] = useState(false);
+  const [isConfirmingEnrollment, setIsConfirmingEnrollment] = useState(false);
+  const [isRegeneratingCodes, setIsRegeneratingCodes] = useState(false);
+  const [isDisablingMfa, setIsDisablingMfa] = useState(false);
+
+  useEffect(() => {
+    if (initializedFromStatus.current || isMfaStatusLoading || !mfaStatus) {
+      return;
+    }
+
+    initializedFromStatus.current = true;
+    setWizardActive(!mfaStatus.enabled);
+    setWizardStep(mfaStatus.enabled ? "complete" : "welcome");
+  }, [isMfaStatusLoading, mfaStatus]);
+
+  useEffect(() => {
+    if (!enrollment?.otpauthUri) {
+      setQrCodeDataUrl(null);
+      return;
+    }
+
+    let cancelled = false;
+    void QRCode.toDataURL(enrollment.otpauthUri, {
+      width: 320,
+      margin: 1,
+      errorCorrectionLevel: "M",
+      color: {
+        dark: "#111827",
+        light: "#ffffff",
+      },
+    })
+      .then((dataUrl) => {
+        if (!cancelled) {
+          setQrCodeDataUrl(dataUrl);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setQrCodeDataUrl(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enrollment]);
+
+  const progressIndex = useMemo(() => {
+    const normalizedStep = wizardStep === "manual" ? "scan" : wizardStep;
+    const index = PROGRESS_STEPS.indexOf(normalizedStep as (typeof PROGRESS_STEPS)[number]);
+    return index >= 0 ? index : 0;
+  }, [wizardStep]);
+
+  const handleStartEnrollment = async () => {
+    setFeedback(null);
+    setIsStartingEnrollment(true);
+    try {
+      const result = await startMfaEnrollment();
+      setEnrollment({ ...result, secret: extractTotpSecret(result.otpauthUri) });
+      setVerificationCode("");
+      setWizardActive(true);
+      setWizardStep("scan");
+      setFeedback({ tone: "info", message: "Great. Scan the QR code in your authenticator app." });
+    } catch (error) {
+      const mapped = mapUiError(error, { fallback: "Unable to start MFA setup." });
+      setFeedback({ tone: "danger", message: mapped.message });
+    } finally {
+      setIsStartingEnrollment(false);
+    }
+  };
+
+  const handleConfirmEnrollment = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const code = verificationCode.trim();
+    if (!code) {
+      setFeedback({ tone: "danger", message: "Enter the 6-digit code from your authenticator app." });
+      return;
+    }
+
+    setFeedback(null);
+    setIsConfirmingEnrollment(true);
+    try {
+      const result = await confirmMfaEnrollment({ code });
+      setRecoveryCodes(result.recoveryCodes);
+      setRecoveryAcknowledged(false);
+      setWizardStep("recovery");
+      await onRefreshMfaStatus();
+      setFeedback({ tone: "success", message: "MFA enabled. Save your recovery codes before continuing." });
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: "Unable to verify your code.",
+        statusMessages: {
+          400: "That code was not accepted. Wait for a new code and try again.",
+        },
+      });
+      setFeedback({ tone: "danger", message: mapped.message });
+    } finally {
+      setIsConfirmingEnrollment(false);
+    }
+  };
+
+  const handleRegenerateRecoveryCodes = async () => {
+    const code = regenerationCode.trim();
+    if (!code) {
+      setFeedback({ tone: "danger", message: "Enter a valid authenticator or recovery code to continue." });
+      return;
+    }
+
+    setFeedback(null);
+    setIsRegeneratingCodes(true);
+    try {
+      const result = await regenerateMfaRecoveryCodes({ code });
+      setRecoveryCodes(result.recoveryCodes);
+      setRecoveryAcknowledged(false);
+      setRegenerationCode("");
+      setRegenerateDialogOpen(false);
+      setWizardActive(true);
+      setWizardStep("recovery");
+      await onRefreshMfaStatus();
+      setFeedback({ tone: "success", message: "Recovery codes regenerated. Save the new set now." });
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: "Unable to regenerate recovery codes.",
+      });
+      setFeedback({ tone: "danger", message: mapped.message });
+    } finally {
+      setIsRegeneratingCodes(false);
+    }
+  };
+
+  const handleDisableMfa = async () => {
+    setFeedback(null);
+    setIsDisablingMfa(true);
+    try {
+      await disableMfa();
+      await onRefreshMfaStatus();
+      setDisableDialogOpen(false);
+      setEnrollment(null);
+      setVerificationCode("");
+      setRecoveryCodes([]);
+      setRecoveryAcknowledged(false);
+      setWizardActive(true);
+      setWizardStep("welcome");
+      setFeedback({ tone: "success", message: "MFA was disabled. You can set it up again at any time." });
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: "Unable to disable MFA.",
+      });
+      setFeedback({ tone: "danger", message: mapped.message });
+    } finally {
+      setIsDisablingMfa(false);
+    }
+  };
+
+  const handleCompleteRecoveryStep = async () => {
+    setRecoveryCodes([]);
+    setRecoveryAcknowledged(false);
+    setWizardActive(false);
+    setWizardStep("complete");
+    await onRefreshMfaStatus();
+    setFeedback({ tone: "success", message: "Setup complete. Your account is now protected with MFA." });
+    onFlowComplete?.();
+  };
+
+  const handleCopy = async (label: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setFeedback({ tone: "success", message: `${label} copied to clipboard.` });
+    } catch {
+      setFeedback({ tone: "danger", message: `Unable to copy ${label.toLowerCase()}. Copy it manually instead.` });
+    }
+  };
+
+  const handleDownloadRecoveryCodes = () => {
+    if (recoveryCodes.length === 0) {
+      return;
+    }
+    const blob = new Blob([`${recoveryCodes.join("\n")}\n`], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "ade-recovery-codes.txt";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const showWizard =
+    wizardActive ||
+    wizardStep === "recovery" ||
+    (!isMfaStatusLoading && (!mfaStatus || !mfaStatus.enabled));
+
+  return (
+    <div className={cn("space-y-5", className)}>
+      {mfaStatusError ? <Alert tone="danger">{mfaStatusError}</Alert> : null}
+      {feedback ? <Alert tone={feedback.tone}>{feedback.message}</Alert> : null}
+
+      {showStatusCard ? (
+        <section className="space-y-3 rounded-xl border border-border bg-card p-5 shadow-xs">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={mfaStatus?.enabled ? "secondary" : "outline"}>
+              {isMfaStatusLoading ? "Checking status" : mfaStatus?.enabled ? "MFA enabled" : "MFA not enabled"}
+            </Badge>
+            {mfaStatus?.enrolledAt ? <Badge variant="outline">Enabled on {formatDate(mfaStatus.enrolledAt)}</Badge> : null}
+            {mfaStatus?.enabled ? (
+              <Badge variant="outline">Recovery codes: {mfaStatus.recoveryCodesRemaining ?? 0}</Badge>
+            ) : null}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Use an authenticator app for sign-in verification. You can rotate setup and regenerate recovery codes anytime.
+          </p>
+        </section>
+      ) : null}
+
+      {showWizard ? (
+        <section className="space-y-5 rounded-xl border border-border bg-card p-5 shadow-xs">
+          <WizardProgress progressIndex={progressIndex} />
+          {wizardStep === "welcome" ? (
+            <div className="space-y-4 animate-in fade-in-0 slide-in-from-right-2 duration-200">
+              <h3 className="text-lg font-semibold text-foreground">Let&apos;s set up MFA</h3>
+              <p className="text-sm text-muted-foreground">
+                This usually takes about 3 minutes. You&apos;ll install or open an authenticator app, scan a QR code, and
+                verify one login code.
+              </p>
+              <div className="rounded-lg border border-border/80 bg-background p-3 text-sm text-muted-foreground">
+                <p className="flex items-start gap-2">
+                  <Lock className="mt-0.5 h-4 w-4 shrink-0 text-info" />
+                  MFA protects your account if someone gets your password.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" onClick={() => setWizardStep("apps")}>Continue</Button>
+                {allowSkip && !onboardingRequired && onSkip ? (
+                  <Button type="button" variant="ghost" onClick={onSkip}>
+                    Skip for now
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+
+          {wizardStep === "apps" ? (
+            <div className="space-y-4 animate-in fade-in-0 slide-in-from-right-2 duration-200">
+              <h3 className="text-lg font-semibold text-foreground">Choose an authenticator app</h3>
+              <p className="text-sm text-muted-foreground">
+                Any TOTP-compatible app works. Here are common options:
+              </p>
+              <ul className="grid gap-2 sm:grid-cols-2">
+                {AUTH_APP_OPTIONS.map((app) => (
+                  <li key={app.name} className="rounded-lg border border-border/80 bg-background p-3">
+                    <p className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                      <Smartphone className="h-4 w-4 text-muted-foreground" />
+                      {app.name}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">{app.description}</p>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs text-muted-foreground">If you already have an app installed, you can continue now.</p>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" onClick={() => void handleStartEnrollment()} disabled={isStartingEnrollment}>
+                  {isStartingEnrollment ? "Preparing QR code…" : "I have an app"}
+                </Button>
+                <Button type="button" variant="ghost" onClick={() => setWizardStep("welcome")}>
+                  Back
+                </Button>
+                {allowSkip && !onboardingRequired && onSkip ? (
+                  <Button type="button" variant="ghost" onClick={onSkip}>
+                    Skip for now
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+
+          {wizardStep === "scan" ? (
+            <div className="space-y-4 animate-in fade-in-0 slide-in-from-right-2 duration-200">
+              <h3 className="text-lg font-semibold text-foreground">Scan this QR code</h3>
+              <p className="text-sm text-muted-foreground">
+                Open your authenticator app, choose add account, then scan this code.
+              </p>
+              <div className="mx-auto w-full max-w-xs rounded-xl border border-border bg-background p-4">
+                {qrCodeDataUrl ? (
+                  <img
+                    src={qrCodeDataUrl}
+                    alt="QR code for authenticator setup"
+                    className="h-auto w-full rounded-md border border-border/70"
+                  />
+                ) : (
+                  <p className="text-center text-sm text-muted-foreground">Generating QR code…</p>
+                )}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" onClick={() => setWizardStep("verify")} disabled={!enrollment}>
+                  I scanned it
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => setWizardStep("manual")} disabled={!enrollment}>
+                  Can&apos;t scan? Enter key manually
+                </Button>
+              </div>
+            </div>
+          ) : null}
+
+          {wizardStep === "manual" ? (
+            <div className="space-y-4 animate-in fade-in-0 slide-in-from-right-2 duration-200">
+              <h3 className="text-lg font-semibold text-foreground">Manual setup</h3>
+              <p className="text-sm text-muted-foreground">
+                In your app, choose manual entry and paste these values.
+              </p>
+              <FormField label="Setup key" hint={`Issuer: ${enrollment?.issuer ?? "ADE"} · Account: ${enrollment?.accountName ?? ""}`}>
+                <div className="flex gap-2">
+                  <Input value={enrollment?.secret ?? ""} readOnly className="font-mono" />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => void handleCopy("Setup key", enrollment?.secret ?? "")}
+                    disabled={!enrollment?.secret}
+                  >
+                    Copy
+                  </Button>
+                </div>
+              </FormField>
+              <FormField label="Authenticator URI">
+                <div className="flex gap-2">
+                  <Input value={enrollment?.otpauthUri ?? ""} readOnly className="font-mono text-xs" />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => void handleCopy("Authenticator URI", enrollment?.otpauthUri ?? "")}
+                    disabled={!enrollment?.otpauthUri}
+                  >
+                    Copy
+                  </Button>
+                </div>
+              </FormField>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" onClick={() => setWizardStep("verify")}>Continue</Button>
+                <Button type="button" variant="ghost" onClick={() => setWizardStep("scan")}>Back to QR code</Button>
+              </div>
+            </div>
+          ) : null}
+
+          {wizardStep === "verify" ? (
+            <form className="space-y-4 animate-in fade-in-0 slide-in-from-right-2 duration-200" onSubmit={handleConfirmEnrollment}>
+              <h3 className="text-lg font-semibold text-foreground">Verify your setup</h3>
+              <p className="text-sm text-muted-foreground">
+                Enter the current 6-digit code from your authenticator app.
+              </p>
+              <FormField label="One-time code" required hint="Codes refresh every 30 seconds.">
+                <Input
+                  type="text"
+                  autoComplete="one-time-code"
+                  placeholder="123456"
+                  value={verificationCode}
+                  onChange={(event) => setVerificationCode(event.target.value)}
+                  disabled={isConfirmingEnrollment}
+                />
+              </FormField>
+              <div className="flex flex-wrap gap-2">
+                <Button type="submit" disabled={isConfirmingEnrollment}>
+                  {isConfirmingEnrollment ? "Verifying…" : "Verify and enable MFA"}
+                </Button>
+                <Button type="button" variant="ghost" onClick={() => setWizardStep("scan")}>
+                  Back
+                </Button>
+              </div>
+            </form>
+          ) : null}
+
+          {wizardStep === "recovery" ? (
+            <div className="space-y-4 animate-in fade-in-0 slide-in-from-right-2 duration-200">
+              <h3 className="text-lg font-semibold text-foreground">Save your recovery codes</h3>
+              <p className="text-sm text-muted-foreground">
+                Store these in a secure location. Each recovery code can be used once if your phone is unavailable.
+              </p>
+              <ul className="grid gap-2 sm:grid-cols-2">
+                {recoveryCodes.map((code) => (
+                  <li key={code} className="rounded-md border border-border bg-background px-3 py-2 font-mono text-sm text-foreground">
+                    {code}
+                  </li>
+                ))}
+              </ul>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => void handleCopy("Recovery codes", recoveryCodes.join("\n"))}
+                  disabled={recoveryCodes.length === 0}
+                >
+                  Copy all
+                </Button>
+                <Button type="button" variant="outline" onClick={handleDownloadRecoveryCodes} disabled={recoveryCodes.length === 0}>
+                  Download
+                </Button>
+                <Button type="button" variant="outline" onClick={() => window.print()} disabled={recoveryCodes.length === 0}>
+                  Print
+                </Button>
+              </div>
+              <div className="flex items-center gap-2 rounded-md border border-border/80 bg-background px-3 py-2 text-sm text-foreground">
+                <Checkbox
+                  id="mfa-recovery-ack"
+                  checked={recoveryAcknowledged}
+                  onCheckedChange={(checked) => setRecoveryAcknowledged(Boolean(checked))}
+                />
+                <label htmlFor="mfa-recovery-ack" className="cursor-pointer">
+                  I saved my recovery codes in a secure place.
+                </label>
+              </div>
+              <Button type="button" disabled={!recoveryAcknowledged} onClick={() => void handleCompleteRecoveryStep()}>
+                Continue
+              </Button>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {!showWizard && mfaStatus?.enabled ? (
+        <section className="space-y-4 rounded-xl border border-border bg-card p-5 shadow-xs">
+          <div className="flex flex-wrap items-center gap-2">
+            <CheckCircle2 className="h-5 w-5 text-success" />
+            <h3 className="text-base font-semibold text-foreground">MFA is active</h3>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Your account is protected with TOTP verification. Keep your recovery posture current.
+          </p>
+          <div className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-2">
+            <p className="rounded-md border border-border/80 bg-background px-3 py-2">
+              Recovery codes remaining: <span className="font-semibold text-foreground">{mfaStatus?.recoveryCodesRemaining ?? 0}</span>
+            </p>
+            <p className="rounded-md border border-border/80 bg-background px-3 py-2">
+              Enrolled: <span className="font-semibold text-foreground">{mfaStatus?.enrolledAt ? formatDate(mfaStatus.enrolledAt) : "Unknown"}</span>
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setRegenerationCode("");
+                setRegenerateDialogOpen(true);
+              }}
+            >
+              Regenerate recovery codes
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setWizardActive(true);
+                setWizardStep("apps");
+              }}
+            >
+              Set up again
+            </Button>
+            <Button type="button" variant="destructive" onClick={() => setDisableDialogOpen(true)}>
+              Disable MFA
+            </Button>
+          </div>
+          <Alert tone="info">
+            If you lose your device, use a saved recovery code to sign in, then regenerate new recovery codes.
+          </Alert>
+        </section>
+      ) : null}
+
+      <ConfirmDialog
+        open={regenerateDialogOpen}
+        title="Regenerate recovery codes"
+        description="Enter a current authenticator code or recovery code to confirm."
+        confirmLabel={isRegeneratingCodes ? "Regenerating…" : "Regenerate"}
+        cancelLabel="Cancel"
+        confirmDisabled={regenerationCode.trim().length === 0}
+        isConfirming={isRegeneratingCodes}
+        onCancel={() => {
+          if (isRegeneratingCodes) {
+            return;
+          }
+          setRegenerateDialogOpen(false);
+        }}
+        onConfirm={() => {
+          void handleRegenerateRecoveryCodes();
+        }}
+      >
+        <FormField label="Verification code" required hint="Accepts 6-digit authenticator code or 8-character recovery code.">
+          <Input
+            value={regenerationCode}
+            onChange={(event) => setRegenerationCode(event.target.value)}
+            autoComplete="one-time-code"
+            placeholder="123456"
+            disabled={isRegeneratingCodes}
+          />
+        </FormField>
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={disableDialogOpen}
+        title="Disable MFA?"
+        description="This removes extra sign-in protection until you enable MFA again."
+        confirmLabel={isDisablingMfa ? "Disabling…" : "Disable MFA"}
+        cancelLabel="Cancel"
+        tone="danger"
+        isConfirming={isDisablingMfa}
+        onCancel={() => {
+          if (isDisablingMfa) {
+            return;
+          }
+          setDisableDialogOpen(false);
+        }}
+        onConfirm={() => {
+          void handleDisableMfa();
+        }}
+      >
+        {mfaStatus?.enabled ? (
+          <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-foreground">
+            You may be blocked from disabling MFA when SSO enforcement is active for global-admin accounts.
+          </p>
+        ) : (
+          <p className="rounded-md border border-border/80 bg-background px-3 py-2 text-sm text-muted-foreground">
+            MFA is already disabled.
+          </p>
+        )}
+      </ConfirmDialog>
+    </div>
+  );
+}
+
+function WizardProgress({ progressIndex }: { readonly progressIndex: number }) {
+  return (
+    <ol className="grid gap-2 text-xs sm:grid-cols-6" aria-label="MFA setup progress">
+      {PROGRESS_STEPS.map((step, index) => {
+        const isComplete = index < progressIndex;
+        const isCurrent = index === progressIndex;
+        return (
+          <li
+            key={step}
+            className={`rounded-md border px-2 py-1.5 text-center font-medium uppercase tracking-wide ${
+              isComplete
+                ? "border-success/40 bg-success/15 text-success"
+                : isCurrent
+                  ? "border-primary/40 bg-primary/10 text-primary"
+                  : "border-border bg-background text-muted-foreground"
+            }`}
+          >
+            {step}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function extractTotpSecret(otpauthUri: string): string | null {
+  try {
+    const uri = new URL(otpauthUri);
+    const secret = uri.searchParams.get("secret")?.trim() ?? "";
+    return secret.length > 0 ? secret : null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/features/mfa-setup/index.ts
+++ b/frontend/src/features/mfa-setup/index.ts
@@ -1,0 +1,1 @@
+export { MfaSetupFlow } from "./MfaSetupFlow";

--- a/frontend/src/hooks/auth/useGlobalPermissions.ts
+++ b/frontend/src/hooks/auth/useGlobalPermissions.ts
@@ -37,11 +37,15 @@ export function useGlobalPermissions() {
   );
 
   const canAccessOrganizationSettings = hasAnyPermission(ORG_SETTINGS_PERMISSIONS);
+  const canManageApiKeys = hasPermission("api_keys.manage_all");
+  const canReadApiKeys = canManageApiKeys || hasPermission("api_keys.read_all");
 
   return {
     permissions: permissionSet,
     hasPermission,
     hasAnyPermission,
     canAccessOrganizationSettings,
+    canManageApiKeys,
+    canReadApiKeys,
   };
 }

--- a/frontend/src/hooks/auth/useMfaStatusQuery.ts
+++ b/frontend/src/hooks/auth/useMfaStatusQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchMfaStatus, sessionKeys, type MfaStatusResponse } from "@/api/auth/api";
+
+interface UseMfaStatusQueryOptions {
+  readonly enabled?: boolean;
+}
+
+export function useMfaStatusQuery(options: UseMfaStatusQueryOptions = {}) {
+  return useQuery<MfaStatusResponse>({
+    queryKey: [...sessionKeys.root, "mfa-status"],
+    queryFn: ({ signal }) => fetchMfaStatus({ signal }),
+    enabled: options.enabled ?? true,
+    staleTime: 30_000,
+    gcTime: 300_000,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/frontend/src/pages/Account/components/AccountShell.tsx
+++ b/frontend/src/pages/Account/components/AccountShell.tsx
@@ -1,0 +1,170 @@
+import clsx from "clsx";
+import type { LucideIcon } from "lucide-react";
+import { Check, ChevronsUpDown, Menu } from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+export interface AccountNavItem {
+  readonly id: string;
+  readonly label: string;
+  readonly shortLabel: string;
+  readonly description: string;
+  readonly href: string;
+  readonly icon: LucideIcon;
+}
+
+interface AccountShellProps {
+  readonly navItems: readonly AccountNavItem[];
+  readonly activeSectionId: string;
+  readonly heading: string;
+  readonly sectionDescription: string;
+  readonly displayName: string;
+  readonly email: string;
+  readonly initials: string;
+  readonly children: ReactNode;
+}
+
+export function AccountShell({
+  navItems,
+  activeSectionId,
+  heading,
+  sectionDescription,
+  displayName,
+  email,
+  initials,
+  children,
+}: AccountShellProps) {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const activeNavItem = useMemo(
+    () => navItems.find((item) => item.id === activeSectionId),
+    [activeSectionId, navItems],
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-5 sm:px-6 sm:py-8">
+      <section className="rounded-2xl border border-border/80 bg-gradient-to-br from-card via-card to-accent/20 p-5 shadow-sm sm:p-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <Avatar className="h-12 w-12 border border-border/70 shadow-sm sm:h-14 sm:w-14">
+              <AvatarFallback className="bg-primary text-sm font-semibold uppercase text-primary-foreground sm:text-base">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+              <p className="text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-muted-foreground">
+                Account Center
+              </p>
+              <h1 className="truncate text-xl font-semibold text-foreground sm:text-2xl">{displayName}</h1>
+              <p className="truncate text-sm text-muted-foreground">{email}</p>
+            </div>
+          </div>
+          <div className="rounded-full border border-border/80 bg-background/80 px-3 py-1.5 text-xs text-muted-foreground shadow-xs">
+            Secure your profile and personal credentials.
+          </div>
+        </div>
+      </section>
+
+      <div className="sticky top-14 z-20 -mx-4 mt-5 border-y border-border/70 bg-background/95 px-4 py-3 backdrop-blur lg:hidden">
+        <p className="text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-muted-foreground">
+          Section
+        </p>
+        <div className="mt-2">
+          <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+            <SheetTrigger asChild>
+              <Button type="button" variant="outline" className="w-full justify-between">
+                <span className="flex min-w-0 items-center gap-2 truncate">
+                  {activeNavItem ? (
+                    <activeNavItem.icon className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <Menu className="h-4 w-4 text-muted-foreground" />
+                  )}
+                  <span className="truncate font-semibold">{activeNavItem?.shortLabel ?? heading}</span>
+                </span>
+                <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-[88vw] max-w-sm p-0 sm:max-w-sm">
+              <div className="flex h-full flex-col bg-card">
+                <SheetHeader className="border-b border-border/80 px-4 py-4 text-left">
+                  <SheetTitle>Account Settings</SheetTitle>
+                  <SheetDescription>Choose what you want to manage for your profile and security.</SheetDescription>
+                </SheetHeader>
+                <div className="flex-1 overflow-y-auto px-4 py-4">
+                  <AccountNavList
+                    navItems={navItems}
+                    activeSectionId={activeSectionId}
+                    onSelect={() => setMobileNavOpen(false)}
+                  />
+                </div>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[16rem_minmax(0,1fr)] lg:items-start lg:gap-8">
+        <aside className="hidden lg:sticky lg:top-6 lg:block">
+          <div className="rounded-xl border border-border bg-card px-3 py-3 shadow-xs">
+            <AccountNavList navItems={navItems} activeSectionId={activeSectionId} />
+          </div>
+        </aside>
+
+        <main className="min-w-0 animate-in fade-in-0 duration-200">
+          <header className="mb-6 space-y-1">
+            <h2 className="text-xl font-semibold text-foreground">{heading}</h2>
+            <p className="text-sm text-muted-foreground">{sectionDescription}</p>
+          </header>
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function AccountNavList({
+  navItems,
+  activeSectionId,
+  onSelect,
+}: {
+  readonly navItems: readonly AccountNavItem[];
+  readonly activeSectionId: string;
+  readonly onSelect?: () => void;
+}) {
+  return (
+    <nav className="space-y-1" aria-label="Account settings sections">
+      {navItems.map((item) => {
+        const isActive = item.id === activeSectionId;
+        return (
+          <Link
+            key={item.id}
+            to={item.href}
+            className={clsx(
+              "group flex w-full items-start gap-3 rounded-md px-3 py-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              isActive ? "bg-accent text-accent-foreground ring-1 ring-border/70" : "hover:bg-muted/40",
+            )}
+            aria-current={isActive ? "page" : undefined}
+            onClick={onSelect}
+          >
+            <item.icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm font-semibold text-foreground">{item.label}</span>
+              <span className="block text-xs text-muted-foreground">{item.description}</span>
+            </span>
+            {isActive ? <Check className="mt-0.5 h-4 w-4 shrink-0 text-foreground/80" /> : null}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { KeyRound, LayoutDashboard, ShieldCheck, UserRound } from "lucide-react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { fetchMfaStatus, type MfaStatusResponse } from "@/api/auth/api";
+import { mapUiError } from "@/api/uiErrors";
+import { PageState } from "@/components/layout";
+import { useGlobalPermissions } from "@/hooks/auth/useGlobalPermissions";
+import { getInitials } from "@/lib/format";
+import { useSession } from "@/providers/auth/SessionContext";
+import { AccountShell, type AccountNavItem } from "./components/AccountShell";
+import { AccountOverviewPage } from "./pages/AccountOverviewPage";
+import { ApiKeysPage } from "./pages/ApiKeysPage";
+import { ProfilePage } from "./pages/ProfilePage";
+import { SecurityPage } from "./pages/SecurityPage";
+
+type AccountSectionId = "overview" | "profile" | "security" | "api-keys";
+
+const BASE_SECTIONS: Array<{
+  id: AccountSectionId;
+  label: string;
+  shortLabel: string;
+  description: string;
+  href: string;
+  icon: AccountNavItem["icon"];
+}> = [
+  {
+    id: "overview",
+    label: "Overview",
+    shortLabel: "Overview",
+    description: "See account health and quick actions.",
+    href: "/account",
+    icon: LayoutDashboard,
+  },
+  {
+    id: "profile",
+    label: "Profile",
+    shortLabel: "Profile",
+    description: "Manage display name and identity details.",
+    href: "/account/profile",
+    icon: UserRound,
+  },
+  {
+    id: "security",
+    label: "Security",
+    shortLabel: "Security",
+    description: "Set up MFA and recovery options.",
+    href: "/account/security",
+    icon: ShieldCheck,
+  },
+  {
+    id: "api-keys",
+    label: "API Keys",
+    shortLabel: "API Keys",
+    description: "Create and revoke personal API credentials.",
+    href: "/account/api-keys",
+    icon: KeyRound,
+  },
+];
+
+export default function AccountCenterScreen() {
+  const session = useSession();
+  const navigate = useNavigate();
+  const params = useParams<{ "*": string }>();
+  const { canManageApiKeys } = useGlobalPermissions();
+
+  const [mfaStatus, setMfaStatus] = useState<MfaStatusResponse | null>(null);
+  const [isMfaStatusLoading, setIsMfaStatusLoading] = useState(true);
+  const [mfaStatusError, setMfaStatusError] = useState<string | null>(null);
+
+  const rawPath = (params["*"] ?? "").trim();
+  const segments = rawPath
+    .split("/")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  const activeSectionId: AccountSectionId =
+    segments.length === 0
+      ? "overview"
+      : segments[0] === "profile"
+        ? "profile"
+        : segments[0] === "security"
+          ? "security"
+          : segments[0] === "api-keys"
+            ? "api-keys"
+            : "overview";
+
+  const isInvalidPath = segments.length > 1 || !["", "profile", "security", "api-keys"].includes(segments[0] ?? "");
+
+  useEffect(() => {
+    if (isInvalidPath) {
+      navigate("/account", { replace: true });
+    }
+  }, [isInvalidPath, navigate]);
+
+  const refreshMfaStatus = useCallback(async () => {
+    setMfaStatusError(null);
+    try {
+      const status = await fetchMfaStatus();
+      setMfaStatus(status);
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: "Unable to read MFA status right now.",
+      });
+      setMfaStatusError(mapped.message);
+    } finally {
+      setIsMfaStatusLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshMfaStatus();
+  }, [refreshMfaStatus]);
+
+  const navItems = useMemo(
+    () =>
+      BASE_SECTIONS.filter((section) => section.id !== "api-keys" || canManageApiKeys).map((section) => ({
+        id: section.id,
+        label: section.label,
+        shortLabel: section.shortLabel,
+        description: section.description,
+        href: section.href,
+        icon: section.icon,
+      })),
+    [canManageApiKeys],
+  );
+
+  const sectionMeta = useMemo(
+    () => BASE_SECTIONS.find((section) => section.id === activeSectionId) ?? BASE_SECTIONS[0],
+    [activeSectionId],
+  );
+
+  const displayName = session.user.display_name?.trim() || session.user.email || "Account";
+  const email = session.user.email ?? "";
+  const initials = getInitials(session.user.display_name, email);
+
+  return (
+    <AccountShell
+      navItems={navItems}
+      activeSectionId={sectionMeta.id}
+      heading={sectionMeta.label}
+      sectionDescription={sectionMeta.description}
+      displayName={displayName}
+      email={email}
+      initials={initials}
+    >
+      {activeSectionId === "overview" ? (
+        <AccountOverviewPage
+          mfaStatus={mfaStatus}
+          isMfaStatusLoading={isMfaStatusLoading}
+          mfaStatusError={mfaStatusError}
+          canManageApiKeys={canManageApiKeys}
+        />
+      ) : null}
+
+      {activeSectionId === "profile" ? (
+        <ProfilePage
+          displayName={session.user.display_name}
+          email={email}
+          createdAt={session.user.created_at}
+        />
+      ) : null}
+
+      {activeSectionId === "security" ? (
+        <SecurityPage
+          mfaStatus={mfaStatus}
+          isMfaStatusLoading={isMfaStatusLoading}
+          mfaStatusError={mfaStatusError}
+          onRefreshMfaStatus={refreshMfaStatus}
+        />
+      ) : null}
+
+      {activeSectionId === "api-keys" ? (
+        canManageApiKeys ? (
+          <ApiKeysPage />
+        ) : (
+          <PageState
+            variant="error"
+            title="You do not have access"
+            description="API key management is restricted to global administrators in this release."
+          />
+        )
+      ) : null}
+    </AccountShell>
+  );
+}

--- a/frontend/src/pages/Account/pages/AccountOverviewPage.tsx
+++ b/frontend/src/pages/Account/pages/AccountOverviewPage.tsx
@@ -1,0 +1,119 @@
+import { Link } from "react-router-dom";
+import { ShieldCheck, ShieldAlert, KeyRound, UserRound } from "lucide-react";
+
+import type { MfaStatusResponse } from "@/api/auth/api";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface AccountOverviewPageProps {
+  readonly mfaStatus: MfaStatusResponse | null;
+  readonly isMfaStatusLoading: boolean;
+  readonly mfaStatusError: string | null;
+  readonly canManageApiKeys: boolean;
+}
+
+export function AccountOverviewPage({
+  mfaStatus,
+  isMfaStatusLoading,
+  mfaStatusError,
+  canManageApiKeys,
+}: AccountOverviewPageProps) {
+  const statusLabel = isMfaStatusLoading
+    ? "Checking"
+    : mfaStatus?.enabled
+      ? "Enabled"
+      : "Not enabled";
+  const recoveryLabel = isMfaStatusLoading
+    ? "Checking recovery posture"
+    : mfaStatus?.enabled
+      ? `Recovery codes remaining: ${mfaStatus.recoveryCodesRemaining ?? 0}`
+      : "Recovery codes will be generated during setup";
+
+  return (
+    <div className="space-y-6">
+      {mfaStatusError ? <Alert tone="danger">{mfaStatusError}</Alert> : null}
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <article className="space-y-4 rounded-xl border border-border bg-card p-5 shadow-xs">
+          <header className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Security health</p>
+            <h3 className="text-lg font-semibold text-foreground">Account protection</h3>
+          </header>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={mfaStatus?.enabled ? "secondary" : "outline"}>{statusLabel}</Badge>
+            {mfaStatus?.enabled ? (
+              <Badge variant="secondary">Recovery configured</Badge>
+            ) : (
+              <Badge variant="outline">Recovery pending</Badge>
+            )}
+          </div>
+
+          <p className="text-sm text-muted-foreground">{recoveryLabel}</p>
+
+          <div className="rounded-lg border border-border/80 bg-background p-3 text-sm text-muted-foreground">
+            {mfaStatus?.enabled ? (
+              <p className="flex items-start gap-2">
+                <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-success" />
+                Your account is protected with TOTP MFA. Keep recovery codes in a safe location.
+              </p>
+            ) : (
+              <p className="flex items-start gap-2">
+                <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+                MFA is not enabled yet. Setup takes about 3 minutes and makes sign-in much safer.
+              </p>
+            )}
+          </div>
+        </article>
+
+        <article className="space-y-4 rounded-xl border border-border bg-card p-5 shadow-xs">
+          <header className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Quick actions</p>
+            <h3 className="text-lg font-semibold text-foreground">Jump to common tasks</h3>
+          </header>
+          <div className="grid gap-2">
+            <Button asChild variant="outline" className="justify-start">
+              <Link to="/account/security">
+                <ShieldCheck className="h-4 w-4" />
+                {mfaStatus?.enabled ? "Manage MFA" : "Set up MFA"}
+              </Link>
+            </Button>
+            <Button asChild variant="outline" className="justify-start">
+              <Link to="/account/profile">
+                <UserRound className="h-4 w-4" />
+                Edit profile
+              </Link>
+            </Button>
+            {canManageApiKeys ? (
+              <Button asChild variant="outline" className="justify-start">
+                <Link to="/account/api-keys">
+                  <KeyRound className="h-4 w-4" />
+                  Manage API keys
+                </Link>
+              </Button>
+            ) : null}
+          </div>
+        </article>
+      </section>
+
+      <article className="space-y-3 rounded-xl border border-border bg-card p-5 shadow-xs">
+        <header>
+          <h3 className="text-base font-semibold text-foreground">Need help?</h3>
+          <p className="text-sm text-muted-foreground">Common questions for getting your account secured.</p>
+        </header>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li className="rounded-md border border-border/80 bg-background px-3 py-2">
+            What app should I use? Microsoft Authenticator, Google Authenticator, Authy, and Duo Mobile all work.
+          </li>
+          <li className="rounded-md border border-border/80 bg-background px-3 py-2">
+            Can&apos;t scan the QR code? Use the manual setup key shown during MFA setup.
+          </li>
+          <li className="rounded-md border border-border/80 bg-background px-3 py-2">
+            Lost your phone? Use a saved recovery code to sign in, then regenerate a new set.
+          </li>
+        </ul>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/pages/Account/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/Account/pages/ApiKeysPage.tsx
@@ -1,0 +1,329 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+
+import { createMyApiKey, listMyApiKeys, revokeMyApiKey } from "@/api/api-keys/api";
+import { mapUiError } from "@/api/uiErrors";
+import type { ApiKeySummary } from "@/types";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { formatDate } from "@/lib/format";
+
+type Feedback =
+  | { tone: "success"; message: string }
+  | { tone: "danger"; message: string }
+  | null;
+
+const EXPIRY_OPTIONS: Array<{ label: string; value: string; days: number | null }> = [
+  { label: "90 days (recommended)", value: "90", days: 90 },
+  { label: "30 days", value: "30", days: 30 },
+  { label: "180 days", value: "180", days: 180 },
+  { label: "Never expires", value: "never", days: null },
+];
+
+export function ApiKeysPage() {
+  const [keys, setKeys] = useState<ApiKeySummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [nameInput, setNameInput] = useState("");
+  const [expiryValue, setExpiryValue] = useState(EXPIRY_OPTIONS[0].value);
+  const [revealSecret, setRevealSecret] = useState<string | null>(null);
+  const [revokeDialogOpen, setRevokeDialogOpen] = useState(false);
+  const [selectedForRevoke, setSelectedForRevoke] = useState<ApiKeySummary | null>(null);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+
+  const loadKeys = useCallback(async (mode: "initial" | "refresh" = "refresh") => {
+    if (mode === "initial") {
+      setIsLoading(true);
+    } else {
+      setIsRefreshing(true);
+    }
+
+    try {
+      const page = await listMyApiKeys({ includeRevoked: true, includeTotal: true, limit: 100 });
+      setKeys(page.items ?? []);
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: "Unable to load API keys.",
+      });
+      setFeedback({ tone: "danger", message: mapped.message });
+    } finally {
+      if (mode === "initial") {
+        setIsLoading(false);
+      } else {
+        setIsRefreshing(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadKeys("initial");
+  }, [loadKeys]);
+
+  const sortedKeys = useMemo(
+    () =>
+      [...keys].sort((left, right) => {
+        const leftDate = left.created_at ? Date.parse(left.created_at) : 0;
+        const rightDate = right.created_at ? Date.parse(right.created_at) : 0;
+        return rightDate - leftDate;
+      }),
+    [keys],
+  );
+
+  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFeedback(null);
+    setRevealSecret(null);
+    setIsCreating(true);
+
+    try {
+      const selectedExpiry = EXPIRY_OPTIONS.find((option) => option.value === expiryValue) ?? EXPIRY_OPTIONS[0];
+      const result = await createMyApiKey({
+        name: nameInput.trim().length > 0 ? nameInput.trim() : undefined,
+        expires_in_days: selectedExpiry.days ?? undefined,
+      });
+      setRevealSecret(result.secret);
+      setNameInput("");
+      setExpiryValue(EXPIRY_OPTIONS[0].value);
+      await loadKeys();
+      setFeedback({ tone: "success", message: "API key created. Copy it now because it will not be shown again." });
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: "Unable to create API key.",
+      });
+      setFeedback({ tone: "danger", message: mapped.message });
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleCopySecret = async () => {
+    if (!revealSecret) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(revealSecret);
+      setFeedback({ tone: "success", message: "API key copied to clipboard." });
+    } catch {
+      setFeedback({ tone: "danger", message: "Clipboard access failed. Select and copy the key manually." });
+    }
+  };
+
+  const openRevokeDialog = (apiKey: ApiKeySummary) => {
+    setSelectedForRevoke(apiKey);
+    setRevokeDialogOpen(true);
+  };
+
+  const handleRevoke = async () => {
+    if (!selectedForRevoke) {
+      return;
+    }
+
+    setIsRevoking(true);
+    setFeedback(null);
+
+    try {
+      await revokeMyApiKey(selectedForRevoke.id, { ifMatch: "*" });
+      setRevokeDialogOpen(false);
+      setSelectedForRevoke(null);
+      await loadKeys();
+      setFeedback({ tone: "success", message: "API key revoked." });
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: "Unable to revoke API key.",
+      });
+      setFeedback({ tone: "danger", message: mapped.message });
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      {feedback ? <Alert tone={feedback.tone}>{feedback.message}</Alert> : null}
+
+      <section className="space-y-4 rounded-xl border border-border bg-card p-5 shadow-xs">
+        <header className="space-y-1">
+          <h3 className="text-base font-semibold text-foreground">Create API key</h3>
+          <p className="text-sm text-muted-foreground">
+            API keys are global user credentials. They inherit the same workspace and route access that your user has.
+          </p>
+        </header>
+
+        <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_16rem_auto]" onSubmit={handleCreate}>
+          <FormField label="Key name" hint="Optional label to track key purpose.">
+            <Input
+              value={nameInput}
+              onChange={(event) => setNameInput(event.target.value)}
+              placeholder="CI deployment key"
+              maxLength={100}
+              disabled={isCreating}
+            />
+          </FormField>
+          <FormField label="Expiration">
+            <select
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+              value={expiryValue}
+              onChange={(event) => setExpiryValue(event.target.value)}
+              disabled={isCreating}
+            >
+              {EXPIRY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </FormField>
+          <div className="flex items-end">
+            <Button type="submit" disabled={isCreating} className="w-full md:w-auto">
+              {isCreating ? "Creating…" : "Create key"}
+            </Button>
+          </div>
+        </form>
+
+        {revealSecret ? (
+          <div className="space-y-3 rounded-lg border border-warning/30 bg-warning/10 p-4">
+            <p className="text-sm font-semibold text-foreground">Copy this key now</p>
+            <Input value={revealSecret} readOnly className="font-mono text-xs" />
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="secondary" size="sm" onClick={handleCopySecret}>
+                Copy key
+              </Button>
+              <Button type="button" variant="ghost" size="sm" onClick={() => setRevealSecret(null)}>
+                Hide key
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">For security, this secret is shown only once.</p>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="space-y-4 rounded-xl border border-border bg-card p-5 shadow-xs">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-base font-semibold text-foreground">Your API keys</h3>
+          <Button type="button" variant="ghost" size="sm" onClick={() => void loadKeys()} disabled={isRefreshing}>
+            {isRefreshing ? "Refreshing…" : "Refresh"}
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading API keys…</p>
+        ) : sortedKeys.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
+            No API keys created yet.
+          </p>
+        ) : (
+          <>
+            <div className="hidden overflow-hidden rounded-xl border border-border md:block">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2">Name</th>
+                    <th className="px-3 py-2">Prefix</th>
+                    <th className="px-3 py-2">Created</th>
+                    <th className="px-3 py-2">Last used</th>
+                    <th className="px-3 py-2">Expires</th>
+                    <th className="px-3 py-2">Status</th>
+                    <th className="px-3 py-2 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedKeys.map((key) => {
+                    const isRevoked = Boolean(key.revoked_at);
+                    return (
+                      <tr key={key.id} className="border-t border-border/70 align-top text-foreground">
+                        <td className="px-3 py-3">{key.name ?? "(unnamed)"}</td>
+                        <td className="px-3 py-3 font-mono text-xs text-muted-foreground">{key.prefix}</td>
+                        <td className="px-3 py-3 text-muted-foreground">{formatDate(key.created_at)}</td>
+                        <td className="px-3 py-3 text-muted-foreground">
+                          {key.last_used_at ? formatDate(key.last_used_at, { month: "short" }) : "Never"}
+                        </td>
+                        <td className="px-3 py-3 text-muted-foreground">
+                          {key.expires_at ? formatDate(key.expires_at, { month: "short" }) : "Never"}
+                        </td>
+                        <td className="px-3 py-3">
+                          <Badge variant={isRevoked ? "outline" : "secondary"}>
+                            {isRevoked ? "Revoked" : "Active"}
+                          </Badge>
+                        </td>
+                        <td className="px-3 py-3 text-right">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            disabled={isRevoked}
+                            onClick={() => openRevokeDialog(key)}
+                          >
+                            Revoke
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <ul className="grid gap-3 md:hidden">
+              {sortedKeys.map((key) => {
+                const isRevoked = Boolean(key.revoked_at);
+                return (
+                  <li key={key.id} className="space-y-3 rounded-lg border border-border bg-background p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-semibold text-foreground">{key.name ?? "(unnamed)"}</p>
+                      <Badge variant={isRevoked ? "outline" : "secondary"}>{isRevoked ? "Revoked" : "Active"}</Badge>
+                    </div>
+                    <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                      <dt className="font-semibold text-foreground">Prefix</dt>
+                      <dd className="font-mono">{key.prefix}</dd>
+                      <dt className="font-semibold text-foreground">Created</dt>
+                      <dd>{formatDate(key.created_at)}</dd>
+                      <dt className="font-semibold text-foreground">Expires</dt>
+                      <dd>{key.expires_at ? formatDate(key.expires_at, { month: "short" }) : "Never"}</dd>
+                    </dl>
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={isRevoked}
+                        onClick={() => openRevokeDialog(key)}
+                      >
+                        Revoke
+                      </Button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </>
+        )}
+      </section>
+
+      <ConfirmDialog
+        open={revokeDialogOpen}
+        title="Revoke API key?"
+        description="This action is immediate and cannot be undone. Any clients using this key will stop working."
+        confirmLabel={isRevoking ? "Revoking…" : "Revoke key"}
+        cancelLabel="Cancel"
+        tone="danger"
+        isConfirming={isRevoking}
+        onCancel={() => {
+          if (isRevoking) {
+            return;
+          }
+          setRevokeDialogOpen(false);
+          setSelectedForRevoke(null);
+        }}
+        onConfirm={() => {
+          void handleRevoke();
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/Account/pages/ProfilePage.tsx
+++ b/frontend/src/pages/Account/pages/ProfilePage.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { sessionKeys, type SessionEnvelope } from "@/api/auth/api";
+import { mapUiError } from "@/api/uiErrors";
+import { updateMyProfile } from "@/api/me/api";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { formatDate } from "@/lib/format";
+
+interface ProfilePageProps {
+  readonly displayName: string | null | undefined;
+  readonly email: string;
+  readonly createdAt?: string | null;
+}
+
+type Feedback =
+  | { tone: "success"; message: string }
+  | { tone: "danger"; message: string }
+  | null;
+
+export function ProfilePage({ displayName, email, createdAt }: ProfilePageProps) {
+  const queryClient = useQueryClient();
+  const [nameInput, setNameInput] = useState(displayName ?? "");
+  const [isSaving, setIsSaving] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+
+  useEffect(() => {
+    setNameInput(displayName ?? "");
+  }, [displayName]);
+
+  const normalizedInitialName = useMemo(() => (displayName ?? "").trim(), [displayName]);
+  const normalizedInput = nameInput.trim();
+  const hasChanges = normalizedInitialName !== normalizedInput;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!hasChanges) {
+      return;
+    }
+
+    setFeedback(null);
+    setIsSaving(true);
+    try {
+      const profile = await updateMyProfile({
+        display_name: normalizedInput.length > 0 ? normalizedInput : null,
+      });
+
+      queryClient.setQueryData<SessionEnvelope | null>(sessionKeys.detail(), (current) => {
+        if (!current) {
+          return current;
+        }
+
+        return {
+          ...current,
+          user: {
+            ...current.user,
+            display_name: profile.display_name,
+            updated_at: profile.updated_at,
+          },
+        };
+      });
+
+      setFeedback({ tone: "success", message: "Profile updated. Changes now appear across ADE." });
+    } catch (error) {
+      const mapped = mapUiError(error, {
+        fallback: "Unable to update profile.",
+        statusMessages: {
+          422: "Display name is invalid. Update the value and try again.",
+        },
+      });
+      setFeedback({ tone: "danger", message: mapped.message });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      {feedback ? <Alert tone={feedback.tone}>{feedback.message}</Alert> : null}
+
+      <section className="space-y-4 rounded-xl border border-border bg-card p-5 shadow-xs">
+        <header className="space-y-1">
+          <h3 className="text-base font-semibold text-foreground">Profile details</h3>
+          <p className="text-sm text-muted-foreground">
+            Update your display name. This name appears in shared activity across ADE.
+          </p>
+        </header>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <FormField
+            label="Display name"
+            hint="You can leave this blank and ADE will fall back to your email identity."
+          >
+            <Input
+              value={nameInput}
+              onChange={(event) => setNameInput(event.target.value)}
+              maxLength={200}
+              placeholder="How should we display your name?"
+              disabled={isSaving}
+            />
+          </FormField>
+
+          <FormField label="Email">
+            <Input value={email} readOnly aria-readonly className="text-muted-foreground" />
+          </FormField>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="submit" disabled={isSaving || !hasChanges}>
+              {isSaving ? "Saving…" : "Save profile"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={isSaving || !hasChanges}
+              onClick={() => setNameInput(displayName ?? "")}
+            >
+              Reset
+            </Button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-xl border border-border bg-card p-5 shadow-xs">
+        <h3 className="text-base font-semibold text-foreground">Account metadata</h3>
+        <dl className="mt-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-[auto_1fr] sm:gap-x-4">
+          <dt className="font-semibold text-foreground">Account email</dt>
+          <dd>{email}</dd>
+          <dt className="font-semibold text-foreground">Created</dt>
+          <dd>{createdAt ? formatDate(createdAt) : "Unknown"}</dd>
+        </dl>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/Account/pages/SecurityPage.tsx
+++ b/frontend/src/pages/Account/pages/SecurityPage.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { ShieldAlert, ShieldCheck } from "lucide-react";
+
+import type { MfaStatusResponse } from "@/api/auth/api";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { MfaSetupFlow } from "@/features/mfa-setup";
+
+interface SecurityPageProps {
+  readonly mfaStatus: MfaStatusResponse | null;
+  readonly isMfaStatusLoading: boolean;
+  readonly mfaStatusError: string | null;
+  readonly onRefreshMfaStatus: () => Promise<void>;
+}
+
+export function SecurityPage({
+  mfaStatus,
+  isMfaStatusLoading,
+  mfaStatusError,
+  onRefreshMfaStatus,
+}: SecurityPageProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const statusLabel = isMfaStatusLoading
+    ? "Checking"
+    : mfaStatus?.enabled
+      ? "MFA enabled"
+      : "MFA not enabled";
+
+  return (
+    <div className="space-y-5">
+      {mfaStatusError ? <Alert tone="danger">{mfaStatusError}</Alert> : null}
+
+      <section className="space-y-4 rounded-xl border border-border bg-card p-5 shadow-xs">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={mfaStatus?.enabled ? "secondary" : "outline"}>{statusLabel}</Badge>
+          {!isMfaStatusLoading ? (
+            <Badge variant="outline">
+              {mfaStatus?.enabled
+                ? `Recovery codes: ${mfaStatus.recoveryCodesRemaining ?? 0}`
+                : "Recovery pending"}
+            </Badge>
+          ) : null}
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          {mfaStatus?.enabled
+            ? "Your account is protected with TOTP MFA. You can rotate setup and regenerate recovery codes."
+            : "Set up MFA to reduce account takeover risk. The guided flow takes about 3 minutes."}
+        </p>
+
+        <div className="rounded-lg border border-border/80 bg-background p-3 text-sm text-muted-foreground">
+          {mfaStatus?.enabled ? (
+            <p className="flex items-start gap-2">
+              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-success" />
+              MFA is active for your sign-ins.
+            </p>
+          ) : (
+            <p className="flex items-start gap-2">
+              <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+              MFA is not active yet. Use the guided setup to enable it.
+            </p>
+          )}
+        </div>
+
+        <Button type="button" onClick={() => setDialogOpen(true)}>
+          {mfaStatus?.enabled ? "Manage MFA" : "Set up MFA"}
+        </Button>
+      </section>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl" showCloseButton>
+          <DialogHeader>
+            <DialogTitle>{mfaStatus?.enabled ? "Manage MFA" : "Set up MFA"}</DialogTitle>
+            <DialogDescription>
+              Follow the guided flow to enroll an authenticator app, verify your code, and save recovery codes.
+            </DialogDescription>
+          </DialogHeader>
+          <MfaSetupFlow
+            mfaStatus={mfaStatus}
+            isMfaStatusLoading={isMfaStatusLoading}
+            mfaStatusError={mfaStatusError}
+            onRefreshMfaStatus={onRefreshMfaStatus}
+            showStatusCard={false}
+            onFlowComplete={() => {
+              setDialogOpen(false);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -241,7 +241,12 @@ export default function LoginScreen() {
         return;
       }
       queryClient.setQueryData(sessionKeys.detail(), result.session);
-      navigate(pickReturnTo(result.session.return_to, destination), { replace: true });
+      const nextPath = pickReturnTo(result.session.return_to, destination);
+      if (result.mfaSetupRequired || result.mfaSetupRecommended) {
+        navigate(buildRedirectPath("/mfa/setup", nextPath), { replace: true });
+        return;
+      }
+      navigate(nextPath, { replace: true });
     } catch (error: unknown) {
       if (error instanceof ApiError) {
         const message = error.problem?.detail ?? error.message ?? "Unable to sign in.";

--- a/frontend/src/pages/MfaSetup/index.tsx
+++ b/frontend/src/pages/MfaSetup/index.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useLocation, useNavigate } from "react-router-dom";
+import { fetchMfaStatus, type MfaStatusResponse } from "@/api/auth/api";
+import { mapUiError } from "@/api/uiErrors";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { MfaSetupFlow } from "@/features/mfa-setup";
+
+const DEFAULT_RETURN_TO = "/";
+
+function sanitizeReturnTo(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+    return null;
+  }
+  if (/[\u0000-\u001F\u007F]/.test(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
+function resolveReturnTo(value: string | null | undefined) {
+  return sanitizeReturnTo(value) ?? DEFAULT_RETURN_TO;
+}
+
+export default function MfaSetupPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [mfaStatus, setMfaStatus] = useState<MfaStatusResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const returnTo = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return resolveReturnTo(params.get("returnTo"));
+  }, [location.search]);
+
+  const refreshStatus = useCallback(async () => {
+    setError(null);
+    try {
+      const next = await fetchMfaStatus();
+      setMfaStatus(next);
+    } catch (err) {
+      const mapped = mapUiError(err, {
+        fallback: "Unable to read MFA status right now.",
+      });
+      setError(mapped.message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshStatus();
+  }, [refreshStatus]);
+
+  useEffect(() => {
+    if (!mfaStatus?.enabled) {
+      return;
+    }
+    navigate(returnTo, { replace: true });
+  }, [mfaStatus?.enabled, navigate, returnTo]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-6">
+        <p className="text-sm text-muted-foreground">Loading MFA setup…</p>
+      </div>
+    );
+  }
+
+  if (error && !mfaStatus) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background px-6 text-center">
+        <p className="text-sm text-muted-foreground">{error}</p>
+        <Button variant="secondary" onClick={() => void refreshStatus()}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col justify-center px-6 py-10">
+      <section className="mb-6 space-y-3 rounded-2xl border border-border/80 bg-gradient-to-br from-card via-card to-accent/20 p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">Security setup</p>
+        <h1 className="text-2xl font-semibold text-foreground sm:text-3xl">Protect your account with MFA</h1>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Use the guided flow to connect your authenticator app, verify a code, and save recovery codes.
+          {mfaStatus?.onboardingRequired
+            ? " MFA setup is required before you can continue."
+            : " You can skip for now and set it up later from Account Settings."}
+        </p>
+        {error ? <Alert tone="danger">{error}</Alert> : null}
+      </section>
+
+      <MfaSetupFlow
+        mfaStatus={mfaStatus}
+        isMfaStatusLoading={isLoading}
+        mfaStatusError={error}
+        onRefreshMfaStatus={refreshStatus}
+        allowSkip={Boolean(mfaStatus?.skipAllowed)}
+        onboardingRequired={Boolean(mfaStatus?.onboardingRequired)}
+        onSkip={() => navigate(returnTo, { replace: true })}
+        onFlowComplete={() => navigate(returnTo, { replace: true })}
+      />
+    </div>
+  );
+}

--- a/frontend/src/types/generated/openapi.d.ts
+++ b/frontend/src/types/generated/openapi.d.ts
@@ -232,6 +232,24 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/auth/mfa/totp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read TOTP MFA status for the current user */
+        get: operations["mfa_status_api_v1_auth_mfa_totp_get"];
+        put?: never;
+        post?: never;
+        /** Disable TOTP for the current user */
+        delete: operations["mfa_disable_api_v1_auth_mfa_totp_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/auth/mfa/totp/enroll/confirm": {
         parameters: {
             query?: never;
@@ -243,6 +261,23 @@ export type paths = {
         put?: never;
         /** Confirm TOTP enrollment with current code */
         post: operations["mfa_enroll_confirm_api_v1_auth_mfa_totp_enroll_confirm_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/mfa/totp/recovery/regenerate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Regenerate recovery codes for current user */
+        post: operations["mfa_regenerate_recovery_codes_api_v1_auth_mfa_totp_recovery_regenerate_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -261,23 +296,6 @@ export type paths = {
         /** Verify MFA challenge and issue a session */
         post: operations["mfa_verify_challenge_api_v1_auth_mfa_challenge_verify_post"];
         delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/auth/mfa/totp": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Disable TOTP for the current user */
-        delete: operations["mfa_disable_api_v1_auth_mfa_totp_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -565,7 +583,11 @@ export type paths = {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update editable fields on the authenticated user's profile
+         * @description Patch mutable fields for the current principal.
+         */
+        patch: operations["patch_me_api_v1_me_patch"];
         trace?: never;
     };
     "/api/v1/me/bootstrap": {
@@ -1622,6 +1644,16 @@ export type components = {
              * @default false
              */
             mfa_required: boolean;
+            /**
+             * Mfasetuprecommended
+             * @default false
+             */
+            mfaSetupRecommended: boolean;
+            /**
+             * Mfasetuprequired
+             * @default false
+             */
+            mfaSetupRequired: boolean;
         };
         /** AuthMfaChallengeVerifyRequest */
         AuthMfaChallengeVerifyRequest: {
@@ -1648,6 +1680,35 @@ export type components = {
             issuer: string;
             /** Accountname */
             accountName: string;
+        };
+        /** AuthMfaRecoveryRegenerateRequest */
+        AuthMfaRecoveryRegenerateRequest: {
+            /** Code */
+            code: string;
+        };
+        /** AuthMfaStatusResponse */
+        AuthMfaStatusResponse: {
+            /** Enabled */
+            enabled: boolean;
+            /** Enrolledat */
+            enrolledAt?: string | null;
+            /** Recoverycodesremaining */
+            recoveryCodesRemaining?: number | null;
+            /**
+             * Onboardingrecommended
+             * @default false
+             */
+            onboardingRecommended: boolean;
+            /**
+             * Onboardingrequired
+             * @default false
+             */
+            onboardingRequired: boolean;
+            /**
+             * Skipallowed
+             * @default false
+             */
+            skipAllowed: boolean;
         };
         /** AuthPasswordForgotRequest */
         AuthPasswordForgotRequest: {
@@ -2651,6 +2712,17 @@ export type components = {
              * @description Timestamp of last profile update, if any.
              */
             updated_at?: string | null;
+        };
+        /**
+         * MeProfileUpdateRequest
+         * @description Payload for updating editable fields on the caller profile.
+         */
+        MeProfileUpdateRequest: {
+            /**
+             * Display Name
+             * @description Optional display name shown in the ADE user interface.
+             */
+            display_name?: string | null;
         };
         /**
          * MeWorkspaceSummary
@@ -4211,6 +4283,60 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
+    mfa_status_api_v1_auth_mfa_totp_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthMfaStatusResponse"];
+                };
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
+    mfa_disable_api_v1_auth_mfa_totp_delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-CSRF-Token"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
     mfa_enroll_confirm_api_v1_auth_mfa_totp_enroll_confirm_post: {
         parameters: {
             query?: never;
@@ -4223,6 +4349,44 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["AuthMfaEnrollConfirmRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthMfaEnrollConfirmResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
+    mfa_regenerate_recovery_codes_api_v1_auth_mfa_totp_recovery_regenerate_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-CSRF-Token"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthMfaRecoveryRegenerateRequest"];
             };
         };
         responses: {
@@ -4271,38 +4435,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["AuthLoginSuccess"];
                 };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            default: components["responses"]["ProblemDetails"];
-        };
-    };
-    mfa_disable_api_v1_auth_mfa_totp_delete: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-CSRF-Token"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
             /** @description Validation Error */
             422: {
@@ -4428,6 +4560,14 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Requires api_keys.manage_all global permission. */
+            403: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4482,6 +4622,14 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Requires api_keys.manage_all global permission. */
+            403: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4526,7 +4674,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description API key not owned by caller. */
+            /** @description Requires api_keys.manage_all global permission. */
             403: {
                 headers: {
                     "X-Request-Id": components["headers"]["X-Request-Id"];
@@ -4587,7 +4735,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description API key not owned by caller. */
+            /** @description Requires api_keys.manage_all global permission. */
             403: {
                 headers: {
                     "X-Request-Id": components["headers"]["X-Request-Id"];
@@ -5647,6 +5795,58 @@ export interface operations {
             };
             /** @description User record not found. */
             404: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
+    patch_me_api_v1_me_patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-CSRF-Token"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MeProfileUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MeProfile"];
+                };
+            };
+            /** @description Authentication required to update the profile. */
+            401: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Service account principals cannot access this endpoint. */
+            403: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No editable fields provided or payload validation failed. */
+            422: {
                 headers: {
                     "X-Request-Id": components["headers"]["X-Request-Id"];
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary
This PR delivers a first-class Account Center experience with a reusable MFA setup flow and optional local-auth MFA enforcement.

### Product/UX
- Add a unified account center at `/account` with sections for:
  - Overview
  - Profile
  - Security
  - API keys (permission-gated)
- Add a reusable guided MFA setup flow (`MfaSetupFlow`) used in two entry points:
  - Full-page onboarding route: `/mfa/setup`
  - In-context security dialog from Account Settings
- Preserve user-friendly optional onboarding behavior:
  - Skip is available when onboarding is recommended
  - Skip is hidden/disabled when onboarding is required
- Add onboarding redirects after successful local login and after first admin setup completion
- Keep account access discoverable via topbar "Account Settings" entry

### Backend/Auth Policy
- Add new env setting: `ADE_AUTH_ENFORCE_LOCAL_MFA` (default: `false`)
- Persist auth session source via `auth_sessions.auth_method` (`password | sso | unknown`)
- Enforce MFA setup server-side for password-authenticated sessions when policy is enabled
  - return deterministic `403` with `mfa_setup_required`
  - allow onboarding/logout/bootstrap endpoints needed to complete setup
- Extend login success payload with onboarding hints:
  - `mfaSetupRecommended`
  - `mfaSetupRequired`
- Extend `GET /api/v1/auth/mfa/totp` response with onboarding policy flags:
  - `onboardingRecommended`
  - `onboardingRequired`
  - `skipAllowed`
- Restrict self API-key endpoints to global admin capability in v1 (`api_keys.manage_all`)

### Profile + API Key Management
- Add self profile patch endpoint (`PATCH /api/v1/me`) for display name updates
- Add frontend profile API client + profile page wiring
- Add account-level API key management UX with one-time secret reveal and revoke flow

### API/Schema/Types
- Regenerate OpenAPI schema and frontend generated types
- Include DB migration for session auth method tracking

## Key Files
- Backend settings/auth/session enforcement:
  - `backend/src/ade_api/settings.py`
  - `backend/src/ade_api/core/http/dependencies.py`
  - `backend/src/ade_api/features/authn/service.py`
  - `backend/src/ade_api/features/auth/router.py`
  - `backend/src/ade_api/features/auth/sso_router.py`
  - `backend/src/ade_db/models/authn.py`
  - `backend/src/ade_db/migrations/versions/0004_auth_session_auth_method.py`
- Frontend reusable MFA + onboarding route:
  - `frontend/src/features/mfa-setup/MfaSetupFlow.tsx`
  - `frontend/src/pages/MfaSetup/index.tsx`
  - `frontend/src/providers/auth/RequireSession.tsx`
  - `frontend/src/pages/Login/index.tsx`
  - `frontend/src/pages/Setup/index.tsx`
- Account center:
  - `frontend/src/pages/Account/*`
  - `frontend/src/app/routes.tsx`
  - `frontend/src/app/layouts/components/topbar/UnifiedTopbarControls.tsx`

## Validation
Executed locally:
- `cd backend && uv run ade api types`
- `cd backend && uv run ade api test`
- `cd backend && uv run ade web lint`
- `cd backend && uv run ade web test`
- `cd backend && uv run ade test`
- `cd backend && uv run pytest tests/api/integration/auth/test_auth_sessions.py tests/api/integration/auth/test_me_profile.py`

All passed.

## Notes
- API keys remain global user-delegated credentials; no workspace scoping introduced.
- MFA enforcement policy is intentionally limited to password-authenticated sessions.
