### PR TITLE
fix: polish document bulk actions and harden auth session migration

### DIFF
--- a/backend/src/ade_db/migrations/versions/0004_auth_session_auth_method.py
+++ b/backend/src/ade_db/migrations/versions/0004_auth_session_auth_method.py
@@ -14,28 +14,54 @@ branch_labels: Optional[str] = None
 depends_on: Optional[str] = None
 
 
+def _has_auth_method_column() -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = inspector.get_columns("auth_sessions")
+    return any(column["name"] == "auth_method" for column in columns)
+
+
+def _has_auth_method_check_constraint() -> bool:
+    bind = op.get_bind()
+    query = sa.text(
+        """
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = :constraint_name
+          AND conrelid = 'auth_sessions'::regclass
+        """
+    )
+    return bind.execute(
+        query,
+        {"constraint_name": "ck_auth_sessions_auth_method"},
+    ).scalar_one_or_none() is not None
+
+
 def upgrade() -> None:
-    op.add_column(
-        "auth_sessions",
-        sa.Column(
-            "auth_method",
-            sa.String(length=32),
-            nullable=False,
-            server_default="unknown",
-        ),
-    )
-    op.execute(
-        """
-        ALTER TABLE auth_sessions
-        ADD CONSTRAINT ck_auth_sessions_auth_method
-        CHECK (auth_method IN ('password', 'sso', 'unknown'))
-        """
-    )
+    if not _has_auth_method_column():
+        op.add_column(
+            "auth_sessions",
+            sa.Column(
+                "auth_method",
+                sa.String(length=32),
+                nullable=False,
+                server_default="unknown",
+            ),
+        )
+
+    if not _has_auth_method_check_constraint():
+        op.execute(
+            """
+            ALTER TABLE auth_sessions
+            ADD CONSTRAINT ck_auth_sessions_auth_method
+            CHECK (auth_method IN ('password', 'sso', 'unknown'))
+            """
+        )
 
 
 def downgrade() -> None:
     op.execute(
         "ALTER TABLE auth_sessions DROP CONSTRAINT IF EXISTS ck_auth_sessions_auth_method"
     )
-    op.drop_column("auth_sessions", "auth_method")
-
+    if _has_auth_method_column():
+        op.drop_column("auth_sessions", "auth_method")

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTable.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTable.tsx
@@ -15,6 +15,12 @@ import {
   ActionBarSeparator,
 } from "@/components/ui/action-bar";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 import { DEFAULT_PAGE_SIZE, DEFAULT_SORTING } from "../../shared/constants";
 import type { DocumentRow } from "../../shared/types";
@@ -28,6 +34,11 @@ interface DocumentsTableProps {
   toolbarActions?: ReactNode;
   onBulkReprocessRequest?: (documents: DocumentRow[]) => void;
   onBulkCancelRequest?: (documents: DocumentRow[]) => void;
+  onBulkAssignRequest?: (documents: DocumentRow[]) => void;
+  onBulkTagRequest?: (documents: DocumentRow[]) => void;
+  onBulkDeleteRequest?: (documents: DocumentRow[]) => void;
+  onBulkDownloadRequest?: (documents: DocumentRow[]) => void;
+  onBulkDownloadOriginalRequest?: (documents: DocumentRow[]) => void;
   selectionResetToken?: number;
 }
 
@@ -40,6 +51,11 @@ export function DocumentsTable({
   toolbarActions,
   onBulkReprocessRequest,
   onBulkCancelRequest,
+  onBulkAssignRequest,
+  onBulkTagRequest,
+  onBulkDeleteRequest,
+  onBulkDownloadRequest,
+  onBulkDownloadOriginalRequest,
   selectionResetToken = 0,
 }: DocumentsTableProps) {
   const isAdvanced = filterMode === "advanced";
@@ -85,6 +101,14 @@ export function DocumentsTable({
     (document) => document.lastRun?.status !== "queued" && document.lastRun?.status !== "running",
   );
   const selectedCount = table.getFilteredSelectedRowModel().rows.length;
+  const showRunActions =
+    (cancellableDocuments.length > 0 && Boolean(onBulkCancelRequest)) ||
+    (reprocessableDocuments.length > 0 && Boolean(onBulkReprocessRequest));
+  const showOrganizeMenu = Boolean(onBulkAssignRequest || onBulkTagRequest);
+  const showDownloadMenu = Boolean(onBulkDownloadRequest || onBulkDownloadOriginalRequest);
+  const showSecondaryActions =
+    showOrganizeMenu || showDownloadMenu || Boolean(onBulkDeleteRequest);
+
   const actionBar = (
     <ActionBar
       open={selectedCount > 0}
@@ -113,6 +137,76 @@ export function DocumentsTable({
             onSelect={() => onBulkReprocessRequest(reprocessableDocuments)}
           >
             Reprocess ({reprocessableDocuments.length})
+          </ActionBarItem>
+        ) : null}
+      </ActionBarGroup>
+      {showRunActions && showSecondaryActions ? <ActionBarSeparator /> : null}
+      <ActionBarGroup>
+        {showOrganizeMenu ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <ActionBarItem
+                variant="outline"
+                size="sm"
+                onSelect={(event) => event.preventDefault()}
+              >
+                Organize
+              </ActionBarItem>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="center" side="top">
+              {onBulkAssignRequest ? (
+                <DropdownMenuItem
+                  onSelect={() => onBulkAssignRequest(selectedDocuments)}
+                >
+                  Assign…
+                </DropdownMenuItem>
+              ) : null}
+              {onBulkTagRequest ? (
+                <DropdownMenuItem
+                  onSelect={() => onBulkTagRequest(selectedDocuments)}
+                >
+                  Edit tags…
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+        {showDownloadMenu ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <ActionBarItem
+                variant="outline"
+                size="sm"
+                onSelect={(event) => event.preventDefault()}
+              >
+                Download
+              </ActionBarItem>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="center" side="top">
+              {onBulkDownloadRequest ? (
+                <DropdownMenuItem
+                  onSelect={() => onBulkDownloadRequest(selectedDocuments)}
+                >
+                  Download ({selectedDocuments.length})
+                </DropdownMenuItem>
+              ) : null}
+              {onBulkDownloadOriginalRequest ? (
+                <DropdownMenuItem
+                  onSelect={() => onBulkDownloadOriginalRequest(selectedDocuments)}
+                >
+                  Download original ({selectedDocuments.length})
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+        {onBulkDeleteRequest ? (
+          <ActionBarItem
+            variant="destructive"
+            size="sm"
+            onSelect={() => onBulkDeleteRequest(selectedDocuments)}
+          >
+            Delete ({selectedDocuments.length})
           </ActionBarItem>
         ) : null}
         <ActionBarItem variant="outline" size="sm" onSelect={() => table.toggleAllRowsSelected(false)}>

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/cells/ActionsCell.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/cells/ActionsCell.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { Ellipsis } from "lucide-react";
 
-import { ChatIcon, CloseIcon, DownloadIcon, EyeIcon, OutputIcon, RefreshIcon } from "@/components/icons";
+import { ChatIcon, CloseIcon, DownloadIcon, EyeIcon, RefreshIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -19,9 +19,8 @@ export function ActionsCell({
   isBusy,
   onRenameRequest,
   onDeleteRequest,
-  onDownloadOutput,
-  onDownloadLatest,
-  onDownloadVersion,
+  onDownload,
+  onDownloadOriginal,
   onReprocessRequest,
   onCancelRunRequest,
 }: {
@@ -31,21 +30,16 @@ export function ActionsCell({
   isBusy: boolean;
   onRenameRequest: (document: DocumentRow) => void;
   onDeleteRequest: (document: DocumentRow) => void;
-  onDownloadOutput: (document: DocumentRow) => void;
-  onDownloadLatest: (document: DocumentRow) => void;
-  onDownloadVersion?: (document: DocumentRow, versionNo: number) => void;
+  onDownload: (document: DocumentRow) => void;
+  onDownloadOriginal: (document: DocumentRow) => void;
   onReprocessRequest: (document: DocumentRow) => void;
   onCancelRunRequest: (document: DocumentRow) => void;
 }) {
   const isRunActive = document.lastRun?.status === "queued" || document.lastRun?.status === "running";
-  const canDownloadOutput = document.lastRun?.status === "succeeded";
+  const canDownloadNormalizedOutput = document.lastRun?.status === "succeeded";
   const runActionLabel = isRunActive ? "Cancel run" : "Reprocess";
   const commentCount = document.commentCount ?? 0;
   const commentBadgeLabel = commentCount > 99 ? "99+" : String(commentCount);
-  const latestLabel = document.currentVersionNo
-    ? `Download latest (v${document.currentVersionNo})`
-    : "Download latest";
-  const showOriginal = typeof document.currentVersionNo === "number" && document.currentVersionNo > 1;
 
   return (
     <div className="flex min-w-0 items-center justify-end gap-1" data-ignore-row-click>
@@ -80,16 +74,9 @@ export function ActionsCell({
         {isRunActive ? <CloseIcon className="h-4 w-4" /> : <RefreshIcon className="h-4 w-4" />}
       </IconButton>
       <IconButton
-        label={canDownloadOutput ? "Download normalized output" : "Output not ready"}
-        onClick={() => onDownloadOutput(document)}
-        disabled={!canDownloadOutput}
-        className="hidden shrink-0 sm:inline-flex"
-      >
-        <OutputIcon className="h-4 w-4" />
-      </IconButton>
-      <IconButton
-        label={latestLabel}
-        onClick={() => onDownloadLatest(document)}
+        label={canDownloadNormalizedOutput ? "Download normalized output" : "Output not ready"}
+        onClick={() => onDownload(document)}
+        disabled={!canDownloadNormalizedOutput}
         className="hidden shrink-0 sm:inline-flex"
       >
         <DownloadIcon className="h-4 w-4" />
@@ -113,19 +100,14 @@ export function ActionsCell({
             {runActionLabel}
           </DropdownMenuItem>
           <DropdownMenuItem
-            onSelect={() => onDownloadOutput(document)}
-            disabled={!canDownloadOutput}
+            onSelect={() => onDownload(document)}
+            disabled={!canDownloadNormalizedOutput}
           >
-            Download normalized output
+            Download
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => onDownloadLatest(document)}>
-            {latestLabel}
+          <DropdownMenuItem onSelect={() => onDownloadOriginal(document)}>
+            Download original
           </DropdownMenuItem>
-          {showOriginal && onDownloadVersion ? (
-            <DropdownMenuItem onSelect={() => onDownloadVersion(document, 1)}>
-              Download original (v1)
-            </DropdownMenuItem>
-          ) : null}
           <DropdownMenuItem onSelect={() => onRenameRequest(document)} disabled={isBusy}>
             Rename
           </DropdownMenuItem>

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/documentsColumns.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/documentsColumns.tsx
@@ -28,9 +28,8 @@ export type DocumentsColumnContext = {
   onToggleTag: (documentId: string, tag: string) => void;
   onRenameRequest: (document: DocumentRow) => void;
   onDeleteRequest: (document: DocumentRow) => void;
-  onDownloadOutput: (document: DocumentRow) => void;
-  onDownloadLatest: (document: DocumentRow) => void;
-  onDownloadVersion?: (document: DocumentRow, versionNo: number) => void;
+  onDownload: (document: DocumentRow) => void;
+  onDownloadOriginal: (document: DocumentRow) => void;
   onReprocessRequest: (document: DocumentRow) => void;
   onCancelRunRequest: (document: DocumentRow) => void;
   isRowActionPending?: (documentId: string) => boolean;
@@ -50,9 +49,8 @@ export function useDocumentsColumns({
   onToggleTag,
   onRenameRequest,
   onDeleteRequest,
-  onDownloadOutput,
-  onDownloadLatest,
-  onDownloadVersion,
+  onDownload,
+  onDownloadOriginal,
   onReprocessRequest,
   onCancelRunRequest,
   isRowActionPending,
@@ -323,9 +321,8 @@ export function useDocumentsColumns({
             isBusy={isRowActionPending?.(row.original.id) ?? false}
             onRenameRequest={onRenameRequest}
             onDeleteRequest={onDeleteRequest}
-            onDownloadOutput={onDownloadOutput}
-            onDownloadLatest={onDownloadLatest}
-            onDownloadVersion={onDownloadVersion}
+            onDownload={onDownload}
+            onDownloadOriginal={onDownloadOriginal}
             onReprocessRequest={onReprocessRequest}
             onCancelRunRequest={onCancelRunRequest}
           />
@@ -347,9 +344,8 @@ export function useDocumentsColumns({
       onAssign,
       onRenameRequest,
       onDeleteRequest,
-      onDownloadLatest,
-      onDownloadVersion,
-      onDownloadOutput,
+      onDownload,
+      onDownloadOriginal,
       onReprocessRequest,
       onCancelRunRequest,
       onTagOptionsChange,


### PR DESCRIPTION
## Summary
This PR delivers a first-class multi-document action experience on the Documents page and resolves a migration startup failure affecting `ade dev`.

It introduces a clearer bulk-action model (`Run`, `Organize`, `Download`, `Danger`) while keeping high-frequency actions prominent. It also makes the `auth_sessions` migration idempotent so local/dev databases with partially-applied schema state no longer fail on startup.

## What Changed
### Documents multi-select UX
- Expanded selection action bar with grouped bulk actions:
  - `Run`: `Cancel runs`, `Reprocess`
  - `Organize`: `Assign…`, `Edit tags…`
  - `Download`: `Download`, `Download original`
  - `Danger`: `Delete`
- Added bulk dialogs/flows:
  - Bulk assign dialog with explicit assignee/unassign choice
  - Bulk tag editor with add/remove behavior and overlap protection
  - Bulk delete confirmation dialog with selection preview
- Added bulk operation orchestration and summaries:
  - Batch tags via existing batch tags endpoint
  - Batch delete via existing batch delete endpoint
  - Bulk downloads with browser-safe staggering and user feedback
- Standardized row-level download actions:
  - Primary download icon downloads **normalized output** and is disabled when output is unavailable
  - Dropdown keeps **Download original** (and includes Download for parity on compact layouts)

### Migration reliability
- Hardened `0004_auth_session_auth_method` migration:
  - Guarded `auth_method` column creation with schema inspection
  - Guarded check-constraint creation with constraint existence query
  - Made downgrade safe for partially-applied states

## Why
- Improves discoverability and consistency for multi-document workflows (assign, tag, download, delete)
- Removes confusing version-specific download labels from common paths
- Prevents `uv run ade dev` from failing on `DuplicateColumn` when `auth_sessions.auth_method` already exists

## Validation
- `cd backend && uv run ade test`
  - API unit tests: passed
  - Worker unit tests: passed
  - Frontend test suite: passed
- `cd backend && uv run ade web lint`: passed
- `cd backend && uv run ade dev`: migrations and services start successfully after the migration fix

## Risk / Rollout
- Frontend-only behavioral changes for document list actions plus an idempotency fix in migration logic
- No API contract changes
