### PR TITLE
feat(documents): unify latest download endpoint and simplify download UX

### DIFF
--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -7970,7 +7970,7 @@
         "tags": [
           "documents"
         ],
-        "summary": "Download a stored document",
+        "summary": "Download latest document artifact",
         "operationId": "download_document_api_v1_workspaces__workspaceId__documents__documentId__download_get",
         "parameters": [
           {
@@ -8030,6 +8030,106 @@
           },
           "404": {
             "description": "Document is missing or its stored file is unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      }
+    },
+    "/api/v1/workspaces/{workspaceId}/documents/{documentId}/original/download": {
+      "get": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Download original document version",
+        "operationId": "download_document_original_api_v1_workspaces__workspaceId__documents__documentId__original_download_get",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
+          {
+            "name": "documentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Document identifier",
+              "title": "Documentid"
+            },
+            "description": "Document identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required to download documents.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "403": {
+            "description": "Workspace permissions do not allow document downloads.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "404": {
+            "description": "Document or original version not found within the workspace.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"

--- a/backend/tests/api/integration/documents/test_documents_download.py
+++ b/backend/tests/api/integration/documents/test_documents_download.py
@@ -2,18 +2,70 @@
 
 from __future__ import annotations
 
+import io
 from uuid import UUID
 
 import anyio
 import pytest
 from httpx import AsyncClient
 
+from ade_api.common.ids import generate_uuid7
+from ade_api.common.time import utc_now
 from ade_storage import build_storage_adapter
-from ade_db.models import File
+from ade_db.models import File, FileKind, FileVersion, FileVersionOrigin
 from ade_api.settings import Settings
 from tests.api.utils import login
+from .helpers import seed_failed_run
 
 pytestmark = pytest.mark.asyncio
+
+
+def _create_output_version(
+    *,
+    db_session,
+    settings: Settings,
+    workspace_id: UUID,
+    document: File,
+    payload: bytes,
+    filename: str = "normalized.xlsx",
+) -> FileVersion:
+    output_file_id = generate_uuid7()
+    output_blob_name = f"{workspace_id}/files/{output_file_id}"
+
+    storage = build_storage_adapter(settings)
+    stored = storage.write(output_blob_name, io.BytesIO(payload))
+
+    output_file = File(
+        id=output_file_id,
+        workspace_id=workspace_id,
+        kind=FileKind.OUTPUT,
+        name=f"{document.name} (Output)",
+        name_key=f"output:{document.id}",
+        blob_name=output_blob_name,
+        source_file_id=document.id,
+        attributes={},
+        uploaded_by_user_id=None,
+        comment_count=0,
+    )
+    output_version = FileVersion(
+        id=generate_uuid7(),
+        file_id=output_file_id,
+        version_no=1,
+        origin=FileVersionOrigin.GENERATED,
+        run_id=None,
+        created_by_user_id=None,
+        sha256=stored.sha256,
+        byte_size=stored.byte_size,
+        content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        filename_at_upload=filename,
+        storage_version_id=stored.version_id,
+        created_at=utc_now(),
+    )
+    output_file.current_version = output_version
+    output_file.versions.append(output_version)
+    db_session.add_all([output_file, output_version])
+    db_session.flush()
+    return output_version
 
 
 async def test_download_missing_file_returns_404(
@@ -48,3 +100,195 @@ async def test_download_missing_file_returns_404(
     )
     assert download.status_code == 404
     assert "was not found" in download.text
+
+
+async def test_unified_download_returns_original_when_no_output_exists(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_base = f"/api/v1/workspaces/{seed_identity.workspace_id}"
+    headers = {"X-API-Key": token}
+
+    upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("source.csv", b"original-bytes", "text/csv")},
+    )
+    assert upload.status_code == 201, upload.text
+    document_id = upload.json()["id"]
+
+    download = await async_client.get(
+        f"{workspace_base}/documents/{document_id}/download",
+        headers=headers,
+    )
+    assert download.status_code == 200
+    assert download.content == b"original-bytes"
+    assert 'filename="source.csv"' in download.headers["content-disposition"]
+
+
+async def test_unified_download_prefers_newer_output_version(
+    async_client: AsyncClient,
+    seed_identity,
+    db_session,
+    settings: Settings,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_id = seed_identity.workspace_id
+    workspace_base = f"/api/v1/workspaces/{workspace_id}"
+    headers = {"X-API-Key": token}
+
+    upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("source.csv", b"original-bytes", "text/csv")},
+    )
+    assert upload.status_code == 201, upload.text
+    document_id = UUID(upload.json()["id"])
+    document = await anyio.to_thread.run_sync(db_session.get, File, document_id)
+    assert document is not None
+
+    _create_output_version(
+        db_session=db_session,
+        settings=settings,
+        workspace_id=workspace_id,
+        document=document,
+        payload=b"normalized-bytes",
+    )
+    await anyio.to_thread.run_sync(db_session.commit)
+
+    download = await async_client.get(
+        f"{workspace_base}/documents/{document_id}/download",
+        headers=headers,
+    )
+    assert download.status_code == 200
+    assert download.content == b"normalized-bytes"
+    assert 'filename="normalized.xlsx"' in download.headers["content-disposition"]
+
+
+async def test_unified_download_prefers_newer_input_version(
+    async_client: AsyncClient,
+    seed_identity,
+    db_session,
+    settings: Settings,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_id = seed_identity.workspace_id
+    workspace_base = f"/api/v1/workspaces/{workspace_id}"
+    headers = {"X-API-Key": token}
+
+    upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("source.csv", b"original-v1", "text/csv")},
+    )
+    assert upload.status_code == 201, upload.text
+    document_id = UUID(upload.json()["id"])
+    document = await anyio.to_thread.run_sync(db_session.get, File, document_id)
+    assert document is not None
+
+    _create_output_version(
+        db_session=db_session,
+        settings=settings,
+        workspace_id=workspace_id,
+        document=document,
+        payload=b"normalized-v1",
+    )
+    await anyio.to_thread.run_sync(db_session.commit)
+
+    upload_newer_input = await async_client.post(
+        f"{workspace_base}/documents/{document_id}/versions",
+        headers=headers,
+        files={"file": ("source.csv", b"original-v2", "text/csv")},
+    )
+    assert upload_newer_input.status_code == 201, upload_newer_input.text
+
+    download = await async_client.get(
+        f"{workspace_base}/documents/{document_id}/download",
+        headers=headers,
+    )
+    assert download.status_code == 200
+    assert download.content == b"original-v2"
+    assert 'filename="source.csv"' in download.headers["content-disposition"]
+
+
+async def test_unified_download_still_returns_output_after_failed_run_without_newer_artifact(
+    async_client: AsyncClient,
+    seed_identity,
+    db_session,
+    settings: Settings,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_id = seed_identity.workspace_id
+    workspace_base = f"/api/v1/workspaces/{workspace_id}"
+    headers = {"X-API-Key": token}
+
+    upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("source.csv", b"original-v1", "text/csv")},
+    )
+    assert upload.status_code == 201, upload.text
+    document_id = UUID(upload.json()["id"])
+    document = await anyio.to_thread.run_sync(db_session.get, File, document_id)
+    assert document is not None
+
+    _create_output_version(
+        db_session=db_session,
+        settings=settings,
+        workspace_id=workspace_id,
+        document=document,
+        payload=b"normalized-v1",
+    )
+    await seed_failed_run(
+        db_session,
+        workspace_id=workspace_id,
+        document_id=document_id,
+        uploader_id=seed_identity.member.id,
+    )
+    await anyio.to_thread.run_sync(db_session.commit)
+
+    download = await async_client.get(
+        f"{workspace_base}/documents/{document_id}/download",
+        headers=headers,
+    )
+    assert download.status_code == 200
+    assert download.content == b"normalized-v1"
+    assert 'filename="normalized.xlsx"' in download.headers["content-disposition"]
+
+
+async def test_download_original_endpoint_returns_version_one(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_base = f"/api/v1/workspaces/{seed_identity.workspace_id}"
+    headers = {"X-API-Key": token}
+
+    upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("source.csv", b"original-v1", "text/csv")},
+    )
+    assert upload.status_code == 201, upload.text
+    document_id = upload.json()["id"]
+
+    upload_newer_input = await async_client.post(
+        f"{workspace_base}/documents/{document_id}/versions",
+        headers=headers,
+        files={"file": ("source.csv", b"original-v2", "text/csv")},
+    )
+    assert upload_newer_input.status_code == 201, upload_newer_input.text
+
+    download_original = await async_client.get(
+        f"{workspace_base}/documents/{document_id}/original/download",
+        headers=headers,
+    )
+    assert download_original.status_code == 200
+    assert download_original.content == b"original-v1"
+    assert 'filename="source.csv"' in download_original.headers["content-disposition"]

--- a/backend/tests/api/integration/documents/test_documents_streaming.py
+++ b/backend/tests/api/integration/documents/test_documents_streaming.py
@@ -49,7 +49,7 @@ def test_stream_document_handles_missing_file(
     storage.delete(stored_row.blob_name)
 
     with pytest.raises(DocumentFileMissingError):
-        _, stream = service.stream_document(
+        _, _, _, stream = service.stream_document(
             workspace_id=workspace_id,
             document_id=record.id,
         )

--- a/frontend/src/pages/Workspace/sections/Documents/detail/components/__tests__/DocumentTicketHeader.test.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/components/__tests__/DocumentTicketHeader.test.tsx
@@ -1,0 +1,63 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@/test/test-utils";
+import type { DocumentRow } from "@/pages/Workspace/sections/Documents/shared/types";
+
+import { DocumentTicketHeader } from "../DocumentTicketHeader";
+
+function makeDocument(): DocumentRow {
+  return {
+    id: "doc_1",
+    workspaceId: "ws_1",
+    name: "source.csv",
+    fileType: "csv",
+    byteSize: 16,
+    commentCount: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    activityAt: "2026-01-01T00:00:00Z",
+    tags: [],
+    lastRun: {
+      id: "run_1",
+      status: "succeeded",
+      createdAt: "2026-01-01T00:00:00Z",
+      startedAt: "2026-01-01T00:01:00Z",
+      completedAt: "2026-01-01T00:02:00Z",
+      errorMessage: null,
+    },
+  } as DocumentRow;
+}
+
+describe("DocumentTicketHeader", () => {
+  it("uses unified download as primary and exposes original in the menu", async () => {
+    const user = userEvent.setup();
+    const document = makeDocument();
+
+    render(
+      <DocumentTicketHeader
+        workspaceId="ws_1"
+        document={document}
+        onBack={vi.fn()}
+        onRenameRequest={vi.fn()}
+        onReprocessRequest={vi.fn()}
+        onCancelRunRequest={vi.fn()}
+      />,
+    );
+
+    const unified = screen.getByRole("link", { name: "Download" });
+    expect(unified).toHaveAttribute(
+      "href",
+      "/api/v1/workspaces/ws_1/documents/doc_1/download",
+    );
+    expect(screen.queryByText("Download normalized")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "More" }));
+
+    const original = screen.getByRole("menuitem", { name: "Download original" });
+    expect(original).toHaveAttribute(
+      "href",
+      "/api/v1/workspaces/ws_1/documents/doc_1/original/download",
+    );
+  });
+});

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx
@@ -493,33 +493,20 @@ export function DocumentsTableContainer({
     }, 0);
   }, []);
 
-  const handleDownloadOutput = useCallback(
+  const handleDownloadLatest = useCallback(
     (document: DocumentRow) => {
-      const runId = document.lastRun?.status === "succeeded" ? document.lastRun.id : null;
-      if (!runId) {
-        notifyToast({
-          title: "Output not available",
-          description: "No successful run output exists for this document yet.",
-          intent: "warning",
-        });
-        return;
-      }
-
-      const url = resolveApiUrl(`/api/v1/workspaces/${workspaceId}/runs/${runId}/output/download`);
+      const url = resolveApiUrl(
+        `/api/v1/workspaces/${workspaceId}/documents/${document.id}/download`,
+      );
       openDownload(url);
     },
-    [notifyToast, openDownload, workspaceId],
+    [openDownload, workspaceId],
   );
 
   const getOriginalDownloadUrl = useCallback(
     (document: DocumentRow) => {
-      const hasVersionHistory =
-        typeof document.currentVersionNo === "number" && document.currentVersionNo > 1;
-      if (!hasVersionHistory) {
-        return resolveApiUrl(`/api/v1/workspaces/${workspaceId}/documents/${document.id}/download`);
-      }
       return resolveApiUrl(
-        `/api/v1/workspaces/${workspaceId}/documents/${document.id}/versions/1/download`,
+        `/api/v1/workspaces/${workspaceId}/documents/${document.id}/original/download`,
       );
     },
     [workspaceId],
@@ -1485,7 +1472,7 @@ export function DocumentsTableContainer({
     onRestoreRequest,
     onReprocessRequest,
     onCancelRunRequest,
-    onDownload: handleDownloadOutput,
+    onDownloadLatest: handleDownloadLatest,
     onDownloadOriginal: handleDownloadOriginal,
     isRowActionPending: isRowMutationPending,
   });

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/cells/ActionsCell.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/cells/ActionsCell.tsx
@@ -21,7 +21,7 @@ export function ActionsCell({
   onRenameRequest,
   onDeleteRequest,
   onRestoreRequest,
-  onDownload,
+  onDownloadLatest,
   onDownloadOriginal,
   onReprocessRequest,
   onCancelRunRequest,
@@ -34,14 +34,13 @@ export function ActionsCell({
   onRenameRequest: (document: DocumentRow) => void;
   onDeleteRequest: (document: DocumentRow) => void;
   onRestoreRequest: (document: DocumentRow) => void;
-  onDownload: (document: DocumentRow) => void;
+  onDownloadLatest: (document: DocumentRow) => void;
   onDownloadOriginal: (document: DocumentRow) => void;
   onReprocessRequest: (document: DocumentRow) => void;
   onCancelRunRequest: (document: DocumentRow) => void;
 }) {
   const isDeletedLifecycle = lifecycle === "deleted";
   const isRunActive = document.lastRun?.status === "queued" || document.lastRun?.status === "running";
-  const canDownloadNormalizedOutput = document.lastRun?.status === "succeeded";
   const runActionLabel = isDeletedLifecycle ? "Restore" : isRunActive ? "Cancel run" : "Reprocess";
   const commentCount = document.commentCount ?? 0;
   const commentBadgeLabel = commentCount > 99 ? "99+" : String(commentCount);
@@ -91,9 +90,8 @@ export function ActionsCell({
         )}
       </IconButton>
       <IconButton
-        label={canDownloadNormalizedOutput ? "Download normalized output" : "Output not ready"}
-        onClick={() => onDownload(document)}
-        disabled={!canDownloadNormalizedOutput}
+        label="Download latest document"
+        onClick={() => onDownloadLatest(document)}
         className="hidden shrink-0 sm:inline-flex"
       >
         <DownloadIcon className="h-4 w-4" />
@@ -123,8 +121,7 @@ export function ActionsCell({
             {runActionLabel}
           </DropdownMenuItem>
           <DropdownMenuItem
-            onSelect={() => onDownload(document)}
-            disabled={!canDownloadNormalizedOutput}
+            onSelect={() => onDownloadLatest(document)}
           >
             Download
           </DropdownMenuItem>

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/cells/__tests__/ActionsCell.test.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/cells/__tests__/ActionsCell.test.tsx
@@ -1,0 +1,64 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@/test/test-utils";
+import type { DocumentRow } from "@/pages/Workspace/sections/Documents/shared/types";
+
+import { ActionsCell } from "../ActionsCell";
+
+function makeDocument(): DocumentRow {
+  return {
+    id: "doc_1",
+    workspaceId: "ws_1",
+    name: "source.csv",
+    fileType: "csv",
+    byteSize: 16,
+    commentCount: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    activityAt: "2026-01-01T00:00:00Z",
+    tags: [],
+    lastRun: {
+      id: "run_1",
+      status: "failed",
+      createdAt: "2026-01-01T00:00:00Z",
+      startedAt: "2026-01-01T00:01:00Z",
+      completedAt: "2026-01-01T00:02:00Z",
+      errorMessage: "engine failed",
+    },
+  } as DocumentRow;
+}
+
+describe("ActionsCell", () => {
+  it("always exposes unified download and keeps original in menu", async () => {
+    const user = userEvent.setup();
+    const document = makeDocument();
+    const onDownloadLatest = vi.fn();
+    const onDownloadOriginal = vi.fn();
+
+    render(
+      <ActionsCell
+        document={document}
+        lifecycle="active"
+        onOpenDocument={vi.fn()}
+        onOpenActivity={vi.fn()}
+        isBusy={false}
+        onRenameRequest={vi.fn()}
+        onDeleteRequest={vi.fn()}
+        onRestoreRequest={vi.fn()}
+        onDownloadLatest={onDownloadLatest}
+        onDownloadOriginal={onDownloadOriginal}
+        onReprocessRequest={vi.fn()}
+        onCancelRunRequest={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Download latest document"));
+    expect(onDownloadLatest).toHaveBeenCalledWith(document);
+    expect(screen.queryByText(/Download normalized/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("More actions"));
+    await user.click(screen.getByText("Download original"));
+    expect(onDownloadOriginal).toHaveBeenCalledWith(document);
+  });
+});

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/documentsColumns.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/documentsColumns.tsx
@@ -30,7 +30,7 @@ export type DocumentsColumnContext = {
   onRenameRequest: (document: DocumentRow) => void;
   onDeleteRequest: (document: DocumentRow) => void;
   onRestoreRequest: (document: DocumentRow) => void;
-  onDownload: (document: DocumentRow) => void;
+  onDownloadLatest: (document: DocumentRow) => void;
   onDownloadOriginal: (document: DocumentRow) => void;
   onReprocessRequest: (document: DocumentRow) => void;
   onCancelRunRequest: (document: DocumentRow) => void;
@@ -53,7 +53,7 @@ export function useDocumentsColumns({
   onRenameRequest,
   onDeleteRequest,
   onRestoreRequest,
-  onDownload,
+  onDownloadLatest,
   onDownloadOriginal,
   onReprocessRequest,
   onCancelRunRequest,
@@ -347,7 +347,7 @@ export function useDocumentsColumns({
             onRenameRequest={onRenameRequest}
             onDeleteRequest={onDeleteRequest}
             onRestoreRequest={onRestoreRequest}
-            onDownload={onDownload}
+            onDownloadLatest={onDownloadLatest}
             onDownloadOriginal={onDownloadOriginal}
             onReprocessRequest={onReprocessRequest}
             onCancelRunRequest={onCancelRunRequest}
@@ -374,7 +374,7 @@ export function useDocumentsColumns({
       onRenameRequest,
       onDeleteRequest,
       onRestoreRequest,
-      onDownload,
+      onDownloadLatest,
       onDownloadOriginal,
       onReprocessRequest,
       onCancelRunRequest,

--- a/frontend/src/types/generated/openapi.d.ts
+++ b/frontend/src/types/generated/openapi.d.ts
@@ -958,8 +958,25 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Download a stored document */
+        /** Download latest document artifact */
         get: operations["download_document_api_v1_workspaces__workspaceId__documents__documentId__download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/workspaces/{workspaceId}/documents/{documentId}/original/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download original document version */
+        get: operations["download_document_original_api_v1_workspaces__workspaceId__documents__documentId__original_download_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -8113,6 +8130,67 @@ export interface operations {
                 content?: never;
             };
             /** @description Document is missing or its stored file is unavailable. */
+            404: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
+    download_document_original_api_v1_workspaces__workspaceId__documents__documentId__original_download_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
+                /** @description Document identifier */
+                documentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Authentication required to download documents. */
+            401: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Workspace permissions do not allow document downloads. */
+            403: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Document or original version not found within the workspace. */
             404: {
                 headers: {
                     "X-Request-Id": components["headers"]["X-Request-Id"];


### PR DESCRIPTION
## Summary
This PR unifies document downloads around a single "latest artifact" behavior while preserving explicit download paths for original and versioned files. It also simplifies the documents UI to one primary **Download** action, with **Download original** available from menus.

## What changed
### Backend
- Updated `GET /api/v1/workspaces/{workspaceId}/documents/{documentId}/download` to stream the latest artifact by comparing:
  - input document `current_version.created_at`
  - linked output document `current_version.created_at` (`name_key = output:{document_id}`)
- Tie-break rule is implemented as specified: output wins on equal timestamps.
- Added explicit original endpoint:
  - `GET /api/v1/workspaces/{workspaceId}/documents/{documentId}/original/download`
  - Streams version `1` of the input document.
- Kept explicit version endpoint unchanged:
  - `GET /api/v1/workspaces/{workspaceId}/documents/{documentId}/versions/{versionNo}/download`
- Preserved 404 behavior for missing document/version/blob paths.
- Updated OpenAPI and regenerated frontend API types.

### Frontend
- Replaced output-specific download logic with unified latest download in list/detail flows.
- Removed run-status gating for the main download action.
- Switched "Download original" URLs to the new explicit endpoint.
- Simplified UI actions:
  - Primary action is now a single **Download**.
  - **Download original** remains in action menus.
- Added component tests to ensure there is no remaining "Download normalized" label and that unified/original actions target correct endpoints.

## Files of note
- `backend/src/ade_api/features/documents/service.py`
- `backend/src/ade_api/features/documents/router.py`
- `backend/tests/api/integration/documents/test_documents_download.py`
- `frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx`
- `frontend/src/pages/Workspace/sections/Documents/list/table/cells/ActionsCell.tsx`
- `frontend/src/pages/Workspace/sections/Documents/detail/components/DocumentTicketHeader.tsx`
- `backend/src/ade_api/openapi.json`
- `frontend/src/types/generated/openapi.d.ts`

## Validation
- `cd backend && uv run ade test`
  - Passed (`api` unit + `worker` unit + `web` tests)
- New frontend tests passed:
  - `DocumentTicketHeader.test.tsx`
  - `ActionsCell.test.tsx`

## Behavioral outcomes
- If processing fails and no normalized output exists, unified download returns original.
- If a normalized output exists and is newer, unified download returns output.
- If a newer input version exists than output current version, unified download returns input.
- Explicit original and explicit version downloads remain available.
