### PR TITLE
feat: add browser-open flags for ade dev/start and streamline codex actions

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -3,29 +3,19 @@ version = 1
 name = "ADE Local Dev"
 
 [setup]
-script = "./setup.sh --with-infra --force"
+script = "./setup.sh"
 
 [[actions]]
-name = "🚀 Dev: API + Worker + Web (hot reload)"
+name = "Infra Up (detached)"
+icon = "tool"
+command = "cd backend && uv run ade infra up -d"
+
+[[actions]]
+name = "Dev + Open (ade dev --open)"
 icon = "run"
-command = "cd backend && uv run ade dev"
+command = "cd backend && uv run ade dev --open"
 
 [[actions]]
-name = "🟢 Infra: Start (detached + health wait)"
+name = "Stop + Clean (kill dev + infra cleanup)"
 icon = "tool"
-command = "cd backend && uv run ade infra up -d --wait"
-
-[[actions]]
-name = "🛑 Infra: Stop and remove"
-icon = "tool"
-command = "cd backend && uv run ade infra down"
-
-[[actions]]
-name = "🌐 Web: Open in browser"
-icon = "tool"
-command = "uv run --project backend ade web open"
-
-[[actions]]
-name = "✅ Test: Full suite (backend + frontend)"
-icon = "test"
-command = "cd backend && uv run ade test"
+command = "repo_root=\"$(pwd)\"; backend_dir=\"$repo_root/backend\"; backend_python=\"$backend_dir/.venv/bin/python\"; if command -v pkill >/dev/null 2>&1; then pkill -f \"$backend_python -m ade_api\" || true; pkill -f \"$backend_python -m ade_worker\" || true; pkill -f \"$backend_python -m ade_cli web dev\" || true; fi; cd backend && uv run ade infra down -v --remove-orphans"

--- a/README.md
+++ b/README.md
@@ -32,20 +32,25 @@ docker compose down -v
 ## Native Dev Loop (Isolated Per Worktree)
 
 ```bash
-./setup.sh --with-infra
+./setup.sh
+cd backend && uv run ade infra up -d --wait
 cd backend && uv run ade dev
 ```
 
 This flow uses a generated local profile in `.env` and keeps each worktree isolated.
+If you want setup to immediately launch ADE and open a browser, run `./setup.sh --open`.
 
 Useful commands:
 
 ```bash
+./setup.sh
+./setup.sh --open
 cd backend && uv run ade infra info
 cd backend && uv run ade infra up -d --wait
 cd backend && uv run ade infra down
 cd backend && uv run ade infra down -v --rmi all
 ./setup.sh --with-infra --force
+cd backend && uv run ade dev --open
 ```
 
 ## Production Start Points

--- a/backend/src/ade_cli/web.py
+++ b/backend/src/ade_cli/web.py
@@ -43,7 +43,7 @@ def _resolve_internal_api_url(env: dict[str, str]) -> str:
     return f"{parsed.scheme}://{parsed.netloc}"
 
 
-def _resolve_public_web_url(env: dict[str, str]) -> str:
+def resolve_public_web_url(env: dict[str, str]) -> str:
     raw_public = env.get("ADE_PUBLIC_WEB_URL", "").strip().rstrip("/")
     if raw_public:
         parsed = urlparse(raw_public)
@@ -133,7 +133,7 @@ def preview() -> None:
 
 @app.command(name="open", help="Open web UI in the default browser.")
 def open_web() -> None:
-    url = _resolve_public_web_url(os.environ)
+    url = resolve_public_web_url(os.environ)
     typer.echo(url)
     status = typer.launch(url)
     if status != 0:
@@ -144,4 +144,4 @@ def open_web() -> None:
         typer.echo(f"Open manually: {url}", err=True)
 
 
-__all__ = ["app"]
+__all__ = ["app", "resolve_public_web_url"]

--- a/backend/tests/api/unit/common/test_root_cli.py
+++ b/backend/tests/api/unit/common/test_root_cli.py
@@ -35,6 +35,28 @@ def test_dev_runs_selected_services(monkeypatch):
     assert calls["process_names"] == ["api", "worker"]
 
 
+def test_dev_open_triggers_browser_helper(monkeypatch):
+    calls: dict[str, object] = {}
+
+    monkeypatch.setattr(cli, "_preflight_runtime", lambda selected: None)
+    monkeypatch.setattr(cli, "_maybe_run_migrations", lambda selected, migrate: None)
+    monkeypatch.setattr(
+        cli,
+        "_maybe_open_browser",
+        lambda *, selected, open_in_browser: calls.update(
+            {"open": (selected, open_in_browser)}
+        ),
+    )
+    monkeypatch.setattr(cli, "run_many", lambda processes, *, cwd: None)
+
+    result = runner.invoke(
+        app, ["dev", "--services", "api,web", "--no-migrate", "--open"]
+    )
+
+    assert result.exit_code == 0
+    assert calls["open"] == (["api", "web"], True)
+
+
 def test_start_defaults_to_all_services(monkeypatch):
     calls: dict[str, object] = {}
 
@@ -60,6 +82,43 @@ def test_start_defaults_to_all_services(monkeypatch):
     assert result.exit_code == 0
     assert calls["migrate"] == (["api", "worker", "web"], False)
     assert calls["process_names"] == ["api", "worker", "web"]
+
+
+def test_start_open_triggers_browser_helper(monkeypatch):
+    calls: dict[str, object] = {}
+
+    monkeypatch.setattr(cli, "_preflight_runtime", lambda selected: None)
+    monkeypatch.setattr(cli, "_maybe_run_migrations", lambda selected, migrate: None)
+    monkeypatch.setattr(
+        cli,
+        "_maybe_open_browser",
+        lambda *, selected, open_in_browser: calls.update(
+            {"open": (selected, open_in_browser)}
+        ),
+    )
+    monkeypatch.setattr(cli, "run_many", lambda processes, *, cwd: None)
+
+    result = runner.invoke(app, ["start", "--no-migrate", "--open"])
+
+    assert result.exit_code == 0
+    assert calls["open"] == (["api", "worker", "web"], True)
+
+
+def test_open_warns_when_web_not_selected(monkeypatch):
+    def _fail_if_called(url: str) -> None:
+        raise AssertionError("browser helper should not run when web service is excluded")
+
+    monkeypatch.setattr(cli, "_preflight_runtime", lambda selected: None)
+    monkeypatch.setattr(cli, "_maybe_run_migrations", lambda selected, migrate: None)
+    monkeypatch.setattr(cli, "run_many", lambda processes, *, cwd: None)
+    monkeypatch.setattr(cli, "_open_browser_when_ready", _fail_if_called)
+
+    result = runner.invoke(
+        app, ["dev", "--services", "api,worker", "--no-migrate", "--open"]
+    )
+
+    assert result.exit_code == 0
+    assert "warning: --open ignored because web service is not selected." in result.output
 
 
 def test_unknown_service_fails():

--- a/docs/how-to/run-local-dev-loop.md
+++ b/docs/how-to/run-local-dev-loop.md
@@ -18,7 +18,7 @@ You need:
 From repo root:
 
 ```bash
-./setup.sh --with-infra
+./setup.sh
 ```
 
 This installs:
@@ -27,7 +27,17 @@ This installs:
 - frontend dependencies in `frontend/node_modules`
 - local infra profile keys in `.env`
 
-`setup.sh --with-infra` starts infrastructure automatically.
+To start local infrastructure during setup:
+
+```bash
+./setup.sh --with-infra
+```
+
+To start ADE immediately after setup and open a browser when the web service is reachable:
+
+```bash
+./setup.sh --open
+```
 
 If you already ran setup and only want to manage infrastructure:
 
@@ -58,37 +68,17 @@ Development mode (recommended while coding):
 cd backend && uv run ade dev
 ```
 
+Open browser automatically while starting services:
+
+```bash
+cd backend && uv run ade dev --open
+```
+
 Production-style mode (no reload behavior):
 
 ```bash
 cd backend && uv run ade start
 ```
-
-Stop tracked ADE service processes:
-
-```bash
-cd backend && uv run ade stop
-```
-
-Show tracked ADE service status:
-
-```bash
-cd backend && uv run ade status
-```
-
-Restart in one command (stop then start):
-
-```bash
-cd backend && uv run ade restart
-```
-
-Restart with service selection and migration control:
-
-```bash
-cd backend && uv run ade restart --services worker --no-migrate
-```
-
-`ade stop`/`ade restart` now act on tracked processes started by `ade` (state file at `.ade/state.json`).
 
 ## Run One Service
 
@@ -156,6 +146,5 @@ curl -sS http://localhost:8001/api/v1/health
 - Re-run `./setup.sh`.
 - If `ade dev` reports missing local runtime settings or unreachable local infra, run `cd backend && uv run ade infra up`.
 - In devcontainers, ADE now uses `/app/.venv` for Python tooling and `/app/data` for runtime state; rebuild/reopen the container after path-related config changes.
-- Check service state with `cd backend && uv run ade status`.
 - If startup errors mention migrations, use [Run Migrations and Resets](run-migrations-and-resets.md).
 - For runtime issues, use [Triage Playbook](../troubleshooting/triage-playbook.md).

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -35,6 +35,7 @@ Key options for `ade start`/`ade dev`:
 
 - `--services`
 - `--migrate` / `--no-migrate`
+- `--open` (open ADE web in the default browser when the web service is reachable)
 - `ADE_API_PROCESSES` applies to `ade start`; `ade dev` keeps API reload mode (single process)
 
 ## API CLI: `ade-api`
@@ -97,6 +98,7 @@ cd backend && uv run ade infra up
 cd backend && uv run ade infra info
 cd backend && uv run ade infra down -v --rmi all
 cd backend && uv run ade dev
+cd backend && uv run ade dev --open
 cd backend && uv run ade start --services worker --no-migrate
 cd backend && uv run ade db migrate
 cd backend && uv run ade api types

--- a/setup.sh
+++ b/setup.sh
@@ -6,14 +6,16 @@ BACKEND_DIR="${ROOT_DIR}/backend"
 FRONTEND_DIR="${ROOT_DIR}/frontend"
 WITH_INFRA=false
 FORCE_INFRA=false
+OPEN_DEV=false
 
 print_usage() {
   cat <<'EOF'
-Usage: ./setup.sh [--with-infra] [--force]
+Usage: ./setup.sh [--with-infra] [--force] [--open]
 
 Options:
   --with-infra   Run `uv run ade infra up -d` after dependency installation.
   --force        Pass `--force` to `ade infra up` (requires --with-infra).
+  --open         Start `uv run ade dev --open` after setup completes.
 EOF
 }
 
@@ -24,6 +26,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     --force)
       FORCE_INFRA=true
+      ;;
+    --open)
+      OPEN_DEV=true
       ;;
     -h|--help)
       print_usage
@@ -65,6 +70,18 @@ if [[ "${WITH_INFRA}" == true ]]; then
     infra_cmd+=(--force)
   fi
   (cd "${BACKEND_DIR}" && "${infra_cmd[@]}")
+fi
+
+if [[ "${OPEN_DEV}" == true ]]; then
+  cat <<'EOF'
+
+Setup complete.
+Starting ADE dev services with browser auto-open:
+  cd backend
+  uv run ade dev --open
+EOF
+  (cd "${BACKEND_DIR}" && uv run ade dev --open)
+  exit 0
 fi
 
 cat <<'EOF'


### PR DESCRIPTION
## Summary
- add `--open` to `ade dev` and `ade start` to launch ADE Web in the default browser once the web service is reachable
- keep startup resilient: browser-open failures/timeouts now emit warnings and never stop service startup
- add `--open` to `setup.sh` so `./setup.sh --open` installs dependencies then runs `uv run ade dev --open`
- simplify Codex environment setup/actions to a minimal workflow (`Infra Up`, `Dev + Open`, `Stop + Clean`) and stop auto-starting infra in setup
- update docs to reflect the new setup and open workflows

## Implementation details
- reused web URL resolution logic from `ade web open` by exporting `resolve_public_web_url`
- in root CLI, start a daemon helper thread before `run_many(...)` to poll web port readiness and call `typer.launch(...)`
- when `--open` is used without selecting `web`, print a warning and continue
- tightened `Stop + Clean` kill patterns to the current workspace backend interpreter path to avoid cross-worktree process kills

## Tests
- `cd backend && uv run pytest tests/api/unit/common/test_root_cli.py tests/api/unit/common/test_web_cli.py`
- `cd backend && uv run ade test`

## Files changed
- `.codex/environments/environment.toml`
- `setup.sh`
- `backend/src/ade_cli/main.py`
- `backend/src/ade_cli/web.py`
- `backend/tests/api/unit/common/test_root_cli.py`
- `README.md`
- `docs/how-to/run-local-dev-loop.md`
- `docs/reference/cli-reference.md`
