### PR TITLE
fix: prevent uuidv7 overflow in baseline migration

### DIFF
--- a/backend/src/ade_db/migrations/versions/0001_initial_schema.py
+++ b/backend/src/ade_db/migrations/versions/0001_initial_schema.py
@@ -55,8 +55,8 @@ def upgrade() -> None:
                     rand_a := floor(random() * 4096)::int;
                     rand_a_hex := lpad(to_hex(rand_a), 3, '0');
 
-                    rand_b_hex := lpad(to_hex(floor(random() * 4294967296)::int), 8, '0')
-                               || lpad(to_hex(floor(random() * 4294967296)::int), 8, '0');
+                    rand_b_hex := lpad(to_hex(floor(random() * 4294967296)::bigint), 8, '0')
+                               || lpad(to_hex(floor(random() * 4294967296)::bigint), 8, '0');
                     variant_nibble := (floor(random() * 4)::int) + 8;
                     rand_b_hex := to_hex(variant_nibble) || substring(rand_b_hex from 2);
 


### PR DESCRIPTION
## Summary
- change the `uuidv7()` baseline migration implementation to use `bigint` for 32-bit random chunks
- avoid `integer out of range` when generating UUIDs during fresh Postgres bootstrap

## Validation
- `cd backend && uv run ade test`
- Fresh Postgres regression run:
  - run migrations to head
  - `SELECT uuidv7()` over 50,000 generated rows
  - insert 2,000 `permissions` rows (UUID default path)
