### PR TITLE
fix(web): add a consistent Home action in authenticated topbar

### DIFF
--- a/frontend/src/app/layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/app/layouts/AuthenticatedLayout.tsx
@@ -1,13 +1,12 @@
 import type { ReactNode } from "react";
-import { Link, Outlet, useLocation } from "react-router-dom";
-import { ArrowLeft } from "lucide-react";
+import { Outlet, useLocation } from "react-router-dom";
 
 import {
   AuthenticatedTopbarProvider,
   useAuthenticatedTopbarConfig,
 } from "@/app/layouts/components/topbar/AuthenticatedTopbarContext";
+import { HomeTopbarAction } from "@/app/layouts/components/topbar/HomeTopbarAction";
 import { UnifiedTopbarControls } from "@/app/layouts/components/topbar/UnifiedTopbarControls";
-import { Button } from "@/components/ui/button";
 import {
   Topbar,
   TopbarCenter,
@@ -62,9 +61,13 @@ export function AuthenticatedLayout() {
 function AuthenticatedLayoutInner() {
   const topbarConfig = useAuthenticatedTopbarConfig();
   const location = useLocation();
+  const isAccountRoute = location.pathname === "/account" || location.pathname.startsWith("/account/");
   const isOrganizationRoute =
     location.pathname === "/organization" || location.pathname.startsWith("/organization/");
-  const shouldRenderTopbarStart = isOrganizationRoute || Boolean(topbarConfig?.mobileAction);
+  const isWorkspacesIndexRoute =
+    location.pathname === "/workspaces" || location.pathname === "/workspaces/new";
+  const shouldShowHomeAction = isAccountRoute || isOrganizationRoute || isWorkspacesIndexRoute;
+  const shouldRenderTopbarStart = shouldShowHomeAction || Boolean(topbarConfig?.mobileAction);
 
   const topbar = (
     <Topbar className="shadow-sm">
@@ -72,14 +75,7 @@ function AuthenticatedLayoutInner() {
       <TopbarContent maxWidth="full" className="px-4 sm:px-6 lg:px-8">
         {shouldRenderTopbarStart ? (
           <TopbarStart className="relative z-10">
-            {isOrganizationRoute ? (
-              <Button asChild variant="outline" size="sm" className="h-9">
-                <Link to="/workspaces">
-                  <ArrowLeft className="size-4" />
-                  <span>Go back to workspace</span>
-                </Link>
-              </Button>
-            ) : null}
+            {shouldShowHomeAction ? <HomeTopbarAction /> : null}
             {topbarConfig?.mobileAction ? (
               <div className="md:hidden">{topbarConfig.mobileAction}</div>
             ) : null}

--- a/frontend/src/app/layouts/__tests__/AuthenticatedLayout.test.tsx
+++ b/frontend/src/app/layouts/__tests__/AuthenticatedLayout.test.tsx
@@ -82,22 +82,34 @@ describe("AuthenticatedLayout", () => {
     expect(screen.queryByTestId("mobile-slot")).not.toBeInTheDocument();
   });
 
-  it("renders a workspace return action on organization routes", async () => {
+  it.each([
+    { path: "/account", routePath: "account/*" },
+    { path: "/organization/users", routePath: "organization/*" },
+    { path: "/workspaces", routePath: "workspaces" },
+    { path: "/workspaces/new", routePath: "workspaces/new" },
+  ])("renders a home action on $path routes", async ({ path, routePath }) => {
     const user = userEvent.setup();
     const router = renderRouter(
-      ["/organization/users"],
+      [path],
       [
-        { path: "organization/*", element: <PlainPage /> },
-        { path: "workspaces", element: <PlainPage /> },
+        { index: true, element: <PlainPage /> },
+        { path: routePath, element: <PlainPage /> },
       ],
     );
 
-    expect(screen.getByRole("link", { name: "Go back to workspace" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Go to home" })).toBeInTheDocument();
 
     await act(async () => {
-      await user.click(screen.getByRole("link", { name: "Go back to workspace" }));
+      await user.click(screen.getByRole("link", { name: "Go to home" }));
     });
 
-    expect(router.state.location.pathname).toBe("/workspaces");
+    expect(router.state.location.pathname).toBe("/");
+  });
+
+  it("does not render a home action on root route", async () => {
+    renderRouter(["/"], [{ index: true, element: <PlainPage /> }]);
+
+    expect(await screen.findByTestId("unified-topbar-controls")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Go to home" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/layouts/components/topbar/HomeTopbarAction.tsx
+++ b/frontend/src/app/layouts/components/topbar/HomeTopbarAction.tsx
@@ -1,0 +1,15 @@
+import { House } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+
+export function HomeTopbarAction() {
+  return (
+    <Button asChild variant="outline" size="sm" className="h-9">
+      <Link to="/" aria-label="Go to home">
+        <House className="size-4" />
+        <span>Home</span>
+      </Link>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
This PR standardizes wayfinding in authenticated areas by introducing a single, consistent Home action in the top-left of the shared authenticated topbar.

### What changed
- Added a reusable HomeTopbarAction component (Home label, house icon, aria-label="Go to home", compact outline style).
- Updated AuthenticatedLayout to show the Home action on:
  - /account/*
  - /organization/*
  - /workspaces
  - /workspaces/new
- Removed the organization-only special case ("Go back to workspace") and replaced it with the shared Home action.
- Preserved existing mobile topbar actions (Home renders first, mobile action remains available).
- Reworked AuthenticatedLayout tests to cover route-based Home visibility and click-through behavior.

## Why
Users could land in account/organization/workspaces flows without a consistent, obvious path back to home context. This keeps the UI low-noise while making return navigation predictable.

## Validation
- cd frontend && npm test -- --run src/app/layouts/__tests__/AuthenticatedLayout.test.tsx
- cd backend && uv run ade web test
- cd backend && uv run ade web lint

## Scope
- Frontend-only.
- No API or backend changes.
- No change to existing / redirect behavior (preferred/last workspace logic remains intact).
