### PR TITLE
fix: make document name reuse active-only

### DIFF
--- a/backend/src/ade_api/features/documents/exceptions.py
+++ b/backend/src/ade_api/features/documents/exceptions.py
@@ -123,6 +123,32 @@ class DocumentNameConflictError(Exception):
         self.name = name
 
 
+class DocumentRestoreNameConflictError(Exception):
+    """Raised when restoring a document would collide with an active document name."""
+
+    def __init__(
+        self,
+        *,
+        document_id: UUID | str,
+        name: str,
+        conflicting_document_id: UUID | str,
+        conflicting_name: str,
+        suggested_name: str,
+    ) -> None:
+        doc_id = str(document_id)
+        conflicting_id = str(conflicting_document_id)
+        message = (
+            f"Cannot restore document {doc_id!r} as {name!r}; "
+            f"active document {conflicting_id!r} already uses {conflicting_name!r}."
+        )
+        super().__init__(message)
+        self.document_id = doc_id
+        self.name = name
+        self.conflicting_document_id = conflicting_id
+        self.conflicting_name = conflicting_name
+        self.suggested_name = suggested_name
+
+
 class InvalidDocumentRenameError(Exception):
     """Raised when a rename request violates filename rules."""
 
@@ -187,6 +213,7 @@ __all__ = [
     "DocumentPreviewSheetNotFoundError",
     "DocumentPreviewParseError",
     "DocumentNameConflictError",
+    "DocumentRestoreNameConflictError",
     "InvalidDocumentRenameError",
     "DocumentVersionNotFoundError",
     "InvalidDocumentTagsError",

--- a/backend/src/ade_api/features/documents/router.py
+++ b/backend/src/ade_api/features/documents/router.py
@@ -66,6 +66,7 @@ from .exceptions import (
     DocumentFileMissingError,
     DocumentNameConflictError,
     DocumentNotFoundError,
+    DocumentRestoreNameConflictError,
     DocumentPreviewParseError,
     DocumentPreviewSheetNotFoundError,
     DocumentPreviewUnsupportedError,
@@ -82,6 +83,7 @@ from .exceptions import (
 from .schemas import (
     DocumentBatchDeleteRequest,
     DocumentBatchDeleteResponse,
+    DocumentBatchRestoreConflict,
     DocumentBatchRestoreRequest,
     DocumentBatchRestoreResponse,
     DocumentBatchTagsRequest,
@@ -96,6 +98,7 @@ from .schemas import (
     DocumentListLifecycle,
     DocumentListRow,
     DocumentOut,
+    DocumentRestoreRequest,
     DocumentSheet,
     DocumentTagsPatch,
     DocumentTagsReplace,
@@ -1353,8 +1356,14 @@ def delete_document(
         status.HTTP_403_FORBIDDEN: {
             "description": "Workspace permissions do not allow document restoration.",
         },
+        status.HTTP_409_CONFLICT: {
+            "description": "Document name conflicts with an active document.",
+        },
         status.HTTP_404_NOT_FOUND: {
             "description": "Document not found within the workspace.",
+        },
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {
+            "description": "Restore name is invalid (for example extension mismatch).",
         },
     },
 )
@@ -1363,12 +1372,50 @@ def restore_document(
     document_id: DocumentPath,
     service: DocumentsServiceDep,
     _actor: DocumentManager,
+    payload: DocumentRestoreRequest | None = None,
 ) -> DocumentOut:
     try:
         return service.restore_document(
             workspace_id=workspace_id,
             document_id=document_id,
+            name=payload.name if payload is not None else None,
         )
+    except DocumentRestoreNameConflictError as exc:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "message": str(exc),
+                "errors": [
+                    {
+                        "path": "documentId",
+                        "message": exc.document_id,
+                        "code": "restore_document_id",
+                    },
+                    {
+                        "path": "name",
+                        "message": exc.name,
+                        "code": "restore_name",
+                    },
+                    {
+                        "path": "conflictingDocumentId",
+                        "message": exc.conflicting_document_id,
+                        "code": "restore_conflicting_document_id",
+                    },
+                    {
+                        "path": "conflictingName",
+                        "message": exc.conflicting_name,
+                        "code": "restore_conflicting_name",
+                    },
+                    {
+                        "path": "suggestedName",
+                        "message": exc.suggested_name,
+                        "code": "restore_suggested_name",
+                    },
+                ],
+            },
+        ) from exc
+    except InvalidDocumentRenameError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
     except DocumentNotFoundError as exc:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
@@ -1422,9 +1469,6 @@ def delete_documents_batch(
         status.HTTP_403_FORBIDDEN: {
             "description": "Workspace permissions do not allow document restoration.",
         },
-        status.HTTP_404_NOT_FOUND: {
-            "description": "One or more documents were not found within the workspace.",
-        },
     },
 )
 def restore_documents_batch(
@@ -1433,15 +1477,24 @@ def restore_documents_batch(
     service: DocumentsServiceDep,
     _actor: DocumentManager,
 ) -> DocumentBatchRestoreResponse:
-    try:
-        restored_ids = service.restore_documents_batch(
-            workspace_id=workspace_id,
-            document_ids=payload.document_ids,
-        )
-    except DocumentNotFoundError as exc:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-
-    return DocumentBatchRestoreResponse(document_ids=restored_ids)
+    result = service.restore_documents_batch(
+        workspace_id=workspace_id,
+        document_ids=payload.document_ids,
+    )
+    return DocumentBatchRestoreResponse(
+        restored_ids=result.restored_ids,
+        conflicts=[
+            DocumentBatchRestoreConflict(
+                document_id=conflict.document_id,
+                name=conflict.name,
+                conflicting_document_id=conflict.conflicting_document_id,
+                conflicting_name=conflict.conflicting_name,
+                suggested_name=conflict.suggested_name,
+            )
+            for conflict in result.conflicts
+        ],
+        not_found_ids=result.not_found_ids,
+    )
 
 
 @tags_router.get(

--- a/backend/src/ade_api/features/runs/service.py
+++ b/backend/src/ade_api/features/runs/service.py
@@ -1844,6 +1844,7 @@ class RunsService:
             File.workspace_id == workspace_id,
             File.kind == FileKind.OUTPUT,
             File.name_key == name_key,
+            File.deleted_at.is_(None),
         )
         existing = self._session.execute(stmt).scalar_one_or_none()
         if existing is not None:

--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -8483,6 +8483,23 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/DocumentRestoreRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -8515,6 +8532,14 @@
               }
             }
           },
+          "409": {
+            "description": "Document name conflicts with an active document.",
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
           "404": {
             "description": "Document not found within the workspace.",
             "headers": {
@@ -8524,14 +8549,7 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
+            "description": "Restore name is invalid (for example extension mismatch).",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
@@ -8741,14 +8759,6 @@
           },
           "403": {
             "description": "Workspace permissions do not allow document restoration.",
-            "headers": {
-              "X-Request-Id": {
-                "$ref": "#/components/headers/X-Request-Id"
-              }
-            }
-          },
-          "404": {
-            "description": "One or more documents were not found within the workspace.",
             "headers": {
               "X-Request-Id": {
                 "$ref": "#/components/headers/X-Request-Id"
@@ -14653,6 +14663,45 @@
         "title": "DocumentBatchDeleteResponse",
         "description": "Response envelope for batch deletions."
       },
+      "DocumentBatchRestoreConflict": {
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Documentid",
+            "description": "UUIDv7 (RFC 9562) generated in the application layer."
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "conflictingDocumentId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Conflictingdocumentid",
+            "description": "UUIDv7 (RFC 9562) generated in the application layer."
+          },
+          "conflictingName": {
+            "type": "string",
+            "title": "Conflictingname"
+          },
+          "suggestedName": {
+            "type": "string",
+            "title": "Suggestedname"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "documentId",
+          "name",
+          "conflictingDocumentId",
+          "conflictingName",
+          "suggestedName"
+        ],
+        "title": "DocumentBatchRestoreConflict",
+        "description": "Conflict payload for a document that could not be restored."
+      },
       "DocumentBatchRestoreRequest": {
         "properties": {
           "documentIds": {
@@ -14664,7 +14713,7 @@
             "type": "array",
             "minItems": 1,
             "title": "Documentids",
-            "description": "Documents to restore (all-or-nothing)."
+            "description": "Documents to restore (each document resolved independently)."
           }
         },
         "additionalProperties": false,
@@ -14677,20 +14726,36 @@
       },
       "DocumentBatchRestoreResponse": {
         "properties": {
-          "documentIds": {
+          "restoredIds": {
             "items": {
               "type": "string",
               "format": "uuid",
               "description": "UUIDv7 (RFC 9562) generated in the application layer."
             },
             "type": "array",
-            "title": "Documentids"
+            "title": "Restoredids"
+          },
+          "conflicts": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentBatchRestoreConflict"
+            },
+            "type": "array",
+            "title": "Conflicts"
+          },
+          "notFoundIds": {
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUIDv7 (RFC 9562) generated in the application layer."
+            },
+            "type": "array",
+            "title": "Notfoundids"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "title": "DocumentBatchRestoreResponse",
-        "description": "Response envelope for batch restores."
+        "description": "Response envelope for partial batch restore operations."
       },
       "DocumentBatchTagsRequest": {
         "properties": {
@@ -15408,6 +15473,26 @@
         ],
         "title": "DocumentOut",
         "description": "Serialised representation of a stored document."
+      },
+      "DocumentRestoreRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Optional replacement name used while restoring a deleted document."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "DocumentRestoreRequest",
+        "description": "Optional payload for restoring a document with a new name."
       },
       "DocumentRunSummary": {
         "properties": {

--- a/backend/src/ade_db/migrations/versions/0002_active_only_file_name_uniqueness.py
+++ b/backend/src/ade_db/migrations/versions/0002_active_only_file_name_uniqueness.py
@@ -1,0 +1,59 @@
+"""Make file name uniqueness apply only to active rows.
+
+Revision ID: 0002_active_name_key_unique
+Revises: 0001_initial_schema
+Create Date: 2026-02-09
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from alembic import op
+
+# Revision identifiers, used by Alembic.
+revision = "0002_active_name_key_unique"
+down_revision: Optional[str] = "0001_initial_schema"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade() -> None:
+    # Prior schema used a table-level UNIQUE constraint. Drop it if present.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'files_workspace_kind_name_key'
+            ) THEN
+                ALTER TABLE files
+                    DROP CONSTRAINT files_workspace_kind_name_key;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+    # Ensure we recreate the index as a partial unique index over active rows only.
+    op.execute("DROP INDEX IF EXISTS files_workspace_kind_name_key;")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX files_workspace_kind_name_key
+            ON files (workspace_id, kind, name_key)
+            WHERE deleted_at IS NULL;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS files_workspace_kind_name_key;")
+    op.execute(
+        """
+        ALTER TABLE files
+            ADD CONSTRAINT files_workspace_kind_name_key
+            UNIQUE (workspace_id, kind, name_key);
+        """
+    )

--- a/backend/src/ade_db/models/file.py
+++ b/backend/src/ade_db/models/file.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.dialects.postgresql import JSONB
@@ -145,11 +146,13 @@ class File(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     __table_args__ = (
-        UniqueConstraint(
+        Index(
+            "files_workspace_kind_name_key",
             "workspace_id",
             "kind",
             "name_key",
-            name="files_workspace_kind_name_key",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
         ),
         Index("ix_files_workspace_created", "workspace_id", "created_at"),
         Index("ix_files_workspace_last_run_id", "workspace_id", "last_run_id"),

--- a/backend/src/ade_worker/db.py
+++ b/backend/src/ade_worker/db.py
@@ -287,6 +287,7 @@ def ensure_output_file(
         files.c.workspace_id == workspace_id,
         files.c.kind == "output",
         files.c.name_key == name_key,
+        files.c.deleted_at.is_(None),
     )
     row = session.execute(stmt).mappings().first()
     if row:
@@ -316,7 +317,10 @@ def ensure_output_file(
     session.execute(
         pg_insert(files)
         .values(**payload)
-        .on_conflict_do_nothing(index_elements=["workspace_id", "kind", "name_key"])
+        .on_conflict_do_nothing(
+            index_elements=["workspace_id", "kind", "name_key"],
+            index_where=files.c.deleted_at.is_(None),
+        )
     )
     row = session.execute(stmt).mappings().first()
     return dict(row) if row else payload

--- a/backend/tests/api/integration/documents/test_documents_delete.py
+++ b/backend/tests/api/integration/documents/test_documents_delete.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from httpx import AsyncClient
@@ -132,9 +132,329 @@ async def test_batch_delete_and_restore_documents(
         json={"documentIds": [id_one, id_two]},
     )
     assert restored.status_code == 200, restored.text
-    assert set(restored.json()["documentIds"]) == {id_one, id_two}
+    restored_payload = restored.json()
+    assert set(restored_payload["restoredIds"]) == {id_one, id_two}
+    assert restored_payload["conflicts"] == []
+    assert restored_payload["notFoundIds"] == []
 
     active_list = await async_client.get(f"{workspace_base}/documents", headers=headers)
     assert active_list.status_code == 200, active_list.text
     active_ids = {item["id"] for item in active_list.json()["items"]}
     assert {id_one, id_two}.issubset(active_ids)
+
+
+async def test_delete_reupload_same_name_releases_name_key(
+    async_client: AsyncClient,
+    seed_identity,
+    db_session,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_base = f"/api/v1/workspaces/{seed_identity.workspace_id}"
+    headers = {"X-API-Key": token}
+
+    first_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("repeat-name.txt", b"first", "text/plain")},
+    )
+    assert first_upload.status_code == 201, first_upload.text
+    first_document_id = first_upload.json()["id"]
+
+    deleted = await async_client.delete(
+        f"{workspace_base}/documents/{first_document_id}",
+        headers=headers,
+    )
+    assert deleted.status_code == 204, deleted.text
+
+    deleted_row = db_session.get(File, UUID(first_document_id))
+    assert deleted_row is not None
+    assert deleted_row.name == "repeat-name.txt"
+    assert deleted_row.name_key == "repeat-name.txt"
+
+    second_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("repeat-name.txt", b"second", "text/plain")},
+    )
+    assert second_upload.status_code == 201, second_upload.text
+    second_document_id = second_upload.json()["id"]
+    assert second_document_id != first_document_id
+
+    active_list = await async_client.get(f"{workspace_base}/documents", headers=headers)
+    assert active_list.status_code == 200, active_list.text
+    active_ids = {item["id"] for item in active_list.json()["items"]}
+    assert second_document_id in active_ids
+    assert first_document_id not in active_ids
+
+    deleted_list = await async_client.get(
+        f"{workspace_base}/documents",
+        headers=headers,
+        params={"lifecycle": "deleted"},
+    )
+    assert deleted_list.status_code == 200, deleted_list.text
+    deleted_ids = {item["id"] for item in deleted_list.json()["items"]}
+    assert first_document_id in deleted_ids
+
+
+async def test_restore_conflict_returns_409_and_supports_renamed_restore(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_base = f"/api/v1/workspaces/{seed_identity.workspace_id}"
+    headers = {"X-API-Key": token}
+
+    first_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("restore-clash.txt", b"first", "text/plain")},
+    )
+    assert first_upload.status_code == 201, first_upload.text
+    deleted_document_id = first_upload.json()["id"]
+
+    deleted = await async_client.delete(
+        f"{workspace_base}/documents/{deleted_document_id}",
+        headers=headers,
+    )
+    assert deleted.status_code == 204, deleted.text
+
+    second_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("restore-clash.txt", b"second", "text/plain")},
+    )
+    assert second_upload.status_code == 201, second_upload.text
+    active_document_id = second_upload.json()["id"]
+
+    restore_conflict = await async_client.post(
+        f"{workspace_base}/documents/{deleted_document_id}/restore",
+        headers=headers,
+    )
+    assert restore_conflict.status_code == 409, restore_conflict.text
+    problem = restore_conflict.json()
+    assert isinstance(problem["detail"], str) and problem["detail"].strip()
+    errors = {
+        item["path"]: item["message"]
+        for item in problem.get("errors", [])
+        if isinstance(item, dict) and "path" in item and "message" in item
+    }
+    assert errors["documentId"] == deleted_document_id
+    assert errors["conflictingDocumentId"] == active_document_id
+    assert errors["name"] == "restore-clash.txt"
+    assert errors["conflictingName"] == "restore-clash.txt"
+    suggested_name = errors["suggestedName"]
+    assert isinstance(suggested_name, str) and suggested_name.strip()
+
+    restored = await async_client.post(
+        f"{workspace_base}/documents/{deleted_document_id}/restore",
+        headers=headers,
+        json={"name": suggested_name},
+    )
+    assert restored.status_code == 200, restored.text
+    restored_payload = restored.json()
+    assert restored_payload["id"] == deleted_document_id
+    assert restored_payload["name"] == suggested_name
+
+
+async def test_batch_restore_partial_with_conflicts_and_not_found(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_base = f"/api/v1/workspaces/{seed_identity.workspace_id}"
+    headers = {"X-API-Key": token}
+
+    conflict_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("batch-clash.txt", b"first", "text/plain")},
+    )
+    assert conflict_upload.status_code == 201, conflict_upload.text
+    conflict_deleted_id = conflict_upload.json()["id"]
+
+    conflict_deleted = await async_client.delete(
+        f"{workspace_base}/documents/{conflict_deleted_id}",
+        headers=headers,
+    )
+    assert conflict_deleted.status_code == 204, conflict_deleted.text
+
+    conflict_active = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("batch-clash.txt", b"second", "text/plain")},
+    )
+    assert conflict_active.status_code == 201, conflict_active.text
+    conflict_active_id = conflict_active.json()["id"]
+
+    restorable_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("batch-restore-ok.txt", b"ok", "text/plain")},
+    )
+    assert restorable_upload.status_code == 201, restorable_upload.text
+    restorable_id = restorable_upload.json()["id"]
+
+    restorable_deleted = await async_client.delete(
+        f"{workspace_base}/documents/{restorable_id}",
+        headers=headers,
+    )
+    assert restorable_deleted.status_code == 204, restorable_deleted.text
+
+    missing_id = str(uuid4())
+    restore = await async_client.post(
+        f"{workspace_base}/documents/batch/restore",
+        headers=headers,
+        json={"documentIds": [conflict_deleted_id, restorable_id, missing_id]},
+    )
+    assert restore.status_code == 200, restore.text
+    payload = restore.json()
+
+    assert payload["restoredIds"] == [restorable_id]
+    assert payload["notFoundIds"] == [missing_id]
+    assert len(payload["conflicts"]) == 1
+    conflict_entry = payload["conflicts"][0]
+    assert conflict_entry["documentId"] == conflict_deleted_id
+    assert conflict_entry["name"] == "batch-clash.txt"
+    assert conflict_entry["conflictingDocumentId"] == conflict_active_id
+    assert conflict_entry["conflictingName"] == "batch-clash.txt"
+    assert isinstance(conflict_entry["suggestedName"], str) and conflict_entry["suggestedName"].strip()
+
+
+async def test_restore_with_extension_change_returns_422(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_base = f"/api/v1/workspaces/{seed_identity.workspace_id}"
+    headers = {"X-API-Key": token}
+
+    upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("extension-lock.txt", b"payload", "text/plain")},
+    )
+    assert upload.status_code == 201, upload.text
+    document_id = upload.json()["id"]
+
+    deleted = await async_client.delete(
+        f"{workspace_base}/documents/{document_id}",
+        headers=headers,
+    )
+    assert deleted.status_code == 204, deleted.text
+
+    restore = await async_client.post(
+        f"{workspace_base}/documents/{document_id}/restore",
+        headers=headers,
+        json={"name": "extension-lock.csv"},
+    )
+    assert restore.status_code == 422, restore.text
+    assert "extension" in str(restore.json().get("detail", "")).lower()
+
+
+async def test_restore_with_conflicting_requested_name_returns_409(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_base = f"/api/v1/workspaces/{seed_identity.workspace_id}"
+    headers = {"X-API-Key": token}
+
+    deleted_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("restore-target.txt", b"deleted", "text/plain")},
+    )
+    assert deleted_upload.status_code == 201, deleted_upload.text
+    deleted_document_id = deleted_upload.json()["id"]
+
+    deleted = await async_client.delete(
+        f"{workspace_base}/documents/{deleted_document_id}",
+        headers=headers,
+    )
+    assert deleted.status_code == 204, deleted.text
+
+    active_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("occupied-name.txt", b"active", "text/plain")},
+    )
+    assert active_upload.status_code == 201, active_upload.text
+    active_document_id = active_upload.json()["id"]
+
+    restore_conflict = await async_client.post(
+        f"{workspace_base}/documents/{deleted_document_id}/restore",
+        headers=headers,
+        json={"name": "occupied-name.txt"},
+    )
+    assert restore_conflict.status_code == 409, restore_conflict.text
+    problem = restore_conflict.json()
+    errors = {
+        item["path"]: item["message"]
+        for item in problem.get("errors", [])
+        if isinstance(item, dict) and "path" in item and "message" in item
+    }
+    assert errors["documentId"] == deleted_document_id
+    assert errors["conflictingDocumentId"] == active_document_id
+    assert errors["name"] == "occupied-name.txt"
+    assert errors["conflictingName"] == "occupied-name.txt"
+
+
+async def test_batch_restore_handles_multiple_deleted_docs_with_same_name(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    member = seed_identity.member
+    token, _ = await login(async_client, email=member.email, password=member.password)
+    workspace_base = f"/api/v1/workspaces/{seed_identity.workspace_id}"
+    headers = {"X-API-Key": token}
+
+    first_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("same-name.txt", b"first", "text/plain")},
+    )
+    assert first_upload.status_code == 201, first_upload.text
+    first_id = first_upload.json()["id"]
+
+    first_deleted = await async_client.delete(
+        f"{workspace_base}/documents/{first_id}",
+        headers=headers,
+    )
+    assert first_deleted.status_code == 204, first_deleted.text
+
+    second_upload = await async_client.post(
+        f"{workspace_base}/documents",
+        headers=headers,
+        files={"file": ("same-name.txt", b"second", "text/plain")},
+    )
+    assert second_upload.status_code == 201, second_upload.text
+    second_id = second_upload.json()["id"]
+
+    second_deleted = await async_client.delete(
+        f"{workspace_base}/documents/{second_id}",
+        headers=headers,
+    )
+    assert second_deleted.status_code == 204, second_deleted.text
+
+    restore = await async_client.post(
+        f"{workspace_base}/documents/batch/restore",
+        headers=headers,
+        json={"documentIds": [first_id, second_id]},
+    )
+    assert restore.status_code == 200, restore.text
+    payload = restore.json()
+
+    assert payload["restoredIds"] == [first_id]
+    assert payload["notFoundIds"] == []
+    assert len(payload["conflicts"]) == 1
+    conflict_entry = payload["conflicts"][0]
+    assert conflict_entry["documentId"] == second_id
+    assert conflict_entry["name"] == "same-name.txt"
+    assert conflict_entry["conflictingDocumentId"] == first_id
+    assert conflict_entry["conflictingName"] == "same-name.txt"
+    assert isinstance(conflict_entry["suggestedName"], str) and conflict_entry["suggestedName"].strip()

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx
@@ -21,7 +21,7 @@ import {
   updateDocumentView as updateSavedDocumentView,
   type DocumentViewRecord,
 } from "@/api/documents/views";
-import { ApiError } from "@/api/errors";
+import { ApiError, groupProblemDetailsErrors } from "@/api/errors";
 import { cancelRun, createRun, createRunsBatch } from "@/api/runs/api";
 import type { RunStreamOptions } from "@/api/runs/api";
 import { listWorkspaceMembers } from "@/api/workspaces/api";
@@ -151,6 +151,21 @@ function deriveFileType(name: string): DocumentRow["fileType"] {
   return inferFileType(name);
 }
 
+function extractRestoreConflict(error: ApiError): { message: string; suggestedName: string | null } {
+  const fallbackMessage = error.message || "Unable to restore document.";
+  const detail = error.problem?.detail;
+  const message = typeof detail === "string" && detail.trim().length > 0 ? detail : fallbackMessage;
+
+  const groupedErrors = groupProblemDetailsErrors(error.problem?.errors);
+  const firstSuggestedName = groupedErrors.suggestedName?.[0];
+  const suggestedName =
+    typeof firstSuggestedName === "string" && firstSuggestedName.trim().length > 0
+      ? firstSuggestedName
+      : null;
+
+  return { message, suggestedName };
+}
+
 function isRunActive(document: DocumentRow) {
   return document.lastRun?.status === "queued" || document.lastRun?.status === "running";
 }
@@ -184,6 +199,9 @@ export function DocumentsTableContainer({
   const navigate = useNavigate();
   const [deleteTarget, setDeleteTarget] = useState<DocumentRow | null>(null);
   const [restoreTarget, setRestoreTarget] = useState<DocumentRow | null>(null);
+  const [restoreRenameTarget, setRestoreRenameTarget] = useState<DocumentRow | null>(null);
+  const [restoreRenameInitialName, setRestoreRenameInitialName] = useState("");
+  const [restoreRenameError, setRestoreRenameError] = useState<string | null>(null);
   const [renameTarget, setRenameTarget] = useState<DocumentRow | null>(null);
   const [renameError, setRenameError] = useState<string | null>(null);
   const [saveAsOpen, setSaveAsOpen] = useState(false);
@@ -304,6 +322,9 @@ export function DocumentsTableContainer({
   useEffect(() => {
     setDeleteTarget(null);
     setRestoreTarget(null);
+    setRestoreRenameTarget(null);
+    setRestoreRenameInitialName("");
+    setRestoreRenameError(null);
     setRenameTarget(null);
     setRenameError(null);
     setSaveAsOpen(false);
@@ -1042,16 +1063,33 @@ export function DocumentsTableContainer({
     targets.forEach((documentId) => markRowPending(documentId, "restore"));
     setIsBulkRestoreSubmitting(true);
     try {
-      const restoredIds = await restoreWorkspaceDocumentsBatch(workspaceId, targets);
-      const resolvedRestoredIds = restoredIds.length > 0 ? restoredIds : targets;
-      resolvedRestoredIds.forEach((documentId) => removeRow(documentId));
+      const result = await restoreWorkspaceDocumentsBatch(workspaceId, targets);
+      const restoredIds = result.restoredIds ?? [];
+      const conflictCount = result.conflicts?.length ?? 0;
+      const notFoundCount = result.notFoundIds?.length ?? 0;
+
+      restoredIds.forEach((documentId) => removeRow(documentId));
       void refreshSnapshot();
+
+      const summaryParts: string[] = [];
+      if (restoredIds.length > 0) {
+        summaryParts.push(`${restoredIds.length} restored`);
+      }
+      if (conflictCount > 0) {
+        summaryParts.push(`${conflictCount} need rename`);
+      }
+      if (notFoundCount > 0) {
+        summaryParts.push(`${notFoundCount} not found`);
+      }
+
       notifyToast({
-        title: "Documents restored",
-        description: `${resolvedRestoredIds.length} document${resolvedRestoredIds.length === 1 ? "" : "s"} restored.`,
-        intent: "success",
+        title: "Batch restore complete",
+        description: summaryParts.length > 0 ? summaryParts.join(", ") : "No documents were restored.",
+        intent: conflictCount > 0 || notFoundCount > 0 ? "warning" : "success",
       });
-      setSelectionResetToken((value) => value + 1);
+      if (restoredIds.length > 0) {
+        setSelectionResetToken((value) => value + 1);
+      }
       onBulkRestoreCancel();
     } catch (error) {
       notifyToast({
@@ -1347,30 +1385,101 @@ export function DocumentsTableContainer({
 
   const onRestoreRequest = useCallback((document: DocumentRow) => {
     setRestoreTarget(document);
+    setRestoreRenameTarget(null);
+    setRestoreRenameInitialName("");
+    setRestoreRenameError(null);
   }, []);
 
   const onRestoreCancel = useCallback(() => {
     setRestoreTarget(null);
   }, []);
 
+  const onRestoreRenameCancel = useCallback(() => {
+    setRestoreRenameTarget(null);
+    setRestoreRenameInitialName("");
+    setRestoreRenameError(null);
+  }, []);
+
   const onRestoreConfirm = useCallback(async () => {
     if (!restoreTarget) return;
-    markRowPending(restoreTarget.id, "restore");
+    const current = documentsById[restoreTarget.id] ?? restoreTarget;
+    markRowPending(current.id, "restore");
     try {
-      await restoreWorkspaceDocument(workspaceId, restoreTarget.id);
-      removeRow(restoreTarget.id);
+      await restoreWorkspaceDocument(workspaceId, current.id);
+      removeRow(current.id);
       void refreshSnapshot();
       notifyToast({ title: "Document restored.", intent: "success", duration: 4000 });
       setRestoreTarget(null);
+      onRestoreRenameCancel();
     } catch (error) {
+      if (error instanceof ApiError && error.status === 409) {
+        const restoreConflict = extractRestoreConflict(error);
+        setRestoreTarget(null);
+        setRestoreRenameTarget(current);
+        setRestoreRenameInitialName(restoreConflict.suggestedName ?? current.name);
+        setRestoreRenameError(null);
+        return;
+      }
       notifyToast({
         title: error instanceof Error ? error.message : "Unable to restore document.",
         intent: "danger",
       });
     } finally {
-      clearRowPending(restoreTarget.id, "restore");
+      clearRowPending(current.id, "restore");
     }
-  }, [clearRowPending, markRowPending, notifyToast, refreshSnapshot, removeRow, restoreTarget, workspaceId]);
+  }, [
+    clearRowPending,
+    documentsById,
+    markRowPending,
+    notifyToast,
+    onRestoreRenameCancel,
+    refreshSnapshot,
+    removeRow,
+    restoreTarget,
+    workspaceId,
+  ]);
+
+  const onRestoreRenameConfirm = useCallback(async (nextName: string) => {
+    if (!restoreRenameTarget) return;
+    const current = documentsById[restoreRenameTarget.id] ?? restoreRenameTarget;
+    markRowPending(current.id, "restore");
+    setRestoreRenameError(null);
+    try {
+      await restoreWorkspaceDocument(workspaceId, current.id, { name: nextName });
+      removeRow(current.id);
+      void refreshSnapshot();
+      notifyToast({ title: "Document restored.", intent: "success", duration: 4000 });
+      onRestoreRenameCancel();
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 409) {
+        const restoreConflict = extractRestoreConflict(error);
+        setRestoreRenameError(restoreConflict.message);
+        if (restoreConflict.suggestedName) {
+          setRestoreRenameInitialName(restoreConflict.suggestedName);
+        }
+        return;
+      }
+      const description = error instanceof Error ? error.message : "Unable to restore document.";
+      setRestoreRenameError(description);
+      notifyToast({
+        title: "Unable to restore document",
+        description,
+        intent: "danger",
+      });
+    } finally {
+      clearRowPending(current.id, "restore");
+    }
+  }, [
+    clearRowPending,
+    documentsById,
+    markRowPending,
+    notifyToast,
+    onRestoreRenameCancel,
+    refreshSnapshot,
+    removeRow,
+    restoreRenameTarget,
+    workspaceId,
+  ]);
 
   const markStale = useCallback(() => {
     if (page > 1) {
@@ -1797,6 +1906,8 @@ export function DocumentsTableContainer({
     deleteTarget ? pendingMutations[deleteTarget.id]?.has("delete") ?? false : false;
   const restorePending =
     restoreTarget ? pendingMutations[restoreTarget.id]?.has("restore") ?? false : false;
+  const restoreRenamePending =
+    restoreRenameTarget ? pendingMutations[restoreRenameTarget.id]?.has("restore") ?? false : false;
   const renamePending =
     renameTarget ? pendingMutations[renameTarget.id]?.has("rename") ?? false : false;
   const bulkAssignCount = bulkAssignTargets.length;
@@ -2111,6 +2222,19 @@ export function DocumentsTableContainer({
           if (renameError) setRenameError(null);
         }}
         onSubmit={onRenameConfirm}
+      />
+      <RenameDocumentDialog
+        open={Boolean(restoreRenameTarget)}
+        documentName={restoreRenameInitialName || restoreRenameTarget?.name || ""}
+        isPending={restoreRenamePending}
+        errorMessage={restoreRenameError}
+        onOpenChange={(open) => {
+          if (!open) onRestoreRenameCancel();
+        }}
+        onClearError={() => {
+          if (restoreRenameError) setRestoreRenameError(null);
+        }}
+        onSubmit={onRestoreRenameConfirm}
       />
       <ReprocessPreflightDialog
         open={reprocessTargets.length > 0}

--- a/frontend/src/types/generated/openapi.d.ts
+++ b/frontend/src/types/generated/openapi.d.ts
@@ -2246,23 +2246,51 @@ export type components = {
             documentIds?: string[];
         };
         /**
+         * DocumentBatchRestoreConflict
+         * @description Conflict payload for a document that could not be restored.
+         */
+        DocumentBatchRestoreConflict: {
+            /**
+             * Documentid
+             * Format: uuid
+             * @description UUIDv7 (RFC 9562) generated in the application layer.
+             */
+            documentId: string;
+            /** Name */
+            name: string;
+            /**
+             * Conflictingdocumentid
+             * Format: uuid
+             * @description UUIDv7 (RFC 9562) generated in the application layer.
+             */
+            conflictingDocumentId: string;
+            /** Conflictingname */
+            conflictingName: string;
+            /** Suggestedname */
+            suggestedName: string;
+        };
+        /**
          * DocumentBatchRestoreRequest
          * @description Payload for restoring multiple soft-deleted documents.
          */
         DocumentBatchRestoreRequest: {
             /**
              * Documentids
-             * @description Documents to restore (all-or-nothing).
+             * @description Documents to restore (each document resolved independently).
              */
             documentIds: string[];
         };
         /**
          * DocumentBatchRestoreResponse
-         * @description Response envelope for batch restores.
+         * @description Response envelope for partial batch restore operations.
          */
         DocumentBatchRestoreResponse: {
-            /** Documentids */
-            documentIds?: string[];
+            /** Restoredids */
+            restoredIds?: string[];
+            /** Conflicts */
+            conflicts?: components["schemas"]["DocumentBatchRestoreConflict"][];
+            /** Notfoundids */
+            notFoundIds?: string[];
         };
         /**
          * DocumentBatchTagsRequest
@@ -2564,6 +2592,17 @@ export type components = {
             lastRunFields?: components["schemas"]["RunFieldResource"][] | null;
             /** @description Optional list row projection for table updates. */
             listRow?: components["schemas"]["DocumentListRow"] | null;
+        };
+        /**
+         * DocumentRestoreRequest
+         * @description Optional payload for restoring a document with a new name.
+         */
+        DocumentRestoreRequest: {
+            /**
+             * Name
+             * @description Optional replacement name used while restoring a deleted document.
+             */
+            name?: string | null;
         };
         /**
          * DocumentRunSummary
@@ -8316,7 +8355,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["DocumentRestoreRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -8352,15 +8395,21 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Validation Error */
+            /** @description Document name conflicts with an active document. */
+            409: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Restore name is invalid (for example extension mismatch). */
             422: {
                 headers: {
                     "X-Request-Id": components["headers"]["X-Request-Id"];
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
             default: components["responses"]["ProblemDetails"];
         };
@@ -8468,14 +8517,6 @@ export interface operations {
             };
             /** @description Workspace permissions do not allow document restoration. */
             403: {
-                headers: {
-                    "X-Request-Id": components["headers"]["X-Request-Id"];
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description One or more documents were not found within the workspace. */
-            404: {
                 headers: {
                     "X-Request-Id": components["headers"]["X-Request-Id"];
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary
- switch file name uniqueness to active-only rows via a partial unique index
- stop mutating `name_key` on delete and keep restore conflict-aware with optional rename
- keep batch restore partial results with structured conflict payloads
- update worker/runs output-file lookups and conflict inference for active-only semantics
- simplify frontend restore conflict parsing and add restore-rename retry flow
- add integration/unit coverage for delete/re-upload/restore edge cases

## Validation
- `cd backend && uv run ade test`
- `cd backend && ADE_DATABASE_URL='postgresql://ade:ade@localhost:5432/ade' ADE_SECRET_KEY='0123456789abcdef0123456789abcdef' ADE_BLOB_CONNECTION_STRING='DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:20866/devstoreaccount1;' uv run pytest tests/api/integration/documents/test_documents_delete.py tests/api/integration/documents/test_documents_upload.py -q`
