### PR TITLE
feat: unify configuration import with ZIP + GitHub URL flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,7 @@
 # ADE_BLOB_MAX_CONCURRENCY=4
 # ADE_BLOB_UPLOAD_CHUNK_SIZE_BYTES=4194304
 # ADE_BLOB_DOWNLOAD_CHUNK_SIZE_BYTES=1048576
+# ADE_CONFIG_IMPORT_MAX_BYTES=52428800                                # Max config zip import bytes (archive + per-file)
 
 # Compose-only (not read by ADE app code).
 # ADE_DOCKER_TAG=main                                                   # Image tag used by docker-compose.prod*.yaml

--- a/backend/src/ade_api/common/exceptions.py
+++ b/backend/src/ade_api/common/exceptions.py
@@ -30,7 +30,7 @@ def _problem_response(
     *,
     request: Request,
     status_code: int,
-    detail: str | None,
+    detail: str | dict[str, object] | None,
     errors,
     error_type: str | None = None,
     title: str | None = None,

--- a/backend/src/ade_api/common/openapi.py
+++ b/backend/src/ade_api/common/openapi.py
@@ -84,7 +84,13 @@ def configure_openapi(app: FastAPI, settings: Settings) -> None:
                     "type": {"type": "string"},
                     "title": {"type": "string"},
                     "status": {"type": "integer"},
-                    "detail": {"type": "string", "nullable": True},
+                    "detail": {
+                        "nullable": True,
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "object", "additionalProperties": True},
+                        ],
+                    },
                     "instance": {"type": "string"},
                     "requestId": {"type": "string", "nullable": True},
                     "errors": {

--- a/backend/src/ade_api/features/configs/github_import.py
+++ b/backend/src/ade_api/features/configs/github_import.py
@@ -1,0 +1,203 @@
+"""Helpers for importing configuration archives from GitHub URLs."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import quote, unquote, urlparse
+
+import httpx
+
+from .exceptions import ConfigImportError
+
+_GITHUB_WEB_HOSTS = {"github.com", "www.github.com"}
+_GITHUB_API_HOSTS = {"api.github.com"}
+_OWNER_REPO_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+_GITHUB_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=30.0)
+
+
+def normalize_github_import_url(url: str) -> tuple[str, str, str | None]:
+    """Parse a supported GitHub URL into ``(owner, repo, ref)``."""
+
+    text = url.strip()
+    if not text:
+        raise ConfigImportError("github_url_invalid")
+    parsed = urlparse(text)
+    if parsed.scheme.lower() != "https":
+        raise ConfigImportError("github_url_invalid")
+
+    host = parsed.netloc.lower().strip()
+    segments = [segment for segment in parsed.path.split("/") if segment]
+
+    if host in _GITHUB_WEB_HOSTS:
+        return _parse_github_web_segments(segments)
+    if host in _GITHUB_API_HOSTS:
+        return _parse_github_api_segments(segments)
+    raise ConfigImportError("github_url_invalid")
+
+
+def download_github_archive(
+    owner: str,
+    repo: str,
+    ref: str | None,
+    *,
+    max_bytes: int,
+    client: httpx.Client | None = None,
+) -> bytes:
+    """Download a GitHub repository zip archive with an upper byte limit."""
+
+    archive_url = _build_github_archive_url(owner, repo, ref)
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "ADE-Config-Import",
+    }
+
+    if client is not None:
+        return _download_archive_with_client(client, archive_url, headers, max_bytes)
+
+    try:
+        with httpx.Client(follow_redirects=True, timeout=_GITHUB_TIMEOUT) as local_client:
+            return _download_archive_with_client(local_client, archive_url, headers, max_bytes)
+    except ConfigImportError:
+        raise
+    except httpx.HTTPError as exc:
+        raise ConfigImportError("github_download_failed") from exc
+
+
+def _parse_github_web_segments(segments: list[str]) -> tuple[str, str, str | None]:
+    if len(segments) < 2:
+        raise ConfigImportError("github_url_invalid")
+    owner = segments[0].strip()
+    repo = segments[1].strip()
+    if repo.endswith(".git"):
+        repo = repo[: -len(".git")]
+    _validate_owner_repo(owner, repo)
+
+    if len(segments) == 2:
+        return owner, repo, None
+
+    if segments[2] == "tree" and len(segments) >= 4:
+        ref = "/".join(segments[3:]).strip()
+        if not ref:
+            raise ConfigImportError("github_url_invalid")
+        return owner, repo, unquote(ref)
+
+    if segments[2] == "archive" and len(segments) >= 4:
+        return owner, repo, _parse_archive_ref(segments[3:])
+
+    raise ConfigImportError("github_url_invalid")
+
+
+def _parse_github_api_segments(segments: list[str]) -> tuple[str, str, str | None]:
+    if len(segments) < 4:
+        raise ConfigImportError("github_url_invalid")
+    if segments[0] != "repos" or segments[3] != "zipball":
+        raise ConfigImportError("github_url_invalid")
+
+    owner = segments[1].strip()
+    repo = segments[2].strip()
+    _validate_owner_repo(owner, repo)
+
+    if len(segments) == 4:
+        return owner, repo, None
+
+    ref = "/".join(segments[4:]).strip()
+    if not ref:
+        raise ConfigImportError("github_url_invalid")
+    return owner, repo, unquote(ref)
+
+
+def _parse_archive_ref(segments: list[str]) -> str:
+    if not segments:
+        raise ConfigImportError("github_url_invalid")
+
+    if segments[:2] == ["refs", "heads"] and len(segments) >= 3:
+        leaf = "/".join(segments[2:])
+        if not leaf.endswith(".zip"):
+            raise ConfigImportError("github_url_invalid")
+        ref = leaf[: -len(".zip")]
+        if not ref:
+            raise ConfigImportError("github_url_invalid")
+        return unquote(ref)
+
+    if segments[:2] == ["refs", "tags"] and len(segments) >= 3:
+        leaf = "/".join(segments[2:])
+        if not leaf.endswith(".zip"):
+            raise ConfigImportError("github_url_invalid")
+        ref = f"refs/tags/{leaf[: -len('.zip')]}"
+        if ref.endswith("/"):
+            raise ConfigImportError("github_url_invalid")
+        return unquote(ref)
+
+    if len(segments) == 1 and segments[0].endswith(".zip"):
+        ref = segments[0][: -len(".zip")]
+        if not ref:
+            raise ConfigImportError("github_url_invalid")
+        return unquote(ref)
+
+    raise ConfigImportError("github_url_invalid")
+
+
+def _validate_owner_repo(owner: str, repo: str) -> None:
+    if not owner or not repo:
+        raise ConfigImportError("github_url_invalid")
+    if not _OWNER_REPO_PATTERN.fullmatch(owner):
+        raise ConfigImportError("github_url_invalid")
+    if not _OWNER_REPO_PATTERN.fullmatch(repo):
+        raise ConfigImportError("github_url_invalid")
+
+
+def _build_github_archive_url(owner: str, repo: str, ref: str | None) -> str:
+    base_url = f"https://api.github.com/repos/{owner}/{repo}/zipball"
+    if not ref:
+        return base_url
+    encoded_ref = quote(ref, safe="")
+    return f"{base_url}/{encoded_ref}"
+
+
+def _download_archive_with_client(
+    client: httpx.Client,
+    archive_url: str,
+    headers: dict[str, str],
+    max_bytes: int,
+) -> bytes:
+    try:
+        with client.stream("GET", archive_url, headers=headers) as response:
+            _raise_for_download_status(response)
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_bytes():
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ConfigImportError("archive_too_large", limit=max_bytes)
+                chunks.append(chunk)
+            return b"".join(chunks)
+    except ConfigImportError:
+        raise
+    except httpx.HTTPError as exc:
+        raise ConfigImportError("github_download_failed") from exc
+
+
+def _raise_for_download_status(response: httpx.Response) -> None:
+    status_code = response.status_code
+    if status_code < 400:
+        return
+
+    if status_code == 429:
+        raise ConfigImportError("github_rate_limited")
+
+    if status_code == 403:
+        remaining = response.headers.get("x-ratelimit-remaining")
+        if remaining == "0":
+            raise ConfigImportError("github_rate_limited")
+        raise ConfigImportError("github_not_found_or_private")
+
+    if status_code in {401, 404}:
+        raise ConfigImportError("github_not_found_or_private")
+
+    raise ConfigImportError("github_download_failed")
+
+
+__all__ = ["download_github_archive", "normalize_github_import_url"]
+

--- a/backend/src/ade_api/features/configs/schemas.py
+++ b/backend/src/ade_api/features/configs/schemas.py
@@ -8,8 +8,8 @@ from uuid import UUID
 
 from pydantic import Field, field_validator, model_validator
 
-from ade_api.common.ids import UUIDStr
 from ade_api.common.cursor_listing import CursorPage
+from ade_api.common.ids import UUIDStr
 from ade_api.common.schema import BaseSchema
 from ade_db.models import ConfigurationSourceKind, ConfigurationStatus
 
@@ -192,6 +192,43 @@ class ConfigurationUpdateRequest(BaseSchema):
         return self
 
 
+class ConfigurationImportGithubRequest(BaseSchema):
+    """Create a configuration by importing a GitHub archive URL."""
+
+    display_name: str = Field(min_length=1, max_length=255)
+    url: str = Field(min_length=1)
+    notes: str | None = None
+
+    @field_validator("display_name", mode="before")
+    @classmethod
+    def _clean_import_display_name(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def _clean_import_url(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("notes", mode="before")
+    @classmethod
+    def _clean_import_notes(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        candidate = value.strip()
+        return candidate or None
+
+
+class ConfigurationReplaceGithubRequest(BaseSchema):
+    """Replace a draft configuration using a GitHub archive URL."""
+
+    url: str = Field(min_length=1)
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def _clean_replace_url(cls, value: str) -> str:
+        return value.strip()
+
+
 class FileCapabilities(BaseSchema):
     editable: bool
     can_create: bool
@@ -304,6 +341,8 @@ __all__ = [
     "ConfigurationRecord",
     "ConfigurationRestoreRequest",
     "ConfigurationUpdateRequest",
+    "ConfigurationImportGithubRequest",
+    "ConfigurationReplaceGithubRequest",
     "FileCapabilities",
     "FileSizeLimits",
     "FileListingSummary",

--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -9595,6 +9595,99 @@
         ]
       }
     },
+    "/api/v1/workspaces/{workspaceId}/configurations/import/github": {
+      "post": {
+        "tags": [
+          "configurations"
+        ],
+        "summary": "Create a configuration from a GitHub repository URL",
+        "operationId": "import_configuration_from_github_api_v1_workspaces__workspaceId__configurations_import_github_post",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
+          {
+            "name": "X-CSRF-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfigurationImportGithubRequest",
+                "description": "Create a draft configuration from a public GitHub repository URL."
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigurationRecord"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/archive": {
       "post": {
         "tags": [
@@ -9831,6 +9924,111 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/Body_replace_configuration_from_archive_api_v1_workspaces__workspaceId__configurations__configurationId__import_put"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigurationRecord"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "X-Request-Id": {
+                "$ref": "#/components/headers/X-Request-Id"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ProblemDetails"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      }
+    },
+    "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/import/github": {
+      "put": {
+        "tags": [
+          "configurations"
+        ],
+        "summary": "Replace a draft configuration from a GitHub repository URL",
+        "operationId": "replace_configuration_from_github_api_v1_workspaces__workspaceId__configurations__configurationId__import_github_put",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Workspace identifier",
+              "title": "Workspaceid"
+            },
+            "description": "Workspace identifier"
+          },
+          {
+            "name": "configurationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Configuration identifier",
+              "title": "Configurationid"
+            },
+            "description": "Configuration identifier"
+          },
+          {
+            "name": "X-CSRF-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfigurationReplaceGithubRequest",
+                "description": "Replace a draft configuration from a public GitHub repository URL."
               }
             }
           }
@@ -14235,6 +14433,40 @@
         "title": "ConfigurationHistoryEntry",
         "description": "Single history row for a configuration family."
       },
+      "ConfigurationImportGithubRequest": {
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Display Name"
+          },
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Url"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "display_name",
+          "url"
+        ],
+        "title": "ConfigurationImportGithubRequest",
+        "description": "Create a configuration by importing a GitHub archive URL."
+      },
       "ConfigurationPage": {
         "properties": {
           "items": {
@@ -14364,6 +14596,22 @@
         ],
         "title": "ConfigurationRecord",
         "description": "Serialized configuration metadata."
+      },
+      "ConfigurationReplaceGithubRequest": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Url"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "ConfigurationReplaceGithubRequest",
+        "description": "Replace a draft configuration using a GitHub archive URL."
       },
       "ConfigurationRestoreRequest": {
         "properties": {
@@ -19416,8 +19664,16 @@
             "type": "integer"
           },
           "detail": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
           },
           "instance": {
             "type": "string"

--- a/backend/src/ade_api/settings.py
+++ b/backend/src/ade_api/settings.py
@@ -76,6 +76,7 @@ class Settings(
 
     # Storage
     storage_upload_max_bytes: int = Field(25 * 1024 * 1024, gt=0)
+    config_import_max_bytes: int = Field(50 * 1024 * 1024, gt=0)
     storage_document_retention_period: timedelta = Field(default=timedelta(days=30))
     documents_upload_concurrency_limit: int | None = Field(8, ge=1)
 

--- a/backend/tests/api/integration/configs/test_configurations_import.py
+++ b/backend/tests/api/integration/configs/test_configurations_import.py
@@ -1,0 +1,369 @@
+"""Configuration import endpoint tests."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.orm import Session
+
+import ade_api.features.configs.service as config_service_module
+from ade_api.features.configs.exceptions import ConfigImportError
+from ade_api.settings import Settings
+from ade_db.models import Configuration
+from tests.api.integration.configs.helpers import auth_headers, config_path, create_from_template
+
+pytestmark = pytest.mark.asyncio
+
+
+def _build_import_archive(
+    *,
+    wrapper: str = "ade-config-main",
+    extra_files: dict[str, bytes] | None = None,
+) -> bytes:
+    archive_bytes = io.BytesIO()
+    with zipfile.ZipFile(archive_bytes, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            f"{wrapper}/pyproject.toml",
+            (
+                "[project]\n"
+                "name = \"ade_config\"\n"
+                "version = \"0.1.0\"\n"
+                "dependencies = [\"ade-engine\"]\n"
+            ),
+        )
+        zf.writestr(f"{wrapper}/src/ade_config/__init__.py", "__all__ = []\n")
+        for path, data in (extra_files or {}).items():
+            zf.writestr(f"{wrapper}/{path}", data)
+    return archive_bytes.getvalue()
+
+
+async def test_import_configuration_from_wrapped_archive(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+
+    archive = _build_import_archive()
+
+    response = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import",
+        headers=headers,
+        data={"display_name": "Imported config", "notes": "from wrapped archive"},
+        files={
+            "file": ("config.zip", archive, "application/zip"),
+        },
+    )
+    assert response.status_code == 201, response.text
+    payload = response.json()
+    assert payload["source_kind"] == "import"
+
+    root = config_path(settings, workspace_id, payload["id"])
+    assert (root / "pyproject.toml").is_file()
+    assert (root / "src" / "ade_config" / "__init__.py").is_file()
+    assert not (root / "ade-config-main").exists()
+
+
+async def test_import_configuration_allows_large_non_source_file_under_default_limit(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+
+    archive = _build_import_archive(extra_files={"logs/engine_events.ndjson": b"x" * (600 * 1024)})
+
+    response = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import",
+        headers=headers,
+        data={"display_name": "Imported config"},
+        files={
+            "file": ("config.zip", archive, "application/zip"),
+        },
+    )
+    assert response.status_code == 201, response.text
+    payload = response.json()
+
+    root = config_path(settings, workspace_id, payload["id"])
+    assert (root / "logs" / "engine_events.ndjson").is_file()
+
+
+async def test_import_configuration_uses_configured_limit(
+    async_client: AsyncClient,
+    seed_identity,
+    override_app_settings,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+
+    archive = _build_import_archive(extra_files={"logs/too_big.ndjson": b"x" * 4096})
+
+    override_app_settings(config_import_max_bytes=2048)
+
+    blocked = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import",
+        headers=headers,
+        data={"display_name": "Blocked import"},
+        files={
+            "file": ("config.zip", archive, "application/zip"),
+        },
+    )
+    assert blocked.status_code == 400, blocked.text
+    blocked_payload = blocked.json()
+    assert blocked_payload.get("detail") == {
+        "error": "file_too_large",
+        "limit": 2048,
+        "detail": "logs/too_big.ndjson",
+    }
+    assert blocked_payload.get("errors", [{}])[0].get("code") == "file_too_large"
+
+    override_app_settings(config_import_max_bytes=8192)
+
+    allowed = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import",
+        headers=headers,
+        data={"display_name": "Allowed import"},
+        files={
+            "file": ("config.zip", archive, "application/zip"),
+        },
+    )
+    assert allowed.status_code == 201, allowed.text
+
+
+async def test_import_configuration_cleans_files_when_db_flush_fails(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+    display_name = "Import flush failure"
+    archive = _build_import_archive()
+    workspace_root = config_path(settings, workspace_id, "placeholder").parent
+    before_entries = (
+        {path.name for path in workspace_root.iterdir() if path.is_dir()}
+        if workspace_root.exists()
+        else set()
+    )
+
+    original_flush = Session.flush
+
+    def _flush_with_failure(self: Session, *args, **kwargs) -> None:
+        if any(
+            isinstance(item, Configuration) and item.display_name == display_name
+            for item in self.new
+        ):
+            raise RuntimeError("forced_flush_failure")
+        return original_flush(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "flush", _flush_with_failure)
+
+    response = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import",
+        headers=headers,
+        data={"display_name": display_name},
+        files={
+            "file": ("config.zip", archive, "application/zip"),
+        },
+    )
+    assert response.status_code == 500, response.text
+
+    after_entries = (
+        {path.name for path in workspace_root.iterdir() if path.is_dir()}
+        if workspace_root.exists()
+        else set()
+    )
+    assert after_entries == before_entries
+    assert not any(name.startswith(".import-") for name in after_entries)
+
+
+async def test_import_configuration_from_github_url(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+    archive = _build_import_archive()
+
+    monkeypatch.setattr(
+        config_service_module,
+        "download_github_archive",
+        lambda *args, **kwargs: archive,
+    )
+
+    response = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import/github",
+        headers=headers,
+        json={
+            "display_name": "GitHub import",
+            "url": "https://github.com/octo/repo",
+            "notes": "imported from github",
+        },
+    )
+    assert response.status_code == 201, response.text
+    payload = response.json()
+    assert payload["source_kind"] == "import"
+
+    root = config_path(settings, workspace_id, payload["id"])
+    assert (root / "pyproject.toml").is_file()
+    assert (root / "src" / "ade_config" / "__init__.py").is_file()
+
+
+async def test_replace_configuration_from_github_url(
+    async_client: AsyncClient,
+    seed_identity,
+    settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+    config = await create_from_template(
+        async_client,
+        workspace_id=str(workspace_id),
+        headers=headers,
+    )
+
+    archive = _build_import_archive(wrapper="github-config-main")
+    monkeypatch.setattr(
+        config_service_module,
+        "download_github_archive",
+        lambda *args, **kwargs: archive,
+    )
+
+    files_response = await async_client.get(
+        f"/api/v1/workspaces/{workspace_id}/configurations/{config['id']}/files",
+        headers=headers,
+    )
+    assert files_response.status_code == 200, files_response.text
+    files_payload = files_response.json()
+
+    replace_response = await async_client.put(
+        f"/api/v1/workspaces/{workspace_id}/configurations/{config['id']}/import/github",
+        headers={**headers, "If-Match": files_payload["fileset_hash"]},
+        json={"url": "https://github.com/octo/repo/tree/main"},
+    )
+    assert replace_response.status_code == 200, replace_response.text
+
+    root = config_path(settings, workspace_id, config["id"])
+    assert (root / "pyproject.toml").is_file()
+    assert (root / "src" / "ade_config" / "__init__.py").is_file()
+
+
+async def test_import_configuration_from_github_url_rejects_invalid_urls(
+    async_client: AsyncClient,
+    seed_identity,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+
+    response = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import/github",
+        headers=headers,
+        json={
+            "display_name": "Invalid URL",
+            "url": "https://gitlab.com/octo/repo",
+        },
+    )
+    assert response.status_code == 400, response.text
+    payload = response.json()
+    assert payload["detail"]["error"] == "github_url_invalid"
+
+
+async def test_import_configuration_from_github_url_maps_private_or_missing(
+    async_client: AsyncClient,
+    seed_identity,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+
+    def _raise_not_found(*args, **kwargs):
+        _ = args, kwargs
+        raise ConfigImportError("github_not_found_or_private")
+
+    monkeypatch.setattr(config_service_module, "download_github_archive", _raise_not_found)
+
+    response = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import/github",
+        headers=headers,
+        json={
+            "display_name": "Private repo",
+            "url": "https://github.com/octo/private-repo",
+        },
+    )
+    assert response.status_code == 400, response.text
+    payload = response.json()
+    assert payload["detail"]["error"] == "github_not_found_or_private"
+    assert payload["errors"][0]["code"] == "github_not_found_or_private"
+
+
+async def test_import_configuration_from_github_url_maps_rate_limits(
+    async_client: AsyncClient,
+    seed_identity,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+
+    def _raise_rate_limit(*args, **kwargs):
+        _ = args, kwargs
+        raise ConfigImportError("github_rate_limited")
+
+    monkeypatch.setattr(config_service_module, "download_github_archive", _raise_rate_limit)
+
+    response = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import/github",
+        headers=headers,
+        json={
+            "display_name": "Rate limited repo",
+            "url": "https://github.com/octo/repo",
+        },
+    )
+    assert response.status_code == 429, response.text
+    payload = response.json()
+    assert payload["detail"]["error"] == "github_rate_limited"
+
+
+async def test_import_configuration_from_github_url_maps_download_failures(
+    async_client: AsyncClient,
+    seed_identity,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = seed_identity.workspace_id
+    owner = seed_identity.workspace_owner
+    headers = await auth_headers(async_client, email=owner.email, password=owner.password)
+
+    def _raise_download_failed(*args, **kwargs):
+        _ = args, kwargs
+        raise ConfigImportError("github_download_failed")
+
+    monkeypatch.setattr(config_service_module, "download_github_archive", _raise_download_failed)
+
+    response = await async_client.post(
+        f"/api/v1/workspaces/{workspace_id}/configurations/import/github",
+        headers=headers,
+        json={
+            "display_name": "Download failure",
+            "url": "https://github.com/octo/repo",
+        },
+    )
+    assert response.status_code == 502, response.text
+    payload = response.json()
+    assert payload["detail"]["error"] == "github_download_failed"

--- a/backend/tests/api/unit/features/configs/test_github_import.py
+++ b/backend/tests/api/unit/features/configs/test_github_import.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from ade_api.features.configs.exceptions import ConfigImportError
+from ade_api.features.configs.github_import import (
+    download_github_archive,
+    normalize_github_import_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/octo/repo", ("octo", "repo", None)),
+        ("https://github.com/octo/repo.git", ("octo", "repo", None)),
+        ("https://github.com/octo/repo/tree/main", ("octo", "repo", "main")),
+        (
+            "https://github.com/octo/repo/tree/feature/config-updates",
+            ("octo", "repo", "feature/config-updates"),
+        ),
+        (
+            "https://github.com/octo/repo/archive/refs/heads/main.zip",
+            ("octo", "repo", "main"),
+        ),
+        (
+            "https://github.com/octo/repo/archive/refs/heads/feature/config-updates.zip",
+            ("octo", "repo", "feature/config-updates"),
+        ),
+        (
+            "https://github.com/octo/repo/archive/refs/tags/v1.2.3.zip",
+            ("octo", "repo", "refs/tags/v1.2.3"),
+        ),
+        ("https://github.com/octo/repo/archive/abc123.zip", ("octo", "repo", "abc123")),
+        ("https://api.github.com/repos/octo/repo/zipball", ("octo", "repo", None)),
+        (
+            "https://api.github.com/repos/octo/repo/zipball/feature%2Fconfig-updates",
+            ("octo", "repo", "feature/config-updates"),
+        ),
+    ],
+)
+def test_normalize_github_import_url_supported_shapes(
+    url: str,
+    expected: tuple[str, str, str | None],
+) -> None:
+    assert normalize_github_import_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "http://github.com/octo/repo",
+        "https://gitlab.com/octo/repo",
+        "https://github.com/octo",
+        "https://github.com/octo/repo/issues/1",
+        "https://github.com/octo/repo/tree",
+        "https://github.com/octo/repo/archive/refs/heads/main",
+        "https://api.github.com/repos/octo/repo",
+    ],
+)
+def test_normalize_github_import_url_rejects_unsupported_shapes(url: str) -> None:
+    with pytest.raises(ConfigImportError) as exc_info:
+        normalize_github_import_url(url)
+    assert exc_info.value.code == "github_url_invalid"
+
+
+def test_download_github_archive_success() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/repos/octo/repo/zipball/main"
+        return httpx.Response(200, content=b"archive-bytes")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+    try:
+        archive = download_github_archive("octo", "repo", "main", max_bytes=1024, client=client)
+    finally:
+        client.close()
+
+    assert archive == b"archive-bytes"
+
+
+def test_download_github_archive_rejects_over_limit() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        _ = request
+        return httpx.Response(200, content=b"123456")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+    try:
+        with pytest.raises(ConfigImportError) as exc_info:
+            download_github_archive("octo", "repo", "main", max_bytes=5, client=client)
+    finally:
+        client.close()
+
+    assert exc_info.value.code == "archive_too_large"
+    assert exc_info.value.limit == 5
+
+
+@pytest.mark.parametrize(
+    ("status_code", "headers", "expected"),
+    [
+        (401, {}, "github_not_found_or_private"),
+        (404, {}, "github_not_found_or_private"),
+        (403, {}, "github_not_found_or_private"),
+        (403, {"x-ratelimit-remaining": "0"}, "github_rate_limited"),
+        (429, {}, "github_rate_limited"),
+        (500, {}, "github_download_failed"),
+    ],
+)
+def test_download_github_archive_maps_upstream_errors(
+    status_code: int,
+    headers: dict[str, str],
+    expected: str,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        _ = request
+        return httpx.Response(status_code, headers=headers)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+    try:
+        with pytest.raises(ConfigImportError) as exc_info:
+            download_github_archive("octo", "repo", "main", max_bytes=1024, client=client)
+    finally:
+        client.close()
+
+    assert exc_info.value.code == expected
+
+
+def test_download_github_archive_maps_http_failures() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+    try:
+        with pytest.raises(ConfigImportError) as exc_info:
+            download_github_archive("octo", "repo", "main", max_bytes=1024, client=client)
+    finally:
+        client.close()
+
+    assert exc_info.value.code == "github_download_failed"
+

--- a/backend/tests/api/unit/features/configs/test_templates.py
+++ b/backend/tests/api/unit/features/configs/test_templates.py
@@ -5,7 +5,35 @@ import zipfile
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
+
+import ade_api.features.configs.storage as config_storage_module
+from ade_api.features.configs.exceptions import ConfigImportError
 from ade_api.features.configs.storage import ConfigStorage
+
+
+def _build_import_archive(
+    *,
+    wrapper: str = "",
+    init_content: str = "__all__ = []\n",
+    extra_files: dict[str, bytes] | None = None,
+) -> bytes:
+    archive_bytes = io.BytesIO()
+    prefix = f"{wrapper}/" if wrapper else ""
+    with zipfile.ZipFile(archive_bytes, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            f"{prefix}pyproject.toml",
+            (
+                "[project]\n"
+                "name = \"ade_config\"\n"
+                "version = \"0.1.0\"\n"
+                "dependencies = [\"ade-engine\"]\n"
+            ),
+        )
+        zf.writestr(f"{prefix}src/ade_config/__init__.py", init_content)
+        for rel_path, payload in (extra_files or {}).items():
+            zf.writestr(f"{prefix}{rel_path}", payload)
+    return archive_bytes.getvalue()
 
 
 def test_templates_materialize_and_load(
@@ -37,7 +65,7 @@ def test_import_archive_does_not_mutate_pyproject_dependencies(tmp_path: Path) -
     configuration_id = uuid4()
 
     archive_bytes = io.BytesIO()
-    with zipfile.ZipFile(archive_bytes, mode="w") as zf:
+    with zipfile.ZipFile(archive_bytes, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(
             "pyproject.toml",
             (
@@ -60,3 +88,210 @@ def test_import_archive_does_not_mutate_pyproject_dependencies(tmp_path: Path) -
     content = pyproject.read_text(encoding="utf-8")
     assert "dependencies = [\"ade-engine\"]" in content
     assert "allow-direct-references" not in content
+
+
+def test_import_archive_strips_single_wrapper_directory(tmp_path: Path) -> None:
+    storage = ConfigStorage(configs_root=tmp_path / "configs")
+    workspace_id = uuid4()
+    configuration_id = uuid4()
+
+    archive_bytes = io.BytesIO()
+    with zipfile.ZipFile(archive_bytes, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "ade-config-main/pyproject.toml",
+            (
+                "[project]\n"
+                "name = \"ade_config\"\n"
+                "version = \"0.1.0\"\n"
+                "dependencies = [\"ade-engine\"]\n"
+            ),
+        )
+        zf.writestr("ade-config-main/src/ade_config/__init__.py", "__all__ = []\n")
+
+    storage.import_archive(
+        workspace_id=workspace_id,
+        configuration_id=configuration_id,
+        archive=archive_bytes.getvalue(),
+    )
+
+    config_root = storage.config_path(workspace_id, configuration_id)
+    assert (config_root / "pyproject.toml").is_file()
+    assert (config_root / "src" / "ade_config" / "__init__.py").is_file()
+    assert not (config_root / "ade-config-main").exists()
+
+
+def test_import_archive_strips_nested_wrappers_for_large_non_source_file(tmp_path: Path) -> None:
+    storage = ConfigStorage(configs_root=tmp_path / "configs")
+    workspace_id = uuid4()
+    configuration_id = uuid4()
+
+    log_payload = b"a" * (600 * 1024)
+    archive_bytes = io.BytesIO()
+    with zipfile.ZipFile(archive_bytes, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "outer/inner/pyproject.toml",
+            (
+                "[project]\n"
+                "name = \"ade_config\"\n"
+                "version = \"0.1.0\"\n"
+                "dependencies = [\"ade-engine\"]\n"
+            ),
+        )
+        zf.writestr("outer/inner/src/ade_config/__init__.py", "__all__ = []\n")
+        zf.writestr("outer/inner/logs/engine_events.ndjson", log_payload)
+
+    storage.import_archive(
+        workspace_id=workspace_id,
+        configuration_id=configuration_id,
+        archive=archive_bytes.getvalue(),
+    )
+
+    config_root = storage.config_path(workspace_id, configuration_id)
+    assert (config_root / "logs" / "engine_events.ndjson").read_bytes() == log_payload
+    assert not (config_root / "outer").exists()
+
+
+def test_import_archive_rejects_file_over_configured_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = ConfigStorage(configs_root=tmp_path / "configs")
+    workspace_id = uuid4()
+    configuration_id = uuid4()
+
+    monkeypatch.setattr(config_storage_module, "_IMPORT_DEFAULT_MAX_BYTES", 2048)
+
+    archive_bytes = io.BytesIO()
+    with zipfile.ZipFile(archive_bytes, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "wrapped/pyproject.toml",
+            (
+                "[project]\n"
+                "name = \"ade_config\"\n"
+                "version = \"0.1.0\"\n"
+                "dependencies = [\"ade-engine\"]\n"
+            ),
+        )
+        zf.writestr("wrapped/src/ade_config/__init__.py", "__all__ = []\n")
+        zf.writestr("wrapped/logs/too_big.ndjson", b"x" * 4096)
+
+    with pytest.raises(ConfigImportError) as exc_info:
+        storage.import_archive(
+            workspace_id=workspace_id,
+            configuration_id=configuration_id,
+            archive=archive_bytes.getvalue(),
+        )
+
+    assert exc_info.value.code == "file_too_large"
+    assert exc_info.value.limit == 2048
+    assert exc_info.value.detail == "logs/too_big.ndjson"
+
+
+def test_replace_archive_rolls_back_on_final_swap_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = ConfigStorage(configs_root=tmp_path / "configs")
+    workspace_id = uuid4()
+    configuration_id = uuid4()
+
+    original_archive = _build_import_archive(init_content="ORIGINAL\n")
+    replacement_archive = _build_import_archive(init_content="REPLACED\n")
+    storage.import_archive(
+        workspace_id=workspace_id,
+        configuration_id=configuration_id,
+        archive=original_archive,
+    )
+
+    destination = storage.config_path(workspace_id, configuration_id)
+    original_replace = Path.replace
+
+    def _replace_with_failure(self: Path, target: Path | str) -> Path:
+        target_path = Path(target)
+        if self.name.startswith(f".import-{configuration_id}") and target_path == destination:
+            raise OSError("simulated_final_swap_failure")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _replace_with_failure)
+
+    with pytest.raises(OSError, match="simulated_final_swap_failure"):
+        storage.replace_from_archive(
+            workspace_id=workspace_id,
+            configuration_id=configuration_id,
+            archive=replacement_archive,
+        )
+
+    init_file = destination / "src" / "ade_config" / "__init__.py"
+    assert init_file.read_text(encoding="utf-8") == "ORIGINAL\n"
+
+    workspace_root = storage.workspace_root(workspace_id)
+    if workspace_root.exists():
+        residual = [
+            path.name
+            for path in workspace_root.iterdir()
+            if path.name.startswith(".import-") or path.name.startswith(".replace-backup-")
+        ]
+        assert residual == []
+
+
+def test_import_archive_failure_cleans_temp_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = ConfigStorage(configs_root=tmp_path / "configs")
+    workspace_id = uuid4()
+    configuration_id = uuid4()
+    monkeypatch.setattr(config_storage_module, "_IMPORT_DEFAULT_MAX_BYTES", 2048)
+    archive = _build_import_archive(
+        wrapper="wrapped",
+        extra_files={"logs/too_big.ndjson": b"x" * 4096},
+    )
+
+    with pytest.raises(ConfigImportError):
+        storage.import_archive(
+            workspace_id=workspace_id,
+            configuration_id=configuration_id,
+            archive=archive,
+        )
+
+    assert not storage.config_path(workspace_id, configuration_id).exists()
+    workspace_root = storage.workspace_root(workspace_id)
+    if workspace_root.exists():
+        residual = [
+            path.name
+            for path in workspace_root.iterdir()
+            if path.name.startswith(".import-") or path.name.startswith(".replace-backup-")
+        ]
+        assert residual == []
+
+
+def test_import_archive_maps_runtime_zip_read_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = ConfigStorage(configs_root=tmp_path / "configs")
+    workspace_id = uuid4()
+    configuration_id = uuid4()
+
+    class BrokenZipFile:
+        def __init__(self, *args, **kwargs) -> None:
+            _ = args, kwargs
+
+        def __enter__(self):
+            raise RuntimeError("unsupported zip stream")
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            _ = exc_type, exc, tb
+            return False
+
+    monkeypatch.setattr(config_storage_module.zipfile, "ZipFile", BrokenZipFile)
+
+    with pytest.raises(ConfigImportError) as exc_info:
+        storage.import_archive(
+            workspace_id=workspace_id,
+            configuration_id=configuration_id,
+            archive=b"zip-bytes",
+        )
+
+    assert exc_info.value.code == "invalid_archive"
+    assert exc_info.value.detail == "Archive could not be read"

--- a/backend/tests/api/unit/settings/conftest.py
+++ b/backend/tests/api/unit/settings/conftest.py
@@ -39,6 +39,7 @@ def reset_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         "ADE_BLOB_UPLOAD_CHUNK_SIZE_BYTES",
         "ADE_BLOB_DOWNLOAD_CHUNK_SIZE_BYTES",
         "ADE_STORAGE_UPLOAD_MAX_BYTES",
+        "ADE_CONFIG_IMPORT_MAX_BYTES",
         "ADE_STORAGE_DOCUMENT_RETENTION_PERIOD",
         "ADE_DATABASE_URL",
         "ADE_DATABASE_CONNECTION_BUDGET",

--- a/backend/tests/api/unit/settings/test_settings_defaults.py
+++ b/backend/tests/api/unit/settings/test_settings_defaults.py
@@ -30,6 +30,7 @@ def test_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.public_web_url == "http://localhost:8000"
     assert settings.server_cors_origins == []
     assert settings.server_cors_origin_regex is None
+    assert settings.config_import_max_bytes == 50 * 1024 * 1024
     url = make_url(str(settings.database_url))
     assert url.drivername == "postgresql+psycopg"
     assert url.host == "postgres"

--- a/backend/tests/api/unit/settings/test_settings_env.py
+++ b/backend/tests/api/unit/settings/test_settings_env.py
@@ -81,6 +81,7 @@ def test_api_runtime_tuning_env_overrides(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv("ADE_API_PROXY_HEADERS_ENABLED", "false")
     monkeypatch.setenv("ADE_API_FORWARDED_ALLOW_IPS", "10.0.0.1,10.0.0.2")
     monkeypatch.setenv("ADE_API_THREADPOOL_TOKENS", "64")
+    monkeypatch.setenv("ADE_CONFIG_IMPORT_MAX_BYTES", "73400320")
     monkeypatch.setenv("ADE_DATABASE_CONNECTION_BUDGET", "120")
     monkeypatch.setenv("ADE_AUTH_ENFORCE_LOCAL_MFA", "true")
 
@@ -89,6 +90,7 @@ def test_api_runtime_tuning_env_overrides(monkeypatch: pytest.MonkeyPatch) -> No
     assert settings.api_proxy_headers_enabled is False
     assert settings.api_forwarded_allow_ips == "10.0.0.1,10.0.0.2"
     assert settings.api_threadpool_tokens == 64
+    assert settings.config_import_max_bytes == 73400320
     assert settings.database_connection_budget == 120
     assert settings.auth_enforce_local_mfa is True
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -129,6 +129,7 @@ Auth transport contract:
 | Variable | Component | Required Scope | Default | Notes |
 | --- | --- | --- | --- | --- |
 | `ADE_STORAGE_UPLOAD_MAX_BYTES` | API | optional | `26214400` | max upload size |
+| `ADE_CONFIG_IMPORT_MAX_BYTES` | API | optional | `52428800` | max config zip import bytes (applies to archive size and per-file extraction size) |
 | `ADE_STORAGE_DOCUMENT_RETENTION_PERIOD` | API | optional | `30 days` | document retention |
 | `ADE_DOCUMENTS_UPLOAD_CONCURRENCY_LIMIT` | API | optional | `8` | upload concurrency cap |
 | `ADE_DOCUMENT_CHANGES_RETENTION_DAYS` | API | optional | `14` | change retention |

--- a/frontend/src/pages/Workspace/hooks/configurations/useConfigurationImport.ts
+++ b/frontend/src/pages/Workspace/hooks/configurations/useConfigurationImport.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import {
   importConfiguration,
-  replaceConfigurationFromArchive,
+  replaceConfigurationImport,
   type ImportConfigurationPayload,
   type ReplaceConfigurationPayload,
 } from "@/api/configurations/api";
@@ -16,7 +16,6 @@ export function useImportConfigurationMutation(workspaceId: string) {
 
 export function useReplaceConfigurationMutation(workspaceId: string, configurationId: string) {
   return useMutation<ConfigurationRecord, Error, ReplaceConfigurationPayload>({
-    mutationFn: (payload) => replaceConfigurationFromArchive(workspaceId, configurationId, payload),
+    mutationFn: (payload) => replaceConfigurationImport(workspaceId, configurationId, payload),
   });
 }
-

--- a/frontend/src/pages/Workspace/sections/ConfigurationEditor/components/ConfigurationImportDialog.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigurationEditor/components/ConfigurationImportDialog.tsx
@@ -1,0 +1,323 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+} from "react";
+
+import { mapUiError } from "@/api/uiErrors";
+import { AlertTriangleIcon, UploadIcon } from "@/components/icons";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export type ConfigurationImportDialogMode = "create" | "replace";
+export type ConfigurationImportMethod = "zip" | "github";
+export type ConfigurationImportSubmitPayload =
+  | { readonly type: "zip"; readonly file: File }
+  | { readonly type: "github"; readonly url: string };
+
+interface ConfigurationImportDialogProps {
+  readonly open: boolean;
+  readonly mode: ConfigurationImportDialogMode;
+  readonly isSubmitting: boolean;
+  readonly canSubmit?: boolean;
+  readonly disabledReason?: string | null;
+  readonly hasUnsavedChanges?: boolean;
+  readonly onClose: () => void;
+  readonly onSubmit: (payload: ConfigurationImportSubmitPayload) => Promise<void>;
+  readonly onError?: (message: string) => void;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+function isZipFile(file: File): boolean {
+  return file.name.trim().toLowerCase().endsWith(".zip");
+}
+
+export function ConfigurationImportDialog({
+  open,
+  mode,
+  isSubmitting,
+  canSubmit = true,
+  disabledReason = null,
+  hasUnsavedChanges = false,
+  onClose,
+  onSubmit,
+  onError,
+}: ConfigurationImportDialogProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [method, setMethod] = useState<ConfigurationImportMethod>("zip");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [githubUrl, setGithubUrl] = useState("");
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setMethod("zip");
+    setSelectedFile(null);
+    setGithubUrl("");
+    setInlineError(null);
+    setDragActive(false);
+  }, [open]);
+
+  const fallbackError =
+    mode === "replace"
+      ? "Unable to replace configuration."
+      : "Unable to import configuration.";
+  const submitLabel = mode === "replace" ? "Replace configuration" : "Import configuration";
+  const title = mode === "replace" ? "Replace configuration" : "Import configuration";
+  const description =
+    mode === "replace"
+      ? "Choose a zip file or public GitHub repository URL to replace this draft configuration."
+      : "Choose a zip file or public GitHub repository URL to create a new draft configuration.";
+
+  const setFile = useCallback((file: File | null) => {
+    if (!file) {
+      return;
+    }
+    if (!isZipFile(file)) {
+      setSelectedFile(null);
+      setInlineError("Please choose a .zip archive.");
+      return;
+    }
+    setSelectedFile(file);
+    setInlineError(null);
+  }, []);
+
+  const handleFileInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0] ?? null;
+      event.target.value = "";
+      setFile(file);
+    },
+    [setFile],
+  );
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setDragActive(false);
+      const file = event.dataTransfer.files?.[0] ?? null;
+      setFile(file);
+    },
+    [setFile],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) {
+      setInlineError(disabledReason || "Import is currently unavailable.");
+      return;
+    }
+    try {
+      if (method === "zip") {
+        if (!selectedFile) {
+          setInlineError("Choose a .zip file to continue.");
+          return;
+        }
+        await onSubmit({ type: "zip", file: selectedFile });
+        return;
+      }
+
+      const trimmedUrl = githubUrl.trim();
+      if (!trimmedUrl) {
+        setInlineError("Enter a GitHub repository URL to continue.");
+        return;
+      }
+      await onSubmit({ type: "github", url: trimmedUrl });
+    } catch (error) {
+      const mapped = mapUiError(error, { fallback: fallbackError });
+      setInlineError(mapped.message);
+      onError?.(mapped.message);
+    }
+  }, [
+    canSubmit,
+    disabledReason,
+    fallbackError,
+    githubUrl,
+    method,
+    onError,
+    onSubmit,
+    selectedFile,
+  ]);
+
+  const isReadyToSubmit =
+    method === "zip" ? Boolean(selectedFile) : githubUrl.trim().length > 0;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !isSubmitting) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-xl" showCloseButton={!isSubmitting}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant={method === "zip" ? "default" : "outline"}
+              onClick={() => {
+                setMethod("zip");
+                setInlineError(null);
+              }}
+              disabled={isSubmitting}
+            >
+              ZIP file
+            </Button>
+            <Button
+              type="button"
+              variant={method === "github" ? "default" : "outline"}
+              onClick={() => {
+                setMethod("github");
+                setInlineError(null);
+              }}
+              disabled={isSubmitting}
+            >
+              GitHub URL
+            </Button>
+          </div>
+
+          {method === "zip" ? (
+            <div
+              data-testid="config-import-dropzone"
+              className={cn(
+                "rounded-xl border border-dashed p-6 text-center transition-colors",
+                dragActive ? "border-primary bg-primary/5" : "border-border bg-muted/20",
+              )}
+              onDragEnter={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setDragActive(true);
+              }}
+              onDragOver={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setDragActive(true);
+              }}
+              onDragLeave={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                  return;
+                }
+                setDragActive(false);
+              }}
+              onDrop={handleDrop}
+            >
+              <UploadIcon className="mx-auto h-8 w-8 text-primary" />
+              <p className="mt-2 text-sm font-semibold text-foreground">Drag and drop a .zip file</p>
+              <p className="mt-1 text-xs text-muted-foreground">or browse from your computer</p>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="mt-3"
+                disabled={isSubmitting}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                Browse zip
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".zip,application/zip"
+                className="hidden"
+                onChange={handleFileInputChange}
+              />
+            </div>
+          ) : (
+            <div className="space-y-2 rounded-xl border border-border bg-muted/20 p-4">
+              <label className="text-xs font-medium text-foreground" htmlFor="config-github-import-url">
+                GitHub repository URL
+              </label>
+              <Input
+                id="config-github-import-url"
+                placeholder="https://github.com/OWNER/REPO or /tree/BRANCH"
+                value={githubUrl}
+                disabled={isSubmitting}
+                onChange={(event) => {
+                  setGithubUrl(event.target.value);
+                  setInlineError(null);
+                }}
+              />
+              <p className="text-xs text-muted-foreground">
+                Private repositories are not supported. Use GitHub Download ZIP, then import the ZIP
+                file here. Public repository and GitHub ZIP links are supported.
+              </p>
+            </div>
+          )}
+
+          {method === "zip" && selectedFile ? (
+            <div className="rounded-lg border border-border bg-background px-3 py-2">
+              <p className="truncate text-sm font-medium text-foreground">{selectedFile.name}</p>
+              <p className="text-xs text-muted-foreground">{formatBytes(selectedFile.size)}</p>
+            </div>
+          ) : null}
+
+          <div className="rounded-lg border border-border/80 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+            Supports direct exports and GitHub-generated nested wrapper zip archives.
+          </div>
+
+          {mode === "replace" && hasUnsavedChanges ? (
+            <Alert tone="warning" icon={<AlertTriangleIcon className="h-4 w-4" />}>
+              You have unsaved changes in the editor. Import will replace configuration files.
+            </Alert>
+          ) : null}
+
+          {!canSubmit && disabledReason ? (
+            <Alert tone="warning">{disabledReason}</Alert>
+          ) : null}
+
+          {inlineError ? <Alert tone="danger">{inlineError}</Alert> : null}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              void handleSubmit();
+            }}
+            disabled={isSubmitting || !canSubmit || !isReadyToSubmit}
+            isLoading={isSubmitting}
+          >
+            {submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/Workspace/sections/ConfigurationEditor/components/__tests__/ConfigurationImportDialog.test.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigurationEditor/components/__tests__/ConfigurationImportDialog.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen, waitFor } from "@/test/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiError, buildApiErrorMessage, type ProblemDetails } from "@/api/errors";
+import {
+  ConfigurationImportDialog,
+  type ConfigurationImportDialogMode,
+  type ConfigurationImportSubmitPayload,
+} from "../ConfigurationImportDialog";
+
+function buildDialogProps(overrides: {
+  mode?: ConfigurationImportDialogMode;
+  isSubmitting?: boolean;
+  canSubmit?: boolean;
+  disabledReason?: string | null;
+  hasUnsavedChanges?: boolean;
+  onSubmit?: (payload: ConfigurationImportSubmitPayload) => Promise<void>;
+  onError?: (message: string) => void;
+} = {}) {
+  return {
+    open: true,
+    mode: overrides.mode ?? "create",
+    isSubmitting: overrides.isSubmitting ?? false,
+    canSubmit: overrides.canSubmit ?? true,
+    disabledReason: overrides.disabledReason ?? null,
+    hasUnsavedChanges: overrides.hasUnsavedChanges ?? false,
+    onClose: vi.fn(),
+    onSubmit: overrides.onSubmit ?? vi.fn(async () => {}),
+    onError: overrides.onError ?? vi.fn(),
+  };
+}
+
+function setSelectedFile(file: File) {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+  if (!input) {
+    throw new Error("File input not found");
+  }
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+describe("ConfigurationImportDialog", () => {
+  it("accepts zip files via drag and drop", async () => {
+    const onSubmit = vi.fn(async () => {});
+    const props = buildDialogProps({ onSubmit });
+    const file = new File(["zip-data"], "config.zip", { type: "application/zip" });
+
+    render(<ConfigurationImportDialog {...props} />);
+
+    fireEvent.drop(screen.getByTestId("config-import-dropzone"), {
+      dataTransfer: { files: [file] },
+    });
+
+    expect(screen.getByText("config.zip")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Import configuration" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith({ type: "zip", file });
+    });
+  });
+
+  it("rejects non-zip files with inline guidance", () => {
+    const file = new File(["plain-text"], "notes.txt", { type: "text/plain" });
+    const props = buildDialogProps();
+
+    render(<ConfigurationImportDialog {...props} />);
+
+    fireEvent.drop(screen.getByTestId("config-import-dropzone"), {
+      dataTransfer: { files: [file] },
+    });
+
+    expect(screen.getByText("Please choose a .zip archive.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Import configuration" })).toBeDisabled();
+  });
+
+  it("submits github URLs", async () => {
+    const onSubmit = vi.fn(async () => {});
+    const props = buildDialogProps({ onSubmit });
+
+    render(<ConfigurationImportDialog {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "GitHub URL" }));
+    fireEvent.change(screen.getByLabelText("GitHub repository URL"), {
+      target: { value: "https://github.com/octo/repo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import configuration" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith({
+        type: "github",
+        url: "https://github.com/octo/repo",
+      });
+    });
+  });
+
+  it("shows private repo fallback guidance for github imports", () => {
+    const props = buildDialogProps();
+    render(<ConfigurationImportDialog {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "GitHub URL" }));
+
+    expect(screen.getByText(/Private repositories are not supported/i)).toBeInTheDocument();
+    expect(screen.getByText(/GitHub Download ZIP/i)).toBeInTheDocument();
+  });
+
+  it("shows friendly file_too_large messages inline", async () => {
+    const problem = {
+      type: "bad_request",
+      title: "Bad request",
+      status: 400,
+      instance: "/api/v1/workspaces/ws/configurations/import",
+      detail: "logs/too_big.ndjson (limit=52428800)",
+      errors: [{ message: "logs/too_big.ndjson", code: "file_too_large" }],
+    } satisfies ProblemDetails;
+    const onSubmit = vi.fn(async () => {
+      throw new ApiError(buildApiErrorMessage(problem, 400), 400, problem);
+    });
+
+    const props = buildDialogProps({ onSubmit });
+    const file = new File(["zip-data"], "config.zip", { type: "application/zip" });
+    render(<ConfigurationImportDialog {...props} />);
+
+    setSelectedFile(file);
+    fireEvent.click(screen.getByRole("button", { name: "Import configuration" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/too large to import/i)).toBeInTheDocument();
+    });
+  });
+
+  it("disables submit while upload is pending", () => {
+    const file = new File(["zip-data"], "config.zip", { type: "application/zip" });
+    const initialProps = buildDialogProps({ isSubmitting: false });
+    const { rerender } = render(<ConfigurationImportDialog {...initialProps} />);
+
+    setSelectedFile(file);
+
+    const pendingProps = buildDialogProps({
+      isSubmitting: true,
+      onSubmit: initialProps.onSubmit,
+      onError: initialProps.onError,
+    });
+    rerender(<ConfigurationImportDialog {...pendingProps} />);
+
+    expect(screen.getByRole("button", { name: "Import configuration" })).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/Workspace/sections/ConfigurationEditor/launcher/components/LauncherPrimaryActions.tsx
+++ b/frontend/src/pages/Workspace/sections/ConfigurationEditor/launcher/components/LauncherPrimaryActions.tsx
@@ -53,7 +53,7 @@ export function LauncherPrimaryActions({
           isLoading={isImporting}
         >
           <Upload className="h-4 w-4" />
-          Import configuration (.zip)
+          Import configuration
         </Button>
         <Button
           type="button"

--- a/frontend/src/types/generated/openapi.d.ts
+++ b/frontend/src/types/generated/openapi.d.ts
@@ -1157,6 +1157,23 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/workspaces/{workspaceId}/configurations/import/github": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a configuration from a GitHub repository URL */
+        post: operations["import_configuration_from_github_api_v1_workspaces__workspaceId__configurations_import_github_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/archive": {
         parameters: {
             query?: never;
@@ -1201,6 +1218,23 @@ export type paths = {
         get?: never;
         /** Replace a draft configuration from an uploaded archive */
         put: operations["replace_configuration_from_archive_api_v1_workspaces__workspaceId__configurations__configurationId__import_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/import/github": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Replace a draft configuration from a GitHub repository URL */
+        put: operations["replace_configuration_from_github_api_v1_workspaces__workspaceId__configurations__configurationId__import_github_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -2086,6 +2120,18 @@ export type components = {
             changes?: components["schemas"]["ConfigurationChangeSummary"] | null;
         };
         /**
+         * ConfigurationImportGithubRequest
+         * @description Create a configuration by importing a GitHub archive URL.
+         */
+        ConfigurationImportGithubRequest: {
+            /** Display Name */
+            display_name: string;
+            /** Url */
+            url: string;
+            /** Notes */
+            notes?: string | null;
+        };
+        /**
          * ConfigurationPage
          * @description Cursor-based configuration listing.
          */
@@ -2137,6 +2183,14 @@ export type components = {
             updated_at: string;
             /** Activated At */
             activated_at?: string | null;
+        };
+        /**
+         * ConfigurationReplaceGithubRequest
+         * @description Replace a draft configuration using a GitHub archive URL.
+         */
+        ConfigurationReplaceGithubRequest: {
+            /** Url */
+            url: string;
         };
         /**
          * ConfigurationRestoreRequest
@@ -4257,7 +4311,9 @@ export type components = {
             type: string;
             title: string;
             status: number;
-            detail?: string | null;
+            detail?: (string | {
+                [key: string]: unknown;
+            }) | null;
             instance: string;
             requestId?: string | null;
             errors?: components["schemas"]["ProblemDetailsErrorItem"][] | null;
@@ -8794,6 +8850,47 @@ export interface operations {
             default: components["responses"]["ProblemDetails"];
         };
     };
+    import_configuration_from_github_api_v1_workspaces__workspaceId__configurations_import_github_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-CSRF-Token"?: string | null;
+            };
+            path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfigurationImportGithubRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConfigurationRecord"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
     archive_configuration_endpoint_api_v1_workspaces__workspaceId__configurations__configurationId__archive_post: {
         parameters: {
             query?: never;
@@ -8890,6 +8987,49 @@ export interface operations {
         requestBody: {
             content: {
                 "multipart/form-data": components["schemas"]["Body_replace_configuration_from_archive_api_v1_workspaces__workspaceId__configurations__configurationId__import_put"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConfigurationRecord"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    "X-Request-Id": components["headers"]["X-Request-Id"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            default: components["responses"]["ProblemDetails"];
+        };
+    };
+    replace_configuration_from_github_api_v1_workspaces__workspaceId__configurations__configurationId__import_github_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-CSRF-Token"?: string | null;
+            };
+            path: {
+                /** @description Workspace identifier */
+                workspaceId: string;
+                /** @description Configuration identifier */
+                configurationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfigurationReplaceGithubRequest"];
             };
         };
         responses: {


### PR DESCRIPTION
## Summary
This PR delivers configuration import v2 as a first-class, unified import experience and hardens failure behavior.

- Adds a single import UX with two methods: ZIP upload (drag/drop) and GitHub URL.
- Supports public GitHub repository imports and keeps private repositories explicitly out of scope for this release.
- Improves ZIP import robustness (nested wrapper folders, configurable limits, safer extraction/error handling).
- Hardens failure paths so failed imports do not leave stale artifacts and replace operations are rollback-safe.

## What Changed
### Backend
- Added GitHub import URL parsing/downloader utilities:
  - `backend/src/ade_api/features/configs/github_import.py`
- Added create/replace GitHub import API schemas:
  - `backend/src/ade_api/features/configs/schemas.py`
- Added new endpoints:
  - `POST /api/v1/workspaces/{workspaceId}/configurations/import/github`
  - `PUT /api/v1/workspaces/{workspaceId}/configurations/{configurationId}/import/github`
  - in `backend/src/ade_api/features/configs/endpoints/configurations.py`
- Unified import size limit via settings/env:
  - `ADE_CONFIG_IMPORT_MAX_BYTES` (default 50 MB)
  - in `backend/src/ade_api/settings.py`
- Storage hardening:
  - rollback-safe replace (backup/restore on swap failure)
  - cleanup of staging/backup temp dirs on failure paths
  - additional archive read errors mapped to `invalid_archive`
  - in `backend/src/ade_api/features/configs/storage.py`
- Service hardening:
  - delete materialized config files if DB persistence fails after successful import materialization
  - in `backend/src/ade_api/features/configs/service.py`
- Problem details/openapi updates for structured import errors:
  - `backend/src/ade_api/common/problem_details.py`
  - `backend/src/ade_api/common/exceptions.py`
  - `backend/src/ade_api/common/openapi.py`
  - `backend/src/ade_api/openapi.json`

### Frontend
- Added guided import dialog used in launcher + workbench:
  - `frontend/src/pages/Workspace/sections/ConfigurationEditor/components/ConfigurationImportDialog.tsx`
- Unified import labels and wiring for both ZIP and GitHub methods:
  - `frontend/src/pages/Workspace/sections/ConfigurationEditor/launcher/ConfigurationLauncherPage.tsx`
  - `frontend/src/pages/Workspace/sections/ConfigurationEditor/workbench/Workbench.tsx`
  - `frontend/src/api/configurations/api.ts`
  - `frontend/src/pages/Workspace/hooks/configurations/useConfigurationImport.ts`
- Error-message improvements, including explicit private-repo guidance and ZIP fallback:
  - `frontend/src/api/errors.ts`

### Docs / Config
- Documented `ADE_CONFIG_IMPORT_MAX_BYTES`:
  - `docs/reference/environment-variables.md`
  - `.env.example`

## Edge-Case Guarantees Added
- Failed import attempts clean up staging directories.
- Failed create-import DB persistence does not leave orphaned config directories.
- Failed replace-import swaps restore the original fileset.
- Private GitHub repositories are explicitly unsupported in UX and error messaging with guidance to use GitHub Download ZIP + manual ZIP import.

## Tests
Added/updated tests for:
- GitHub URL parsing/downloader + error mapping.
- Wrapped/nested ZIP import behavior.
- Configurable size limits.
- Replace rollback + temp cleanup behavior.
- Frontend dialog behavior and friendly error messaging.

### Verification Run
Executed locally:
- `cd backend && uv run ade api test` ✅
- `cd backend && uv run ade web test` ✅
- `cd backend && uv run ade web lint` ✅
- `cd backend && uv run ade test` ✅
- `cd backend && uv run ade api lint` ⚠️ (fails due existing repo-wide lint debt unrelated to this PR)

## Notes
- Private GitHub repo authentication is intentionally deferred for a future phase to keep this release minimal and operationally safe.
