### PR TITLE
chore(docs): overhaul API docs and add coverage checks

### DIFF
--- a/backend/src/ade_api/common/openapi.py
+++ b/backend/src/ade_api/common/openapi.py
@@ -151,11 +151,137 @@ def configure_openapi(app: FastAPI, settings: Settings) -> None:
             ("/api/v1/workspaces/{workspaceId}/roleassignments/{assignmentId}", "GET"),
         }
         if_match_routes = {
-            ("/api/v1/workspaces/{workspaceId}/roles/{roleId}", "PATCH"),
-            ("/api/v1/workspaces/{workspaceId}/roles/{roleId}", "DELETE"),
-            ("/api/v1/workspaces/{workspaceId}/roleassignments/{assignmentId}", "DELETE"),
-            ("/api/v1/users/me/apikeys/{apiKeyId}", "DELETE"),
-            ("/api/v1/users/{userId}/apikeys/{apiKeyId}", "DELETE"),
+                ("/api/v1/workspaces/{workspaceId}/roles/{roleId}", "PATCH"),
+                ("/api/v1/workspaces/{workspaceId}/roles/{roleId}", "DELETE"),
+                ("/api/v1/workspaces/{workspaceId}/roleassignments/{assignmentId}", "DELETE"),
+                ("/api/v1/users/me/apikeys/{apiKeyId}", "DELETE"),
+                ("/api/v1/users/{userId}/apikeys/{apiKeyId}", "DELETE"),
+        }
+        top_workflow_tags = {"auth", "me", "workspaces", "configurations", "documents", "runs"}
+        operation_examples: dict[tuple[str, str], dict[str, Any]] = {
+            (
+                "/api/v1/me",
+                "GET",
+            ): {
+                "response": {
+                    "200": {
+                        "application/json": {
+                            "meProfile": {
+                                "summary": "Authenticated profile",
+                                "value": {
+                                    "id": "01J7YATV4Y2R7BNS2N8MP4H2YK",
+                                    "email": "operator@example.com",
+                                    "displayName": "ADE Operator",
+                                    "isServiceAccount": False,
+                                    "isVerified": True,
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+            (
+                "/api/v1/workspaces/{workspaceId}/documents",
+                "POST",
+            ): {
+                "request": {
+                    "multipart/form-data": {
+                        "uploadDocument": {
+                            "summary": "Upload and queue with active sheet only",
+                            "value": {
+                                "metadata": '{"source":"api-guide","mode":"active-sheet-only"}',
+                                "run_options": '{"activeSheetOnly":true}',
+                                "conflictMode": "keep_both",
+                            },
+                        }
+                    }
+                },
+                "response": {
+                    "201": {
+                        "application/json": {
+                            "uploadedDocument": {
+                                "summary": "Uploaded document",
+                                "value": {
+                                    "id": "01J7YB4D2YQ35XQB7AVJH8GWWV",
+                                    "workspaceId": "01J7YAX69V8ACZ8SBRJ8GHXW1A",
+                                    "name": "input.xlsx",
+                                    "byteSize": 12482,
+                                    "metadata": {
+                                        "source": "api-guide",
+                                        "mode": "active-sheet-only",
+                                    },
+                                },
+                            }
+                        }
+                    }
+                },
+            },
+            (
+                "/api/v1/workspaces/{workspaceId}/runs",
+                "POST",
+            ): {
+                "request": {
+                    "application/json": {
+                        "processDocumentRun": {
+                            "summary": "Create a run for one uploaded document",
+                            "value": {
+                                "inputDocumentId": "01J7YB4D2YQ35XQB7AVJH8GWWV",
+                                "options": {
+                                    "operation": "process",
+                                    "activeSheetOnly": True,
+                                },
+                            },
+                        }
+                    }
+                },
+                "response": {
+                    "201": {
+                        "application/json": {
+                            "createdRun": {
+                                "summary": "Queued run",
+                                "value": {
+                                    "id": "01J7YB9A6Y3QFNBVE9S9THQ4HC",
+                                    "workspaceId": "01J7YAX69V8ACZ8SBRJ8GHXW1A",
+                                    "status": "queued",
+                                    "operation": "process",
+                                },
+                            }
+                        }
+                    }
+                },
+            },
+            (
+                "/api/v1/workspaces/{workspaceId}/configurations",
+                "POST",
+            ): {
+                "request": {
+                    "application/json": {
+                        "createFromTemplate": {
+                            "summary": "Create a draft configuration from template",
+                            "value": {
+                                "displayName": "Customer Imports v2",
+                                "source": {"type": "template"},
+                                "notes": "Initial draft for spreadsheet normalization.",
+                            },
+                        }
+                    }
+                },
+                "response": {
+                    "201": {
+                        "application/json": {
+                            "configurationRecord": {
+                                "summary": "Created draft configuration",
+                                "value": {
+                                    "id": "01J7YC64V8M7CJWVJCE2R9VW5G",
+                                    "workspaceId": "01J7YAX69V8ACZ8SBRJ8GHXW1A",
+                                    "displayName": "Customer Imports v2",
+                                    "status": "draft",
+                                },
+                            }
+                        }
+                    }
+                },
+            },
         }
 
         def _add_parameter(operation: dict[str, Any], ref: str, name: str | None = None) -> None:
@@ -173,6 +299,44 @@ def configure_openapi(app: FastAPI, settings: Settings) -> None:
                 return
             params.append({"$ref": ref})
 
+        def _set_examples(
+            operation: dict[str, Any],
+            *,
+            request: dict[str, dict[str, Any]] | None = None,
+            response: dict[str, dict[str, dict[str, Any]]] | None = None,
+        ) -> None:
+            if request:
+                request_body = operation.setdefault("requestBody", {})
+                if not isinstance(request_body, dict):
+                    request_body = {}
+                    operation["requestBody"] = request_body
+                content = request_body.setdefault("content", {})
+                if not isinstance(content, dict):
+                    content = {}
+                    request_body["content"] = content
+                for media_type, examples in request.items():
+                    media = content.setdefault(media_type, {})
+                    if not isinstance(media, dict) or "examples" in media:
+                        continue
+                    media["examples"] = examples
+
+            if response:
+                responses = operation.setdefault("responses", {})
+                if not isinstance(responses, dict):
+                    return
+                for status_code, media_by_type in response.items():
+                    response_obj = responses.get(status_code)
+                    if not isinstance(response_obj, dict) or "$ref" in response_obj:
+                        continue
+                    content = response_obj.setdefault("content", {})
+                    if not isinstance(content, dict):
+                        continue
+                    for media_type, examples in media_by_type.items():
+                        media = content.setdefault(media_type, {})
+                        if not isinstance(media, dict) or "examples" in media:
+                            continue
+                        media["examples"] = examples
+
         for path, operations in schema.get("paths", {}).items():
             for method, operation in operations.items():
                 if not isinstance(operation, dict):
@@ -185,6 +349,12 @@ def configure_openapi(app: FastAPI, settings: Settings) -> None:
                 else:
                     if "security" not in operation or operation["security"] is None:
                         operation["security"] = list(auth_security)
+
+                tags = {str(tag) for tag in operation.get("tags", []) if isinstance(tag, str)}
+                if tags.intersection(top_workflow_tags) and not operation.get("description"):
+                    summary = str(operation.get("summary", "")).strip()
+                    if summary:
+                        operation["description"] = f"{summary}."
 
                 responses = operation.setdefault("responses", {})
                 responses.setdefault("default", {"$ref": "#/components/responses/ProblemDetails"})
@@ -212,6 +382,14 @@ def configure_openapi(app: FastAPI, settings: Settings) -> None:
 
                 if (path, method_upper) in if_match_routes:
                     _add_parameter(operation, "#/components/parameters/IfMatch", "If-Match")
+
+                operation_example = operation_examples.get((path, method_upper))
+                if operation_example:
+                    _set_examples(
+                        operation,
+                        request=operation_example.get("request"),
+                        response=operation_example.get("response"),
+                    )
 
         app.openapi_schema = schema
         return schema

--- a/backend/src/ade_api/features/auth/sso_router.py
+++ b/backend/src/ade_api/features/auth/sso_router.py
@@ -285,6 +285,7 @@ def _resolve_user(
     response_model=PublicSsoProviderListResponse,
     status_code=status.HTTP_200_OK,
     summary="Return active SSO providers",
+    description="List public SSO providers currently available for interactive sign-in.",
 )
 def list_sso_providers(
     settings: Annotated[Settings, Depends(get_settings)],
@@ -307,7 +308,13 @@ def list_sso_providers(
     )
 
 
-@router.get("/authorize")
+@router.get(
+    "/authorize",
+    summary="Start SSO authorization",
+    description=(
+        "Initiate the OIDC authorization flow and redirect to the configured identity provider."
+    ),
+)
 def authorize_sso(
     request: Request,
     return_to: Annotated[str | None, Query(alias="returnTo")] = None,
@@ -364,7 +371,13 @@ def authorize_sso(
     return RedirectResponse(url)
 
 
-@router.get("/callback")
+@router.get(
+    "/callback",
+    summary="Complete SSO authorization",
+    description=(
+        "Handle the OIDC callback, validate the provider response, and establish an ADE session."
+    ),
+)
 def callback_sso(
     request: Request,
     settings: Annotated[Settings, Depends(get_settings)] = None,

--- a/backend/src/ade_api/features/configs/endpoints/configurations.py
+++ b/backend/src/ade_api/features/configs/endpoints/configurations.py
@@ -434,6 +434,8 @@ def archive_configuration_endpoint(
     responses={
         status.HTTP_200_OK: {"content": {"application/zip": {}}},
     },
+    summary="Export a configuration archive",
+    description="Export the selected configuration as a ZIP archive.",
 )
 def export_config(
     workspace_id: WorkspaceIdPath,

--- a/backend/src/ade_api/features/configs/endpoints/files.py
+++ b/backend/src/ade_api/features/configs/endpoints/files.py
@@ -207,6 +207,11 @@ def list_config_files(
         status.HTTP_206_PARTIAL_CONTENT: {"content": {"application/octet-stream": {}}},
         status.HTTP_304_NOT_MODIFIED: {"model": None},
     },
+    summary="Read configuration file content",
+    description=(
+        "Read a file from a draft configuration as JSON (`format=json`) or raw bytes. "
+        "Supports ETag and HTTP range semantics."
+    ),
 )
 def read_config_file(
     workspace_id: WorkspaceIdPath,
@@ -358,6 +363,11 @@ def head_config_file(
         status.HTTP_200_OK: {"model": FileWriteResponse},
         status.HTTP_201_CREATED: {"model": FileWriteResponse},
     },
+    summary="Create or replace a configuration file",
+    description=(
+        "Write file content into a draft configuration path. "
+        "Supports conditional writes with `If-Match` and `If-None-Match`."
+    ),
 )
 def upsert_config_file(
     workspace_id: WorkspaceIdPath,
@@ -434,6 +444,8 @@ def upsert_config_file(
     "/configurations/{configurationId}/files/{filePath:path}",
     dependencies=[Security(require_csrf)],
     status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a configuration file",
+    description="Delete a file from a draft configuration with optional optimistic concurrency checks.",
 )
 def delete_config_file(
     workspace_id: WorkspaceIdPath,
@@ -494,6 +506,8 @@ def delete_config_file(
             "description": "Directory created",
         },
     },
+    summary="Create a configuration directory",
+    description="Create a directory path in a draft configuration.",
 )
 def create_config_directory(
     workspace_id: WorkspaceIdPath,
@@ -533,6 +547,8 @@ def create_config_directory(
     "/configurations/{configurationId}/directories/{directoryPath:path}",
     dependencies=[Security(require_csrf)],
     status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a configuration directory",
+    description="Delete a directory path from a draft configuration.",
 )
 def delete_config_directory(
     workspace_id: WorkspaceIdPath,

--- a/backend/src/ade_api/features/runs/router.py
+++ b/backend/src/ade_api/features/runs/router.py
@@ -260,6 +260,11 @@ def _build_run_events_download_filename(*, run: Run, input_filename: str | None)
     response_model=RunResource,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Security(require_csrf)],
+    summary="Create and enqueue a run",
+    description=(
+        "Create a run in the target workspace and enqueue it for worker processing. "
+        "When `configuration_id` is omitted, the active workspace configuration is used."
+    ),
 )
 def create_workspace_run_endpoint(
     *,
@@ -306,6 +311,11 @@ def create_workspace_run_endpoint(
     response_model=RunBatchCreateResponse,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Security(require_csrf)],
+    summary="Create and enqueue runs in batch",
+    description=(
+        "Create one run per document in `document_ids` and enqueue all runs as a single "
+        "all-or-nothing operation."
+    ),
 )
 def create_workspace_runs_batch_endpoint(
     *,
@@ -346,6 +356,10 @@ def create_workspace_runs_batch_endpoint(
     "",
     response_model=RunPage,
     response_model_exclude_none=True,
+    summary="List runs in a workspace",
+    description=(
+        "Return a cursor-paginated run list for the workspace with filtering, search, and sorting."
+    ),
 )
 def list_workspace_runs_endpoint(
     workspace_id: WorkspacePath,
@@ -373,7 +387,12 @@ def list_workspace_runs_endpoint(
     )
 
 
-@router.get("/{runId}", response_model=RunResource)
+@router.get(
+    "/{runId}",
+    response_model=RunResource,
+    summary="Get run details",
+    description="Return a single run resource for the requested workspace and run identifier.",
+)
 def get_workspace_run_endpoint(
     workspace_id: WorkspacePath,
     run_id: RunPath,
@@ -388,6 +407,8 @@ def get_workspace_run_endpoint(
     "/{runId}/cancel",
     response_model=RunResource,
     dependencies=[Security(require_csrf)],
+    summary="Cancel a run",
+    description="Request cancellation for a run that is still cancellable.",
 )
 def cancel_workspace_run_endpoint(
     workspace_id: WorkspacePath,
@@ -409,6 +430,11 @@ def cancel_workspace_run_endpoint(
     "/{runId}/metrics",
     response_model=RunMetricsResource,
     response_model_exclude_none=True,
+    summary="Get run metrics",
+    description=(
+        "Return derived run metrics from worker events, including evaluation, validation, and "
+        "workbook statistics."
+    ),
 )
 def get_workspace_run_metrics_endpoint(
     workspace_id: WorkspacePath,
@@ -430,6 +456,8 @@ def get_workspace_run_metrics_endpoint(
     "/{runId}/fields",
     response_model=list[RunFieldResource],
     response_model_exclude_none=True,
+    summary="List run field detection results",
+    description="Return field-level detection outcomes captured for the run.",
 )
 def list_workspace_run_fields_endpoint(
     workspace_id: WorkspacePath,
@@ -449,6 +477,8 @@ def list_workspace_run_fields_endpoint(
     "/{runId}/columns",
     response_model=list[RunColumnResource],
     response_model_exclude_none=True,
+    summary="List run column mappings",
+    description="Return detected input columns and mapping metadata for the run.",
 )
 def list_workspace_run_columns_endpoint(
     workspace_id: WorkspacePath,
@@ -470,6 +500,7 @@ def list_workspace_run_columns_endpoint(
     response_model=RunInput,
     response_model_exclude_none=True,
     summary="Get run input metadata",
+    description="Return the input document/version metadata associated with the run.",
 )
 def get_workspace_run_input_endpoint(
     workspace_id: WorkspacePath,
@@ -491,6 +522,7 @@ def get_workspace_run_input_endpoint(
 @router.get(
     "/{runId}/input/download",
     summary="Download run input file",
+    description="Download the exact input file version used by this run.",
 )
 def download_workspace_run_input_endpoint(
     workspace_id: WorkspacePath,
@@ -527,6 +559,10 @@ def download_workspace_run_input_endpoint(
     "/{runId}/events/stream",
     responses={status.HTTP_404_NOT_FOUND: {"description": "Run not found"}},
     summary="Stream run events (SSE)",
+    description=(
+        "Stream run events using Server-Sent Events. "
+        "Use `cursor` or `Last-Event-ID` to resume from a prior position."
+    ),
 )
 async def stream_workspace_run_events_endpoint(
     workspace_id: WorkspacePath,
@@ -568,6 +604,7 @@ async def stream_workspace_run_events_endpoint(
     "/{runId}/events/download",
     responses={status.HTTP_404_NOT_FOUND: {"description": "Events unavailable"}},
     summary="Download run events (NDJSON log)",
+    description="Download the persisted NDJSON event log for the run.",
 )
 def download_workspace_run_events_file_endpoint(
     workspace_id: WorkspacePath,
@@ -610,6 +647,7 @@ def download_workspace_run_events_file_endpoint(
         status.HTTP_404_NOT_FOUND: {"description": "Run or output not found"},
     },
     summary="Get run output metadata",
+    description="Return output file metadata, readiness, and download link information.",
 )
 def get_workspace_run_output_metadata_endpoint(
     workspace_id: WorkspacePath,
@@ -638,6 +676,7 @@ def get_workspace_run_output_metadata_endpoint(
         },
     },
     summary="Upload manual run output",
+    description="Upload an output artifact for a run managed manually outside worker execution.",
 )
 def upload_workspace_run_output_endpoint(
     workspace_id: WorkspacePath,
@@ -674,6 +713,7 @@ def upload_workspace_run_output_endpoint(
         status.HTTP_409_CONFLICT: {"description": "Output not ready"},
     },
     summary="Download run output file",
+    description="Download the latest output file artifact associated with the run.",
 )
 def download_workspace_run_output_endpoint(
     workspace_id: WorkspacePath,
@@ -730,6 +770,7 @@ def download_workspace_run_output_endpoint(
         },
     },
     summary="List run output worksheets",
+    description="List worksheets available in the run output artifact when sheet introspection is supported.",
 )
 def list_workspace_run_output_sheets_endpoint(
     workspace_id: WorkspacePath,
@@ -764,6 +805,10 @@ def list_workspace_run_output_sheets_endpoint(
     response_model=WorkbookSheetPreview,
     response_model_exclude_none=True,
     summary="Preview run output worksheet",
+    description=(
+        "Return a bounded preview of run output worksheet data with optional sheet selection "
+        "and trimming controls."
+    ),
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Run or output not found"},
         status.HTTP_409_CONFLICT: {"description": "Output not ready"},

--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -112,6 +112,7 @@
           "auth"
         ],
         "summary": "Return active SSO providers",
+        "description": "List public SSO providers currently available for interactive sign-in.",
         "operationId": "list_sso_providers_api_v1_auth_sso_providers_get",
         "responses": {
           "200": {
@@ -143,7 +144,8 @@
           "auth",
           "auth"
         ],
-        "summary": "Authorize Sso",
+        "summary": "Start SSO authorization",
+        "description": "Initiate the OIDC authorization flow and redirect to the configured identity provider.",
         "operationId": "authorize_sso_api_v1_auth_sso_authorize_get",
         "parameters": [
           {
@@ -206,7 +208,8 @@
           "auth",
           "auth"
         ],
-        "summary": "Callback Sso",
+        "summary": "Complete SSO authorization",
+        "description": "Handle the OIDC callback, validate the provider response, and establish an ADE session.",
         "operationId": "callback_sso_api_v1_auth_sso_callback_get",
         "responses": {
           "200": {
@@ -256,7 +259,8 @@
             "$ref": "#/components/responses/ProblemDetails"
           }
         },
-        "security": []
+        "security": [],
+        "description": "Return setup status for the first admin user."
       },
       "post": {
         "tags": [
@@ -302,7 +306,8 @@
             "$ref": "#/components/responses/ProblemDetails"
           }
         },
-        "security": []
+        "security": [],
+        "description": "Create the first admin user and log them in."
       }
     },
     "/api/v1/auth/providers": {
@@ -332,7 +337,8 @@
             "$ref": "#/components/responses/ProblemDetails"
           }
         },
-        "security": []
+        "security": [],
+        "description": "Return configured authentication providers."
       }
     },
     "/api/v1/auth/login": {
@@ -395,7 +401,8 @@
             "$ref": "#/components/responses/ProblemDetails"
           }
         },
-        "security": []
+        "security": [],
+        "description": "Authenticate with local username/password."
       }
     },
     "/api/v1/auth/logout": {
@@ -458,7 +465,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Logout current user and revoke their sessions."
       }
     },
     "/api/v1/auth/password/forgot": {
@@ -511,7 +519,8 @@
             "$ref": "#/components/responses/ProblemDetails"
           }
         },
-        "security": []
+        "security": [],
+        "description": "Create a password reset token and schedule delivery."
       }
     },
     "/api/v1/auth/password/reset": {
@@ -559,7 +568,8 @@
             "$ref": "#/components/responses/ProblemDetails"
           }
         },
-        "security": []
+        "security": [],
+        "description": "Consume a password reset token and update credentials."
       }
     },
     "/api/v1/auth/mfa/totp/enroll/start": {
@@ -629,7 +639,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Start TOTP MFA enrollment for the current user."
       }
     },
     "/api/v1/auth/mfa/totp": {
@@ -666,7 +677,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Read TOTP MFA status for the current user."
       },
       "delete": {
         "tags": [
@@ -727,7 +739,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Disable TOTP for the current user."
       }
     },
     "/api/v1/auth/mfa/totp/enroll/confirm": {
@@ -807,7 +820,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Confirm TOTP enrollment with current code."
       }
     },
     "/api/v1/auth/mfa/totp/recovery/regenerate": {
@@ -887,7 +901,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Regenerate recovery codes for current user."
       }
     },
     "/api/v1/auth/mfa/challenge/verify": {
@@ -942,7 +957,8 @@
             "$ref": "#/components/responses/ProblemDetails"
           }
         },
-        "security": []
+        "security": [],
+        "description": "Verify MFA challenge and issue a session."
       }
     },
     "/api/v1/apikeys": {
@@ -3999,6 +4015,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MeProfile"
+                },
+                "examples": {
+                  "meProfile": {
+                    "summary": "Authenticated profile",
+                    "value": {
+                      "id": "01J7YATV4Y2R7BNS2N8MP4H2YK",
+                      "email": "operator@example.com",
+                      "displayName": "ADE Operator",
+                      "isServiceAccount": false,
+                      "isVerified": true
+                    }
+                  }
                 }
               }
             },
@@ -4426,7 +4454,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Create a new workspace."
       },
       "get": {
         "tags": [
@@ -4627,7 +4656,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List workspaces for the authenticated user."
       }
     },
     "/api/v1/workspaces/{workspaceId}": {
@@ -4717,7 +4747,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Retrieve workspace context by identifier."
       },
       "patch": {
         "tags": [
@@ -4832,7 +4863,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Update workspace metadata."
       },
       "delete": {
         "tags": [
@@ -4929,7 +4961,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Delete a workspace."
       }
     },
     "/api/v1/workspaces/{workspaceId}/default": {
@@ -5020,7 +5053,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Mark a workspace as the caller's default."
       }
     },
     "/api/v1/workspaces/{workspaceId}/members": {
@@ -5219,7 +5253,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List workspace members with their roles."
       },
       "post": {
         "tags": [
@@ -5309,7 +5344,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Add a workspace member with roles."
       }
     },
     "/api/v1/workspaces/{workspaceId}/members/{userId}": {
@@ -5413,7 +5449,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Replace workspace member roles."
       },
       "delete": {
         "tags": [
@@ -5498,7 +5535,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Remove a workspace member."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/tags": {
@@ -5706,7 +5744,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List document tags."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents": {
@@ -5752,6 +5791,16 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/Body_upload_document_api_v1_workspaces__workspaceId__documents_post"
+              },
+              "examples": {
+                "uploadDocument": {
+                  "summary": "Upload and queue with active sheet only",
+                  "value": {
+                    "metadata": "{\"source\":\"api-guide\",\"mode\":\"active-sheet-only\"}",
+                    "run_options": "{\"activeSheetOnly\":true}",
+                    "conflictMode": "keep_both"
+                  }
+                }
               }
             }
           }
@@ -5763,6 +5812,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DocumentOut"
+                },
+                "examples": {
+                  "uploadedDocument": {
+                    "summary": "Uploaded document",
+                    "value": {
+                      "id": "01J7YB4D2YQ35XQB7AVJH8GWWV",
+                      "workspaceId": "01J7YAX69V8ACZ8SBRJ8GHXW1A",
+                      "name": "input.xlsx",
+                      "byteSize": 12482,
+                      "metadata": {
+                        "source": "api-guide",
+                        "mode": "active-sheet-only"
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -5838,7 +5902,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Upload a document."
       },
       "get": {
         "tags": [
@@ -6083,7 +6148,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List documents."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/versions": {
@@ -6219,7 +6285,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Upload a new document version."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/views": {
@@ -6285,7 +6352,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List saved document views."
       },
       "post": {
         "tags": [
@@ -6375,7 +6443,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Create a saved document view."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/views/{viewId}": {
@@ -6479,7 +6548,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Update a saved document view."
       },
       "delete": {
         "tags": [
@@ -6564,7 +6634,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Delete a saved document view."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/stream": {
@@ -6646,7 +6717,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Stream document changes."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/delta": {
@@ -6759,7 +6831,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List document changes since token."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}": {
@@ -6888,7 +6961,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Update document metadata, assignment, or name."
       },
       "get": {
         "tags": [
@@ -7018,7 +7092,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Retrieve document metadata."
       },
       "delete": {
         "tags": [
@@ -7127,7 +7202,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Soft delete a document."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/batch/tags": {
@@ -7236,7 +7312,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Update tags on multiple documents."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/tags": {
@@ -7357,7 +7434,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Replace document tags."
       },
       "patch": {
         "tags": [
@@ -7476,7 +7554,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Update document tags."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/listrow": {
@@ -7608,7 +7687,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Retrieve document list row."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/comments": {
@@ -7843,7 +7923,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List document comments."
       },
       "post": {
         "tags": [
@@ -7962,7 +8043,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Create a document comment."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/download": {
@@ -8062,7 +8144,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Download latest document artifact."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/original/download": {
@@ -8162,7 +8245,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Download original document version."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/versions/{versionNo}/download": {
@@ -8272,7 +8356,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Download a specific document version."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/preview": {
@@ -8448,7 +8533,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Preview a document worksheet."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/sheets": {
@@ -8531,7 +8617,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List worksheets for a document."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/{documentId}/restore": {
@@ -8649,7 +8736,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Restore a soft-deleted document."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/batch/delete": {
@@ -8765,7 +8853,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Soft delete multiple documents."
       }
     },
     "/api/v1/workspaces/{workspaceId}/documents/batch/restore": {
@@ -8881,7 +8970,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Restore multiple soft-deleted documents."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations": {
@@ -9080,7 +9170,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List configurations for a workspace."
       },
       "post": {
         "tags": [
@@ -9125,6 +9216,18 @@
               "schema": {
                 "$ref": "#/components/schemas/ConfigurationCreate",
                 "description": "Display name and template/clone source for the configuration."
+              },
+              "examples": {
+                "createFromTemplate": {
+                  "summary": "Create a draft configuration from template",
+                  "value": {
+                    "displayName": "Customer Imports v2",
+                    "source": {
+                      "type": "template"
+                    },
+                    "notes": "Initial draft for spreadsheet normalization."
+                  }
+                }
               }
             }
           }
@@ -9136,6 +9239,17 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ConfigurationRecord"
+                },
+                "examples": {
+                  "configurationRecord": {
+                    "summary": "Created draft configuration",
+                    "value": {
+                      "id": "01J7YC64V8M7CJWVJCE2R9VW5G",
+                      "workspaceId": "01J7YAX69V8ACZ8SBRJ8GHXW1A",
+                      "displayName": "Customer Imports v2",
+                      "status": "draft"
+                    }
+                  }
                 }
               }
             },
@@ -9171,7 +9285,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Create a configuration from a template or clone."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/history": {
@@ -9311,7 +9426,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Retrieve workspace configuration timeline."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}": {
@@ -9392,7 +9508,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Retrieve configuration metadata."
       },
       "patch": {
         "tags": [
@@ -9495,7 +9612,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Update editable metadata for a draft configuration."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/restore": {
@@ -9600,7 +9718,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Restore a previous configuration as a new draft."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/import": {
@@ -9692,7 +9811,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Create a configuration from an uploaded archive."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/archive": {
@@ -9786,7 +9906,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Archive a draft or active configuration."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/export": {
@@ -9794,7 +9915,8 @@
         "tags": [
           "configurations"
         ],
-        "summary": "Export Config",
+        "summary": "Export a configuration archive",
+        "description": "Export the selected configuration as a ZIP archive.",
         "operationId": "export_config_api_v1_workspaces__workspaceId__configurations__configurationId__export_get",
         "parameters": [
           {
@@ -9977,7 +10099,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Replace a draft configuration from an uploaded archive."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/files": {
@@ -10176,7 +10299,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "List editable files and directories."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/files/{filePath}": {
@@ -10184,7 +10308,8 @@
         "tags": [
           "configurations"
         ],
-        "summary": "Read Config File",
+        "summary": "Read configuration file content",
+        "description": "Read a file from a draft configuration as JSON (`format=json`) or raw bytes. Supports ETag and HTTP range semantics.",
         "operationId": "read_config_file_api_v1_workspaces__workspaceId__configurations__configurationId__files__filePath__get",
         "parameters": [
           {
@@ -10380,13 +10505,15 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Head Config File."
       },
       "put": {
         "tags": [
           "configurations"
         ],
-        "summary": "Upsert Config File",
+        "summary": "Create or replace a configuration file",
+        "description": "Write file content into a draft configuration path. Supports conditional writes with `If-Match` and `If-None-Match`.",
         "operationId": "upsert_config_file_api_v1_workspaces__workspaceId__configurations__configurationId__files__filePath__put",
         "parameters": [
           {
@@ -10524,7 +10651,8 @@
         "tags": [
           "configurations"
         ],
-        "summary": "Delete Config File",
+        "summary": "Delete a configuration file",
+        "description": "Delete a file from a draft configuration with optional optimistic concurrency checks.",
         "operationId": "delete_config_file_api_v1_workspaces__workspaceId__configurations__configurationId__files__filePath__delete",
         "parameters": [
           {
@@ -10723,7 +10851,8 @@
           {
             "APIKeyHeader": []
           }
-        ]
+        ],
+        "description": "Rename or move a file."
       }
     },
     "/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/directories/{directoryPath}": {
@@ -10731,7 +10860,8 @@
         "tags": [
           "configurations"
         ],
-        "summary": "Create Config Directory",
+        "summary": "Create a configuration directory",
+        "description": "Create a directory path in a draft configuration.",
         "operationId": "create_config_directory_api_v1_workspaces__workspaceId__configurations__configurationId__directories__directoryPath__put",
         "parameters": [
           {
@@ -10847,7 +10977,8 @@
         "tags": [
           "configurations"
         ],
-        "summary": "Delete Config Directory",
+        "summary": "Delete a configuration directory",
+        "description": "Delete a directory path from a draft configuration.",
         "operationId": "delete_config_directory_api_v1_workspaces__workspaceId__configurations__configurationId__directories__directoryPath__delete",
         "parameters": [
           {
@@ -10953,8 +11084,8 @@
         "tags": [
           "runs"
         ],
-        "summary": "Create Workspace Run Endpoint",
-        "description": "Create a run for ``workspace_id`` and enqueue execution.",
+        "summary": "Create and enqueue a run",
+        "description": "Create a run in the target workspace and enqueue it for worker processing. When `configuration_id` is omitted, the active workspace configuration is used.",
         "operationId": "create_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs_post",
         "parameters": [
           {
@@ -10992,6 +11123,18 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RunWorkspaceCreateRequest"
+              },
+              "examples": {
+                "processDocumentRun": {
+                  "summary": "Create a run for one uploaded document",
+                  "value": {
+                    "inputDocumentId": "01J7YB4D2YQ35XQB7AVJH8GWWV",
+                    "options": {
+                      "operation": "process",
+                      "activeSheetOnly": true
+                    }
+                  }
+                }
               }
             }
           }
@@ -11003,6 +11146,17 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RunResource"
+                },
+                "examples": {
+                  "createdRun": {
+                    "summary": "Queued run",
+                    "value": {
+                      "id": "01J7YB9A6Y3QFNBVE9S9THQ4HC",
+                      "workspaceId": "01J7YAX69V8ACZ8SBRJ8GHXW1A",
+                      "status": "queued",
+                      "operation": "process"
+                    }
+                  }
                 }
               }
             },
@@ -11044,7 +11198,8 @@
         "tags": [
           "runs"
         ],
-        "summary": "List Workspace Runs Endpoint",
+        "summary": "List runs in a workspace",
+        "description": "Return a cursor-paginated run list for the workspace with filtering, search, and sorting.",
         "operationId": "list_workspace_runs_endpoint_api_v1_workspaces__workspaceId__runs_get",
         "parameters": [
           {
@@ -11243,8 +11398,8 @@
         "tags": [
           "runs"
         ],
-        "summary": "Create Workspace Runs Batch Endpoint",
-        "description": "Create multiple runs for ``workspace_id`` and enqueue execution.",
+        "summary": "Create and enqueue runs in batch",
+        "description": "Create one run per document in `document_ids` and enqueue all runs as a single all-or-nothing operation.",
         "operationId": "create_workspace_runs_batch_endpoint_api_v1_workspaces__workspaceId__runs_batch_post",
         "parameters": [
           {
@@ -11336,7 +11491,8 @@
         "tags": [
           "runs"
         ],
-        "summary": "Get Workspace Run Endpoint",
+        "summary": "Get run details",
+        "description": "Return a single run resource for the requested workspace and run identifier.",
         "operationId": "get_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__get",
         "parameters": [
           {
@@ -11414,7 +11570,8 @@
         "tags": [
           "runs"
         ],
-        "summary": "Cancel Workspace Run Endpoint",
+        "summary": "Cancel a run",
+        "description": "Request cancellation for a run that is still cancellable.",
         "operationId": "cancel_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__cancel_post",
         "parameters": [
           {
@@ -11508,7 +11665,8 @@
         "tags": [
           "runs"
         ],
-        "summary": "Get Workspace Run Metrics Endpoint",
+        "summary": "Get run metrics",
+        "description": "Return derived run metrics from worker events, including evaluation, validation, and workbook statistics.",
         "operationId": "get_workspace_run_metrics_endpoint_api_v1_workspaces__workspaceId__runs__runId__metrics_get",
         "parameters": [
           {
@@ -11586,7 +11744,8 @@
         "tags": [
           "runs"
         ],
-        "summary": "List Workspace Run Fields Endpoint",
+        "summary": "List run field detection results",
+        "description": "Return field-level detection outcomes captured for the run.",
         "operationId": "list_workspace_run_fields_endpoint_api_v1_workspaces__workspaceId__runs__runId__fields_get",
         "parameters": [
           {
@@ -11668,7 +11827,8 @@
         "tags": [
           "runs"
         ],
-        "summary": "List Workspace Run Columns Endpoint",
+        "summary": "List run column mappings",
+        "description": "Return detected input columns and mapping metadata for the run.",
         "operationId": "list_workspace_run_columns_endpoint_api_v1_workspaces__workspaceId__runs__runId__columns_get",
         "parameters": [
           {
@@ -11837,6 +11997,7 @@
           "runs"
         ],
         "summary": "Get run input metadata",
+        "description": "Return the input document/version metadata associated with the run.",
         "operationId": "get_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_get",
         "parameters": [
           {
@@ -11915,6 +12076,7 @@
           "runs"
         ],
         "summary": "Download run input file",
+        "description": "Download the exact input file version used by this run.",
         "operationId": "download_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_download_get",
         "parameters": [
           {
@@ -11991,6 +12153,7 @@
           "runs"
         ],
         "summary": "Stream run events (SSE)",
+        "description": "Stream run events using Server-Sent Events. Use `cursor` or `Last-Event-ID` to resume from a prior position.",
         "operationId": "stream_workspace_run_events_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_stream_get",
         "parameters": [
           {
@@ -12094,6 +12257,7 @@
           "runs"
         ],
         "summary": "Download run events (NDJSON log)",
+        "description": "Download the persisted NDJSON event log for the run.",
         "operationId": "download_workspace_run_events_file_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_download_get",
         "parameters": [
           {
@@ -12178,6 +12342,7 @@
           "runs"
         ],
         "summary": "Get run output metadata",
+        "description": "Return output file metadata, readiness, and download link information.",
         "operationId": "get_workspace_run_output_metadata_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_get",
         "parameters": [
           {
@@ -12262,6 +12427,7 @@
           "runs"
         ],
         "summary": "Upload manual run output",
+        "description": "Upload an output artifact for a run managed manually outside worker execution.",
         "operationId": "upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post",
         "parameters": [
           {
@@ -12390,6 +12556,7 @@
           "runs"
         ],
         "summary": "Download run output file",
+        "description": "Download the latest output file artifact associated with the run.",
         "operationId": "download_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_download_get",
         "parameters": [
           {
@@ -12482,6 +12649,7 @@
           "runs"
         ],
         "summary": "List run output worksheets",
+        "description": "List worksheets available in the run output artifact when sheet introspection is supported.",
         "operationId": "list_workspace_run_output_sheets_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_sheets_get",
         "parameters": [
           {
@@ -12581,6 +12749,7 @@
           "runs"
         ],
         "summary": "Preview run output worksheet",
+        "description": "Return a bounded preview of run output worksheet data with optional sheet selection and trimming controls.",
         "operationId": "preview_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_preview_get",
         "parameters": [
           {

--- a/docs/how-to/api-authenticate-with-api-key.md
+++ b/docs/how-to/api-authenticate-with-api-key.md
@@ -1,0 +1,107 @@
+# Authenticate with API Key
+
+## Goal
+
+Verify API-key authentication against ADE and retrieve your caller profile.
+
+## Before You Start
+
+You need:
+
+- ADE API base URL
+- valid API key
+
+Set variables:
+
+```bash
+export BASE_URL="http://localhost:8001"
+export API_KEY="<your-api-key>"
+```
+
+```python
+import os
+
+BASE_URL = os.environ["BASE_URL"]
+API_KEY = os.environ["API_KEY"]
+```
+
+```powershell
+$env:BASE_URL = "http://localhost:8001"
+$env:API_KEY = "<your-api-key>"
+```
+
+## Steps
+
+### 1. Send a profile request with `X-API-Key`
+
+```bash
+curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/v1/me"
+```
+
+```python
+import requests
+
+response = requests.get(
+    f"{BASE_URL}/api/v1/me",
+    headers={"X-API-Key": API_KEY},
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json())
+```
+
+```powershell
+$headers = @{ "X-API-Key" = $env:API_KEY }
+$me = Invoke-RestMethod `
+  -Method Get `
+  -Uri "$($env:BASE_URL)/api/v1/me" `
+  -Headers $headers
+$me
+```
+
+### 2. Confirm workspace visibility (optional)
+
+```bash
+curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/v1/workspaces?limit=5"
+```
+
+```python
+response = requests.get(
+    f"{BASE_URL}/api/v1/workspaces",
+    headers={"X-API-Key": API_KEY},
+    params={"limit": 5},
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json())
+```
+
+```powershell
+$workspaces = Invoke-RestMethod `
+  -Method Get `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces?limit=5" `
+  -Headers $headers
+$workspaces
+```
+
+## Verify
+
+Authentication is working when:
+
+- `/api/v1/me` returns `200` with your user profile
+- `/api/v1/workspaces` returns `200` and a workspace list (or an empty list)
+
+## If Something Fails
+
+- `401 Unauthorized`: missing, revoked, or invalid API key.
+- `403 Forbidden`: key is valid but lacks the required permission/scope.
+- `404 Not Found`: incorrect base URL or API prefix.
+
+Notes:
+
+- API-key transport is `X-API-Key`.
+- `Authorization: Bearer <api-key>` is not the supported API-key transport.

--- a/docs/how-to/api-create-and-monitor-runs.md
+++ b/docs/how-to/api-create-and-monitor-runs.md
@@ -1,0 +1,156 @@
+# Create and Monitor Runs via API
+
+## Goal
+
+Create a run for an uploaded document, monitor progress, and retrieve run output metadata.
+
+## Before You Start
+
+You need:
+
+- `BASE_URL`
+- `API_KEY`
+- `WORKSPACE_ID`
+- `DOCUMENT_ID` for an existing uploaded document
+
+Set variables:
+
+```bash
+export BASE_URL="http://localhost:8001"
+export API_KEY="<your-api-key>"
+export WORKSPACE_ID="<workspace-uuid>"
+export DOCUMENT_ID="<document-uuid>"
+```
+
+```python
+import os
+
+BASE_URL = os.environ["BASE_URL"]
+API_KEY = os.environ["API_KEY"]
+WORKSPACE_ID = os.environ["WORKSPACE_ID"]
+DOCUMENT_ID = os.environ["DOCUMENT_ID"]
+```
+
+```powershell
+$env:BASE_URL = "http://localhost:8001"
+$env:API_KEY = "<your-api-key>"
+$env:WORKSPACE_ID = "<workspace-uuid>"
+$env:DOCUMENT_ID = "<document-uuid>"
+```
+
+## Steps
+
+### 1. Create a run
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"inputDocumentId\":\"$DOCUMENT_ID\",\"options\":{\"operation\":\"process\"}}" \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/runs"
+```
+
+```python
+import requests
+
+headers = {"X-API-Key": API_KEY, "Content-Type": "application/json"}
+payload = {
+    "inputDocumentId": DOCUMENT_ID,
+    "options": {"operation": "process"},
+}
+response = requests.post(
+    f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/runs",
+    headers=headers,
+    json=payload,
+    timeout=30,
+)
+response.raise_for_status()
+run = response.json()
+print(run["id"])
+```
+
+```powershell
+$headers = @{ "X-API-Key" = $env:API_KEY; "Content-Type" = "application/json" }
+$payload = @{
+  inputDocumentId = $env:DOCUMENT_ID
+  options = @{ operation = "process" }
+} | ConvertTo-Json -Depth 5
+
+$run = Invoke-RestMethod `
+  -Method Post `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/runs" `
+  -Headers $headers `
+  -Body $payload
+$run.id
+```
+
+### 2. Poll run status
+
+Set `RUN_ID` from step 1.
+
+```bash
+export RUN_ID="<run-uuid>"
+curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/runs/$RUN_ID"
+```
+
+```python
+RUN_ID = "<run-uuid>"
+response = requests.get(
+    f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/runs/{RUN_ID}",
+    headers={"X-API-Key": API_KEY},
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json()["status"])
+```
+
+```powershell
+$env:RUN_ID = "<run-uuid>"
+$status = Invoke-RestMethod `
+  -Method Get `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/runs/$($env:RUN_ID)" `
+  -Headers @{ "X-API-Key" = $env:API_KEY }
+$status.status
+```
+
+### 3. Read output metadata
+
+```bash
+curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/runs/$RUN_ID/output"
+```
+
+```python
+response = requests.get(
+    f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/runs/{RUN_ID}/output",
+    headers={"X-API-Key": API_KEY},
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json())
+```
+
+```powershell
+$output = Invoke-RestMethod `
+  -Method Get `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/runs/$($env:RUN_ID)/output" `
+  -Headers @{ "X-API-Key" = $env:API_KEY }
+$output
+```
+
+## Verify
+
+- Run creation returns `201` and a new run `id`.
+- Polling endpoint returns run lifecycle status (`queued`, `running`, `succeeded`, `failed`, or `cancelled`).
+- Output metadata endpoint reports readiness (`ready=true`) when output is available.
+
+## If Something Fails
+
+- `401 Unauthorized`: missing/invalid API key.
+- `403 Forbidden`: key lacks run permissions in workspace.
+- `404 Not Found`: workspace, document, or run ID is invalid.
+- `409 Conflict`: run cannot transition (for example cancel or output not ready).
+- `422 Unprocessable Content`: invalid run options or conflicting option values.

--- a/docs/how-to/api-manage-configurations.md
+++ b/docs/how-to/api-manage-configurations.md
@@ -1,0 +1,155 @@
+# Manage Configurations via API
+
+## Goal
+
+Create, inspect, and archive workspace configurations through the ADE API.
+
+## Before You Start
+
+You need:
+
+- `BASE_URL`
+- `API_KEY`
+- `WORKSPACE_ID`
+
+Set variables:
+
+```bash
+export BASE_URL="http://localhost:8001"
+export API_KEY="<your-api-key>"
+export WORKSPACE_ID="<workspace-uuid>"
+```
+
+```python
+import os
+
+BASE_URL = os.environ["BASE_URL"]
+API_KEY = os.environ["API_KEY"]
+WORKSPACE_ID = os.environ["WORKSPACE_ID"]
+```
+
+```powershell
+$env:BASE_URL = "http://localhost:8001"
+$env:API_KEY = "<your-api-key>"
+$env:WORKSPACE_ID = "<workspace-uuid>"
+```
+
+## Steps
+
+### 1. List configurations
+
+```bash
+curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/configurations?limit=20"
+```
+
+```python
+import requests
+
+headers = {"X-API-Key": API_KEY}
+response = requests.get(
+    f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/configurations",
+    headers=headers,
+    params={"limit": 20},
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json())
+```
+
+```powershell
+$headers = @{ "X-API-Key" = $env:API_KEY }
+$configs = Invoke-RestMethod `
+  -Method Get `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/configurations?limit=20" `
+  -Headers $headers
+$configs
+```
+
+### 2. Create a draft from template
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"displayName":"API Draft Config","source":{"type":"template"},"notes":"created from API"}' \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/configurations"
+```
+
+```python
+payload = {
+    "displayName": "API Draft Config",
+    "source": {"type": "template"},
+    "notes": "created from API",
+}
+response = requests.post(
+    f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/configurations",
+    headers={"X-API-Key": API_KEY, "Content-Type": "application/json"},
+    json=payload,
+    timeout=30,
+)
+response.raise_for_status()
+configuration = response.json()
+print(configuration["id"])
+```
+
+```powershell
+$payload = @{
+  displayName = "API Draft Config"
+  source = @{ type = "template" }
+  notes = "created from API"
+} | ConvertTo-Json -Depth 5
+$jsonHeaders = @{ "X-API-Key" = $env:API_KEY; "Content-Type" = "application/json" }
+
+$config = Invoke-RestMethod `
+  -Method Post `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/configurations" `
+  -Headers $jsonHeaders `
+  -Body $payload
+$config.id
+```
+
+### 3. Archive a configuration
+
+Set `CONFIGURATION_ID` to a draft or active configuration you want to archive.
+
+```bash
+export CONFIGURATION_ID="<configuration-uuid>"
+curl -sS -X POST \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/configurations/$CONFIGURATION_ID/archive"
+```
+
+```python
+CONFIGURATION_ID = "<configuration-uuid>"
+response = requests.post(
+    f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/configurations/{CONFIGURATION_ID}/archive",
+    headers={"X-API-Key": API_KEY},
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json()["status"])
+```
+
+```powershell
+$env:CONFIGURATION_ID = "<configuration-uuid>"
+$archived = Invoke-RestMethod `
+  -Method Post `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/configurations/$($env:CONFIGURATION_ID)/archive" `
+  -Headers $headers
+$archived.status
+```
+
+## Verify
+
+- List endpoint shows the new or archived configuration status.
+- Archived records should report `status` as archived in the response payload.
+
+## If Something Fails
+
+- `401 Unauthorized`: missing/invalid API key.
+- `403 Forbidden`: key lacks workspace configuration permissions.
+- `404 Not Found`: workspace/configuration ID not found.
+- `409 Conflict`: attempted mutation is invalid for current configuration state.
+- `422 Unprocessable Content`: payload shape or source configuration data is invalid.

--- a/docs/how-to/api-upload-and-queue-runs.md
+++ b/docs/how-to/api-upload-and-queue-runs.md
@@ -1,0 +1,296 @@
+# Upload a Document and Queue Runs
+
+## Goal
+
+Upload a document with API key auth and queue a run with sheet-selection options.
+
+## Before You Start
+
+You need:
+
+- ADE already running
+- a valid API key for a user with workspace document upload permissions
+- target workspace ID
+- input file path
+
+Set required variables:
+
+```bash
+export BASE_URL="http://localhost:8001"
+export API_KEY="<your-api-key>"
+export WORKSPACE_ID="<workspace-uuid>"
+export INPUT_FILE="/absolute/path/to/input.xlsx"
+```
+
+```python
+import os
+
+BASE_URL = os.environ["BASE_URL"]
+API_KEY = os.environ["API_KEY"]
+WORKSPACE_ID = os.environ["WORKSPACE_ID"]
+INPUT_FILE = os.environ["INPUT_FILE"]
+```
+
+```powershell
+$env:BASE_URL = "http://localhost:8001"
+$env:API_KEY = "<your-api-key>"
+$env:WORKSPACE_ID = "<workspace-uuid>"
+$env:INPUT_FILE = "C:\path\to\input.xlsx"
+```
+
+Run queueing preconditions:
+
+- the workspace has an active configuration
+- workspace processing is not paused
+
+## Steps
+
+### 1. Auth (API key)
+
+Send a quick request with `X-API-Key`:
+
+```bash
+curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/v1/me"
+```
+
+```python
+import requests
+
+response = requests.get(
+    f"{BASE_URL}/api/v1/me",
+    headers={"X-API-Key": API_KEY},
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json()["email"])
+```
+
+```powershell
+$headers = @{ "X-API-Key" = $env:API_KEY }
+$me = Invoke-RestMethod `
+  -Method Get `
+  -Uri "$($env:BASE_URL)/api/v1/me" `
+  -Headers $headers
+$me.email
+```
+
+### 2. Upload and queue a run
+
+`POST /api/v1/workspaces/{workspaceId}/documents` accepts multipart form fields:
+
+- `file` (required)
+- `metadata` (optional JSON string)
+- `run_options` (optional JSON string)
+- `conflictMode` (optional: `reject`, `upload_new_version`, `keep_both`)
+
+`run_options` keys should use API-style names:
+
+- `activeSheetOnly`
+- `inputSheetNames`
+
+Do not send both in the same request.
+
+#### Example A: default upload behavior
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: $API_KEY" \
+  -F "file=@$INPUT_FILE" \
+  -F 'metadata={"source":"api-guide","mode":"default"}' \
+  -F "conflictMode=keep_both" \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/documents"
+```
+
+```python
+import json
+from pathlib import Path
+
+import requests
+
+with Path(INPUT_FILE).open("rb") as file_handle:
+    response = requests.post(
+        f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/documents",
+        headers={"X-API-Key": API_KEY},
+        files={"file": (Path(INPUT_FILE).name, file_handle)},
+        data={
+            "metadata": json.dumps({"source": "api-guide", "mode": "default"}),
+            "conflictMode": "keep_both",
+        },
+        timeout=120,
+    )
+response.raise_for_status()
+print(response.json()["id"])
+```
+
+```powershell
+$headers = @{ "X-API-Key" = $env:API_KEY }
+$upload = Invoke-RestMethod `
+  -Method Post `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/documents" `
+  -Headers $headers `
+  -Form @{
+    file = Get-Item $env:INPUT_FILE
+    metadata = '{"source":"api-guide","mode":"default"}'
+    conflictMode = "keep_both"
+  }
+$upload.id
+```
+
+#### Example B: queue run with active sheet only
+
+Use this for XLSX uploads when the run should process only the workbook's active sheet.
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: $API_KEY" \
+  -F "file=@$INPUT_FILE" \
+  -F 'metadata={"source":"api-guide","mode":"active-sheet-only"}' \
+  -F 'run_options={"activeSheetOnly":true}' \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/documents"
+```
+
+```python
+import json
+from pathlib import Path
+
+import requests
+
+with Path(INPUT_FILE).open("rb") as file_handle:
+    response = requests.post(
+        f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/documents",
+        headers={"X-API-Key": API_KEY},
+        files={"file": (Path(INPUT_FILE).name, file_handle)},
+        data={
+            "metadata": json.dumps({"source": "api-guide", "mode": "active-sheet-only"}),
+            "run_options": json.dumps({"activeSheetOnly": True}),
+        },
+        timeout=120,
+    )
+response.raise_for_status()
+print(response.json()["id"])
+```
+
+```powershell
+$headers = @{ "X-API-Key" = $env:API_KEY }
+$upload = Invoke-RestMethod `
+  -Method Post `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/documents" `
+  -Headers $headers `
+  -Form @{
+    file = Get-Item $env:INPUT_FILE
+    metadata = '{"source":"api-guide","mode":"active-sheet-only"}'
+    run_options = '{"activeSheetOnly":true}'
+  }
+$upload.id
+```
+
+#### Example C: queue run with specific sheets
+
+Use this for XLSX uploads when the run should process only named sheets.
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: $API_KEY" \
+  -F "file=@$INPUT_FILE" \
+  -F 'metadata={"source":"api-guide","mode":"selected-sheets"}' \
+  -F 'run_options={"inputSheetNames":["Sheet1","Sheet2"]}' \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/documents"
+```
+
+```python
+import json
+from pathlib import Path
+
+import requests
+
+with Path(INPUT_FILE).open("rb") as file_handle:
+    response = requests.post(
+        f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/documents",
+        headers={"X-API-Key": API_KEY},
+        files={"file": (Path(INPUT_FILE).name, file_handle)},
+        data={
+            "metadata": json.dumps({"source": "api-guide", "mode": "selected-sheets"}),
+            "run_options": json.dumps({"inputSheetNames": ["Sheet1", "Sheet2"]}),
+        },
+        timeout=120,
+    )
+response.raise_for_status()
+print(response.json()["id"])
+```
+
+```powershell
+$headers = @{ "X-API-Key" = $env:API_KEY }
+$upload = Invoke-RestMethod `
+  -Method Post `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/documents" `
+  -Headers $headers `
+  -Form @{
+    file = Get-Item $env:INPUT_FILE
+    metadata = '{"source":"api-guide","mode":"selected-sheets"}'
+    run_options = '{"inputSheetNames":["Sheet1","Sheet2"]}'
+  }
+$upload.id
+```
+
+## Verify the Run Was Queued
+
+List documents and inspect `lastRun` for the uploaded document:
+
+```bash
+curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/api/v1/workspaces/$WORKSPACE_ID/documents?limit=20"
+```
+
+```python
+import requests
+
+response = requests.get(
+    f"{BASE_URL}/api/v1/workspaces/{WORKSPACE_ID}/documents",
+    headers={"X-API-Key": API_KEY},
+    params={"limit": 20},
+    timeout=30,
+)
+response.raise_for_status()
+
+for document in response.json().get("items", []):
+    last_run = document.get("lastRun")
+    if last_run:
+        print(document["name"], last_run["id"], last_run["status"])
+```
+
+```powershell
+$headers = @{ "X-API-Key" = $env:API_KEY }
+$docs = Invoke-RestMethod `
+  -Method Get `
+  -Uri "$($env:BASE_URL)/api/v1/workspaces/$($env:WORKSPACE_ID)/documents?limit=20" `
+  -Headers $headers
+
+foreach ($doc in $docs.items) {
+  if ($null -ne $doc.lastRun) {
+    "$($doc.name) $($doc.lastRun.id) $($doc.lastRun.status)"
+  }
+}
+```
+
+Upload can succeed while no run is queued. Common reasons:
+
+- no active configuration in the workspace
+- workspace processing is paused
+
+## If Something Fails
+
+- `401 Unauthorized`: API key missing, revoked, or invalid.
+- `403 Forbidden`: key does not have workspace upload permissions.
+- `400 Bad Request`: malformed `run_options` JSON or invalid sheet option combination.
+- `413 Content Too Large`: file exceeds upload size limit.
+- `429 Too Many Requests`: upload concurrency limit reached.
+- `409 Conflict`: duplicate document name when `conflictMode=reject`.
+
+## Notes
+
+- API key transport is `X-API-Key`.
+- `Authorization: Bearer <api-key>` is not a supported API-key transport.
+- PowerShell examples assume PowerShell 7+ (`Invoke-RestMethod -Form`).

--- a/docs/how-to/upload-and-queue-runs-via-api-key.md
+++ b/docs/how-to/upload-and-queue-runs-via-api-key.md
@@ -1,0 +1,7 @@
+# Upload and Queue Runs via API Key (Moved)
+
+This guide moved to a standardized API how-to page:
+
+- [Upload a Document and Queue Runs](api-upload-and-queue-runs.md)
+
+Use the new page for current examples and troubleshooting guidance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,14 @@ This documentation is written for people who operate ADE in production and contr
 5. [System Architecture](explanation/system-architecture.md)
 6. [Documentation Maintenance](standards/documentation-maintenance.md)
 
+### API Integrator Path
+
+1. [API Reference Hub](reference/api/index.md)
+2. [Authenticate with API Key](how-to/api-authenticate-with-api-key.md)
+3. [Manage Configurations via API](how-to/api-manage-configurations.md)
+4. [Upload a Document and Queue Runs](how-to/api-upload-and-queue-runs.md)
+5. [Create and Monitor Runs via API](how-to/api-create-and-monitor-runs.md)
+
 ## I Need To
 
 | Task | Go To |
@@ -44,6 +52,11 @@ This documentation is written for people who operate ADE in production and contr
 | Manage users and permissions | [Manage Users and Access](how-to/manage-users-and-access.md) |
 | Operate auth and SSO policy | [Auth Operations Runbook](how-to/auth-operations.md) |
 | Run auth rollout smoke checks | [Auth Rollout and Smoke Checklist](how-to/auth-rollout-and-smoke-checklist.md) |
+| Authenticate API requests with API key | [Authenticate with API Key](how-to/api-authenticate-with-api-key.md) |
+| Manage configuration lifecycle through API | [Manage Configurations via API](how-to/api-manage-configurations.md) |
+| Upload documents and queue runs via API | [Upload a Document and Queue Runs](how-to/api-upload-and-queue-runs.md) |
+| Create and monitor runs via API | [Create and Monitor Runs via API](how-to/api-create-and-monitor-runs.md) |
+| Explore API endpoint contracts | [API Reference Hub](reference/api/index.md) |
 | Understand run states and retries | [Runtime Lifecycle](reference/runtime-lifecycle.md) |
 | Respond to auth incidents | [Auth Incident Runbook](troubleshooting/auth-incident-runbook.md) |
 | Troubleshoot quickly | [Triage Playbook](troubleshooting/triage-playbook.md) |
@@ -65,6 +78,10 @@ This documentation is written for people who operate ADE in production and contr
   - [Manage Users and Access](how-to/manage-users-and-access.md)
   - [Auth Operations Runbook](how-to/auth-operations.md)
   - [Auth Rollout and Smoke Checklist](how-to/auth-rollout-and-smoke-checklist.md)
+  - [Authenticate with API Key](how-to/api-authenticate-with-api-key.md)
+  - [Manage Configurations via API](how-to/api-manage-configurations.md)
+  - [Upload a Document and Queue Runs](how-to/api-upload-and-queue-runs.md)
+  - [Create and Monitor Runs via API](how-to/api-create-and-monitor-runs.md)
   - [Operate Runs](how-to/operate-runs.md)
 - Troubleshooting
   - [Triage Playbook](troubleshooting/triage-playbook.md)
@@ -76,6 +93,13 @@ This documentation is written for people who operate ADE in production and contr
   - [Auth Architecture](reference/auth-architecture.md)
   - [Environment Variables](reference/environment-variables.md)
   - [API Capability Map](reference/api-capability-map.md)
+  - [API Reference Hub](reference/api/index.md)
+  - [API Authentication](reference/api/authentication.md)
+  - [API Workspaces](reference/api/workspaces.md)
+  - [API Configurations](reference/api/configurations.md)
+  - [API Documents](reference/api/documents.md)
+  - [API Runs](reference/api/runs.md)
+  - [API Errors and Problem Details](reference/api/errors-and-problem-details.md)
   - [Defaults Matrix](reference/defaults-matrix.md)
   - [Runtime Lifecycle](reference/runtime-lifecycle.md)
   - [Release Process](reference/release-process.md)

--- a/docs/reference/api-capability-map.md
+++ b/docs/reference/api-capability-map.md
@@ -2,47 +2,69 @@
 
 ## Purpose
 
-This page gives a plain-language map of what the API can do.
+This page gives a high-level API map and points to detailed workflow references.
 
-Use OpenAPI output for exact request/response schemas.
+Use this page to choose where to read next. Use API reference pages for endpoint details.
+
+## Scope Boundary
+
+This map is intentionally high-level.
+
+For request/response schemas, examples, and endpoint-specific behavior, use:
+
+- [API Reference Hub](api/index.md)
+- [Authentication API](api/authentication.md)
+- [Workspaces API](api/workspaces.md)
+- [Configurations API](api/configurations.md)
+- [Documents API](api/documents.md)
+- [Runs API](api/runs.md)
+- [Errors and Problem Details](api/errors-and-problem-details.md)
 
 ## How to Discover Current Routes
 
 ```bash
-cd backend && uv run ade-api routes
-cd backend && uv run ade-api types
+cd backend
+uv run ade-api routes
+uv run ade api types
 ```
 
 ## Capability Areas
 
-| Area | Typical URL prefixes | Main use |
-| --- | --- | --- |
-| Auth | `/api/v1/auth/*`, `/api/v1/me*` | sign-in, session bootstrap, provider discovery |
-| Workspaces | `/api/v1/workspaces*` | create/update workspaces, manage members |
-| Configurations | `/api/v1/workspaces/{workspaceId}/configurations*` | create/validate/publish config packages |
-| Documents | `/api/v1/workspaces/{workspaceId}/documents*` | upload, list, update, tag, preview documents |
-| Runs | `/api/v1/runs*`, `/api/v1/workspaces/{workspaceId}/runs*` | start runs, inspect status, fetch output |
-| Roles/Permissions | `/api/v1/roles*`, `/api/v1/permissions*` | access-control management |
-| System | `/api/v1/system/safemode` | view/change safe mode |
-| Health/Meta | `/api/v1/health`, `/api/v1/info`, `/api/v1/meta/versions` | health and version info |
+| Area | Typical URL prefixes | Main use | Detailed reference |
+| --- | --- | --- | --- |
+| Auth | `/api/v1/auth/*`, `/api/v1/me*` | sign-in, session bootstrap, API-key identity checks | [Authentication API](api/authentication.md) |
+| Workspaces | `/api/v1/workspaces*` | create/update workspaces, manage members | [Workspaces API](api/workspaces.md) |
+| Configurations | `/api/v1/workspaces/{workspaceId}/configurations*` | draft/import/archive configurations and manage config files | [Configurations API](api/configurations.md) |
+| Documents | `/api/v1/workspaces/{workspaceId}/documents*` | upload, version, tag, preview, and stream document changes | [Documents API](api/documents.md) |
+| Runs | `/api/v1/workspaces/{workspaceId}/runs*` | create runs, monitor status, stream events, download output | [Runs API](api/runs.md) |
+| Roles/Permissions | `/api/v1/roles*`, `/api/v1/permissions*`, `/api/v1/roleassignments*` | access-control administration | [Manage Users and Access](../how-to/manage-users-and-access.md) |
+| System | `/api/v1/system/safemode` | view/change safe mode | [Auth Operations Runbook](../how-to/auth-operations.md) |
+| Health/Meta | `/api/v1/health`, `/api/v1/info`, `/api/v1/meta/versions` | health checks and runtime metadata | [CLI Reference](cli-reference.md) |
 
 ## Common Flows
 
-### First Login Setup
+### API-Key Integration Setup
 
-1. Check `/api/v1/auth/setup`.
-2. Create first admin if setup is incomplete.
-3. Sign in and load `/api/v1/me/bootstrap`.
+1. Validate key transport with `GET /api/v1/me`.
+2. Confirm workspace scope with `GET /api/v1/workspaces`.
+3. Continue with workflow-specific guides.
+
+Use: [Authenticate with API Key](../how-to/api-authenticate-with-api-key.md)
 
 ### Document to Output
 
-1. Upload a document.
-2. Start a run.
-3. Poll or stream run updates.
-4. Download output.
+1. Upload document: `POST /api/v1/workspaces/{workspaceId}/documents`.
+2. Queue run automatically via upload options or explicitly via run create endpoint.
+3. Monitor run: `GET /api/v1/workspaces/{workspaceId}/runs/{runId}`.
+4. Download output: `GET /api/v1/workspaces/{workspaceId}/runs/{runId}/output/download`.
 
-### Access Administration
+Use: [Upload a Document and Queue Runs](../how-to/api-upload-and-queue-runs.md) and [Create and Monitor Runs](../how-to/api-create-and-monitor-runs.md)
 
-1. Create/update users.
-2. Assign roles (global or workspace).
-3. Verify effective permissions.
+### Configuration Lifecycle
+
+1. List workspace configurations.
+2. Create draft (template/clone/import).
+3. Update files as needed.
+4. Archive superseded configurations.
+
+Use: [Manage Configurations via API](../how-to/api-manage-configurations.md)

--- a/docs/reference/api/authentication.md
+++ b/docs/reference/api/authentication.md
@@ -1,0 +1,81 @@
+# Authentication API Reference
+
+## Purpose
+
+Document auth/session endpoints and API-key access checks for ADE integrations.
+
+## Authentication Requirements
+
+ADE supports two authentication transports:
+
+- API key header: `X-API-Key: <key>`
+- Session cookie: browser session cookie issued by interactive auth flows
+
+For service integrations, use `X-API-Key`.
+
+## Endpoint Matrix
+
+### Auth Endpoints
+
+| Method | Path | Auth | Primary status | Request shape | Response shape | Common errors |
+| --- | --- | --- | --- | --- | --- | --- |
+| `POST` | `/api/v1/auth/login` | public | `200` | JSON: email/password | JSON: auth state (`success` or MFA challenge) | `401` invalid credentials |
+| `POST` | `/api/v1/auth/logout` | protected | `204` | no body | empty | `401` missing auth, `403` CSRF |
+| `POST` | `/api/v1/auth/mfa/challenge/verify` | public | `200` | JSON: challenge token + code | JSON: auth success | `400`, `401` invalid challenge/code |
+| `GET` | `/api/v1/auth/mfa/totp` | protected | `200` | none | JSON: MFA status | `401` |
+| `DELETE` | `/api/v1/auth/mfa/totp` | protected | `204` | none | empty | `401`, `403` CSRF |
+| `POST` | `/api/v1/auth/mfa/totp/enroll/confirm` | protected | `200` | JSON: enrollment code | JSON: recovery codes | `400`, `401`, `403` |
+| `POST` | `/api/v1/auth/mfa/totp/enroll/start` | protected | `200` | none | JSON: OTP URI metadata | `401`, `403` |
+| `POST` | `/api/v1/auth/mfa/totp/recovery/regenerate` | protected | `200` | JSON: current code | JSON: new recovery codes | `400`, `401`, `403` |
+| `POST` | `/api/v1/auth/password/forgot` | public | `202` | JSON: email | empty | `400` invalid payload |
+| `POST` | `/api/v1/auth/password/reset` | public | `204` | JSON: reset token + new password | empty | `400` token invalid/expired |
+| `GET` | `/api/v1/auth/providers` | public | `200` | none | JSON: provider list | none typical |
+| `GET` | `/api/v1/auth/setup` | public | `200` | none | JSON: setup state | none typical |
+| `POST` | `/api/v1/auth/setup` | public | `204` | JSON: first-admin payload | empty + session cookies | `409` setup already completed |
+| `GET` | `/api/v1/auth/sso/authorize` | public | `200` | query: `returnTo` optional | redirect or JSON status | `429` throttled, provider errors |
+| `GET` | `/api/v1/auth/sso/callback` | public | `200` | query: `code`/`state` | redirect or JSON status | provider validation failures |
+| `GET` | `/api/v1/auth/sso/providers` | public | `200` | none | JSON: active SSO providers | none typical |
+
+### Me Endpoints
+
+| Method | Path | Auth | Primary status | Request shape | Response shape | Common errors |
+| --- | --- | --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/me` | protected | `200` | none | JSON: current user profile | `401`, `403` service account |
+| `PATCH` | `/api/v1/me` | protected | `200` | JSON: editable profile fields | JSON: updated profile | `401`, `403`, `422` invalid patch |
+| `GET` | `/api/v1/me/bootstrap` | protected | `200` | none | JSON: profile + roles + permissions + workspaces | `401`, `403` |
+| `GET` | `/api/v1/me/permissions` | protected | `200` | none | JSON: effective permissions | `401` |
+| `POST` | `/api/v1/me/permissions/check` | protected | `200` | JSON: permissions to evaluate | JSON: evaluation result | `401`, `404`, `422` |
+
+## Core Endpoint Details
+
+### `POST /api/v1/auth/login`
+
+- Request body: local credentials.
+- Response: session success payload or MFA challenge payload.
+- Cookies: session and CSRF cookies are set on success.
+
+### `GET /api/v1/me`
+
+- Preferred API-key smoke test endpoint.
+- Request: include `X-API-Key`.
+- Response: profile fields for the authenticated principal.
+
+### `GET /api/v1/auth/providers`
+
+- Public provider discovery endpoint.
+- Useful for login UX decisions before calling interactive auth routes.
+
+## Error Handling
+
+Auth endpoints can return standard Problem Details responses.
+
+- `401 Unauthorized`: missing, expired, or invalid credentials.
+- `403 Forbidden`: principal authenticated but lacks required access or CSRF requirements.
+- `409 Conflict`: setup/auth flow state conflict.
+- `429 Too Many Requests`: rate limiting for SSO/auth hardening.
+
+See [Errors and Problem Details](errors-and-problem-details.md) for shared error format.
+
+## Related Guides
+
+- [Authenticate with API Key](../../how-to/api-authenticate-with-api-key.md)

--- a/docs/reference/api/configurations.md
+++ b/docs/reference/api/configurations.md
@@ -1,0 +1,64 @@
+# Configurations API Reference
+
+## Purpose
+
+Document configuration lifecycle and configuration file-management endpoints.
+
+## Authentication Requirements
+
+All configuration endpoints are protected and scoped to workspace permissions.
+
+## Endpoint Matrix
+
+| Method | Path | Auth | Primary status | Request shape | Response shape | Common errors |
+| --- | --- | --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/workspaces/{workspaceId}/configurations` | protected | `200` | path + cursor/search/sort | cursor page of configurations | `401`, `403` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/configurations` | protected | `201` | path + JSON create payload | configuration record | `401`, `403`, `404`, `409`, `422` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/configurations/history` | protected | `200` | path + history filters | configuration timeline payload | `401`, `403`, `404`, `422` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/configurations/import` | protected | `201` | path + multipart archive upload | configuration record | `400`, `401`, `403`, `409`, `413`, `422` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}` | protected | `200` | path | configuration record + `ETag` | `401`, `403`, `404` |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}` | protected | `200` | path + JSON metadata patch | configuration record | `401`, `403`, `404`, `409` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/archive` | protected | `200` | path | configuration record | `401`, `403`, `404`, `409` |
+| `PUT` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/directories/{directoryPath}` | protected | `200` | path | directory write response | `400`, `401`, `403`, `404`, `409` |
+| `DELETE` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/directories/{directoryPath}` | protected | `204` | path + optional `recursive` query | empty | `400`, `401`, `403`, `404`, `409` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/export` | protected | `200` | path + optional `format=zip` | ZIP stream | `400`, `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/files` | protected | `200` | path + listing filters | file listing payload | `400`, `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/files/{filePath}` | protected | `200` | path + optional `format` | file bytes or JSON payload | `400`, `401`, `403`, `404`, `416` |
+| `PUT` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/files/{filePath}` | protected | `200` | path + raw body + conditional headers | file write response | `400`, `401`, `403`, `404`, `409`, `412`, `413`, `428` |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/files/{filePath}` | protected | `200` | path + JSON move payload | file rename response | `400`, `401`, `403`, `404`, `409`, `412`, `428` |
+| `DELETE` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/files/{filePath}` | protected | `204` | path + optional `If-Match` | empty | `400`, `401`, `403`, `404`, `409`, `412`, `428` |
+| `PUT` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/import` | protected | `200` | path + multipart archive + `If-Match` | configuration record | `400`, `401`, `403`, `404`, `409`, `412`, `413`, `422`, `428` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/configurations/{configurationId}/restore` | protected | `201` | path + JSON restore payload | configuration record | `401`, `403`, `404`, `409`, `422` |
+
+## Core Endpoint Details
+
+### `POST /api/v1/workspaces/{workspaceId}/configurations`
+
+- Creates a new draft configuration from template or clone source.
+- Response includes configuration lifecycle metadata.
+
+### `POST /api/v1/workspaces/{workspaceId}/configurations/import`
+
+- Imports a configuration archive into a new draft.
+- Large archives can return `413 Content Too Large`.
+
+### `GET /api/v1/workspaces/{workspaceId}/configurations/{configurationId}/files`
+
+- Returns editable file/directory structure for the selected draft.
+- Supports prefix/depth/filter cursor controls for large config trees.
+
+## Error Handling
+
+- `401 Unauthorized`: auth missing or invalid.
+- `403 Forbidden`: missing workspace configuration permissions.
+- `404 Not Found`: workspace/config/resource not found.
+- `409 Conflict`: state conflicts (for example non-editable draft state).
+- `412 Precondition Failed` / `428 Precondition Required`: optimistic concurrency failures.
+- `413 Content Too Large`: archive/file size exceeds configured limit.
+- `422 Unprocessable Content`: invalid source/archive shape.
+
+See [Errors and Problem Details](errors-and-problem-details.md) for shared response format.
+
+## Related Guides
+
+- [Manage Configurations](../../how-to/api-manage-configurations.md)

--- a/docs/reference/api/documents.md
+++ b/docs/reference/api/documents.md
@@ -1,0 +1,79 @@
+# Documents API Reference
+
+## Purpose
+
+Document endpoints for document upload, metadata management, tagging, comments, views, and content retrieval.
+
+## Authentication Requirements
+
+All document endpoints are protected and require workspace document permissions.
+
+## Endpoint Matrix
+
+| Method | Path | Auth | Primary status | Request shape | Response shape | Common errors |
+| --- | --- | --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents` | protected | `200` | path + cursor/search/filter | cursor page of document rows | `401`, `403` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/documents` | protected | `201` | path + multipart (`file`, optional `metadata`, `run_options`, `conflictMode`) | document record | `400`, `401`, `403`, `409`, `413`, `429` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/documents/batch/delete` | protected | `200` | path + JSON `documentIds` | batch delete response | `400`, `401`, `403`, `404` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/documents/batch/restore` | protected | `200` | path + JSON `documentIds` | batch restore response | `400`, `401`, `403`, `404` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/documents/batch/tags` | protected | `200` | path + JSON add/remove tags | batch tag response | `400`, `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/delta` | protected | `200` | path + token/limit query | delta changes payload | `400`, `401`, `403` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/stream` | protected | `200` | path + optional cursor query | SSE stream | `401`, `403` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/tags` | protected | `200` | path + paging query | tag catalog page | `401`, `403` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/views` | protected | `200` | path + pagination query | saved view list | `401`, `403` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/documents/views` | protected | `201` | path + JSON view create payload | saved view record | `400`, `401`, `403`, `409` |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/documents/views/{viewId}` | protected | `200` | path + JSON view patch | saved view record | `400`, `401`, `403`, `404`, `409` |
+| `DELETE` | `/api/v1/workspaces/{workspaceId}/documents/views/{viewId}` | protected | `204` | path | empty | `401`, `403`, `404`, `409` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}` | protected | `200` | path | document record | `401`, `403`, `404` |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}` | protected | `200` | path + JSON patch | document record | `400`, `401`, `403`, `404`, `409` |
+| `DELETE` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}` | protected | `204` | path | empty | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/comments` | protected | `200` | path + pagination query | comment page | `401`, `403`, `404` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/comments` | protected | `201` | path + JSON comment payload | comment record | `400`, `401`, `403`, `404`, `422` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/download` | protected | `200` | path | file stream | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/listrow` | protected | `200` | path | document list-row projection | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/original/download` | protected | `200` | path | original file stream | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/preview` | protected | `200` | path + sheet preview query | workbook preview payload | `401`, `403`, `404`, `415`, `422` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/restore` | protected | `200` | path | restored document record | `401`, `403`, `404`, `409` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/sheets` | protected | `200` | path | sheet list payload | `401`, `403`, `404`, `415`, `422` |
+| `PUT` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/tags` | protected | `200` | path + JSON full tag set | document record | `400`, `401`, `403`, `404` |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/tags` | protected | `200` | path + JSON add/remove tags | document record | `400`, `401`, `403`, `404` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/versions` | protected | `201` | path + multipart file/version fields | document record | `400`, `401`, `403`, `404`, `413`, `409` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/documents/{documentId}/versions/{versionNo}/download` | protected | `200` | path | specific version stream | `401`, `403`, `404` |
+
+## Core Endpoint Details
+
+### `POST /api/v1/workspaces/{workspaceId}/documents`
+
+- Multipart upload endpoint used by API integrations and the web upload workflow.
+- `run_options` accepts JSON string values with API keys:
+  - `activeSheetOnly`
+  - `inputSheetNames`
+- `activeSheetOnly` and `inputSheetNames` are mutually exclusive in one request.
+
+### `GET /api/v1/workspaces/{workspaceId}/documents`
+
+- Primary endpoint for verifying upload outcomes and checking `lastRun` metadata.
+- Supports filtering, search, pagination, and sorting.
+
+### `POST /api/v1/workspaces/{workspaceId}/documents/{documentId}/versions`
+
+- Uploads a new version for an existing document identity.
+- Use this when replacing file content while preserving document metadata history.
+
+## Error Handling
+
+- `400 Bad Request`: invalid JSON metadata/run options or invalid filters.
+- `401 Unauthorized`: missing/invalid auth credentials.
+- `403 Forbidden`: workspace permissions missing.
+- `404 Not Found`: workspace/document/view/version not found.
+- `409 Conflict`: naming/state conflicts for uploads or restores.
+- `413 Content Too Large`: upload exceeds configured size limit.
+- `415 Unsupported Media Type`: preview/sheet introspection not supported for file type.
+- `422 Unprocessable Content`: document parse or validation errors.
+- `429 Too Many Requests`: upload concurrency/rate limits.
+
+See [Errors and Problem Details](errors-and-problem-details.md) for shared response format.
+
+## Related Guides
+
+- [Upload a Document and Queue Runs](../../how-to/api-upload-and-queue-runs.md)

--- a/docs/reference/api/errors-and-problem-details.md
+++ b/docs/reference/api/errors-and-problem-details.md
@@ -1,0 +1,80 @@
+# Errors and Problem Details
+
+## Purpose
+
+Describe ADE API error payload conventions and common remediation paths.
+
+## Error Envelope
+
+ADE uses Problem Details style responses for many non-2xx results.
+
+Typical media type:
+
+- `application/problem+json`
+
+Typical fields:
+
+- `type`: URI-like identifier for error category
+- `title`: short error label
+- `status`: HTTP status code
+- `detail`: optional human-readable explanation
+- `instance`: request instance path
+- `requestId`: server-side request correlation ID
+- `errors`: optional field-level details
+
+## Shared Response Headers
+
+- `X-Request-Id`: request correlation identifier for support and tracing
+- `ETag`: present on select read responses that support optimistic concurrency
+
+## Common Status Codes
+
+| Status | Meaning | Typical cause | Common fix |
+| --- | --- | --- | --- |
+| `400` | Bad Request | malformed JSON/form/query payload | validate payload shape and field names |
+| `401` | Unauthorized | missing/revoked/invalid API key or session | send valid `X-API-Key` or refresh auth |
+| `403` | Forbidden | auth present but permission/CSRF requirement not met | grant required role/scope, include CSRF where needed |
+| `404` | Not Found | workspace/resource not found in scope | verify identifiers and workspace access |
+| `409` | Conflict | state transition not allowed | re-read resource state and retry valid transition |
+| `412` | Precondition Failed | stale `If-Match` token | fetch latest ETag and retry |
+| `413` | Content Too Large | upload exceeds configured limit | reduce file/archive size |
+| `415` | Unsupported Media Type | requested preview/worksheet feature unsupported | use compatible file type or fallback route |
+| `422` | Unprocessable Content | payload validates structurally but violates rules | fix semantic validation issues |
+| `428` | Precondition Required | concurrency header required | include `If-Match`/`If-None-Match` as required |
+| `429` | Too Many Requests | request throttled | retry with backoff |
+
+## Example Problem Details Payload
+
+```json
+{
+  "type": "https://ade.dev/problems/validation",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "run_options cannot combine activeSheetOnly and inputSheetNames",
+  "instance": "/api/v1/workspaces/01J.../documents",
+  "requestId": "req_01J...",
+  "errors": [
+    {
+      "path": "run_options.activeSheetOnly",
+      "message": "activeSheetOnly cannot be combined with inputSheetNames",
+      "code": "invalid_combination"
+    }
+  ]
+}
+```
+
+## Concurrency Notes
+
+Some endpoints require ETag-based optimistic concurrency:
+
+- Read endpoint returns `ETag`.
+- Mutation endpoint requires `If-Match`.
+- Server returns `412` or `428` when tokens are stale/missing.
+
+## Related Pages
+
+- [Authentication](authentication.md)
+- [Workspaces](workspaces.md)
+- [Configurations](configurations.md)
+- [Documents](documents.md)
+- [Runs](runs.md)

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -1,0 +1,42 @@
+# API Reference Hub
+
+## Purpose
+
+Use this section to navigate ADE API reference and task-focused API guides.
+
+- Reference pages describe endpoint contracts and behavior.
+- How-to pages show copy/paste workflows in `curl`, Python, and PowerShell.
+
+## Audience
+
+This section is for integrators and operators who call ADE APIs directly.
+
+## Reference Pages
+
+- [Authentication](authentication.md)
+- [Errors and Problem Details](errors-and-problem-details.md)
+- [Workspaces](workspaces.md)
+- [Configurations](configurations.md)
+- [Documents](documents.md)
+- [Runs](runs.md)
+
+## How-To Guides
+
+- [Authenticate with API Key](../../how-to/api-authenticate-with-api-key.md)
+- [Manage Configurations](../../how-to/api-manage-configurations.md)
+- [Upload a Document and Queue Runs](../../how-to/api-upload-and-queue-runs.md)
+- [Create and Monitor Runs](../../how-to/api-create-and-monitor-runs.md)
+
+## Source of Truth
+
+Use generated OpenAPI for exact schema shape:
+
+```bash
+cd backend
+uv run ade api types
+```
+
+Then inspect:
+
+- `backend/src/ade_api/openapi.json`
+- `frontend/src/types/generated/openapi.d.ts`

--- a/docs/reference/api/runs.md
+++ b/docs/reference/api/runs.md
@@ -1,0 +1,69 @@
+# Runs API Reference
+
+## Purpose
+
+Document run creation, monitoring, events, and output retrieval endpoints.
+
+## Authentication Requirements
+
+All run endpoints are protected and scoped to workspace run permissions.
+
+## Endpoint Matrix
+
+| Method | Path | Auth | Primary status | Request shape | Response shape | Common errors |
+| --- | --- | --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs` | protected | `200` | path + cursor/search/filter | cursor page of runs | `401`, `403` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/runs` | protected | `201` | path + JSON run create payload | run resource | `400`, `401`, `403`, `404`, `409`, `422` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/runs/batch` | protected | `201` | path + JSON batch payload | batch run response | `401`, `403`, `404`, `422` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}` | protected | `200` | path | run resource | `401`, `403`, `404` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/cancel` | protected | `200` | path | run resource | `401`, `403`, `404`, `409` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/columns` | protected | `200` | path + optional column filters | list of run column rows | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/events/download` | protected | `200` | path | NDJSON stream | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/events/stream` | protected | `200` | path + optional `cursor` | SSE stream | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/fields` | protected | `200` | path | list of run field rows | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/input` | protected | `200` | path | run input metadata | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/input/download` | protected | `200` | path | input file stream | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/metrics` | protected | `200` | path | run metrics payload | `401`, `403`, `404` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/output` | protected | `200` | path | output metadata | `401`, `403`, `404` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/output` | protected | `201` | path + multipart output file | output metadata | `401`, `403`, `404`, `409`, `413` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/output/download` | protected | `200` | path | output file stream | `401`, `403`, `404`, `409` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/output/preview` | protected | `200` | path + preview query | worksheet preview payload | `401`, `403`, `404`, `409`, `415`, `422` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/runs/{runId}/output/sheets` | protected | `200` | path | output sheet list | `401`, `403`, `404`, `409`, `415`, `422` |
+
+## Core Endpoint Details
+
+### `POST /api/v1/workspaces/{workspaceId}/runs`
+
+- Creates and queues one run for one input document.
+- Optional `options` controls behavior (`activeSheetOnly`, `inputSheetNames`, operation mode).
+
+### `GET /api/v1/workspaces/{workspaceId}/runs/{runId}`
+
+- Primary polling endpoint for run status transitions.
+- Use with events endpoints for live updates.
+
+### `GET /api/v1/workspaces/{workspaceId}/runs/{runId}/events/stream`
+
+- SSE event stream for real-time run updates.
+- Resume from known stream offset using `cursor` or `Last-Event-ID`.
+
+### `GET /api/v1/workspaces/{workspaceId}/runs/{runId}/output/download`
+
+- Downloads produced output when run output is available.
+- Returns conflict/availability errors while output is not ready.
+
+## Error Handling
+
+- `401 Unauthorized`: missing/invalid auth credentials.
+- `403 Forbidden`: workspace run permission missing.
+- `404 Not Found`: workspace/run/input/output not found.
+- `409 Conflict`: run not cancellable or output not ready.
+- `413 Content Too Large`: uploaded manual output exceeds limit.
+- `415 Unsupported Media Type`: worksheet features unavailable for output type.
+- `422 Unprocessable Content`: run output parsing/preview failures.
+
+See [Errors and Problem Details](errors-and-problem-details.md) for shared response format.
+
+## Related Guides
+
+- [Create and Monitor Runs](../../how-to/api-create-and-monitor-runs.md)

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -1,0 +1,55 @@
+# Workspaces API Reference
+
+## Purpose
+
+Document workspace and workspace membership endpoints.
+
+## Authentication Requirements
+
+All workspace endpoints are protected. Send `X-API-Key` or a valid session cookie.
+
+## Endpoint Matrix
+
+| Method | Path | Auth | Primary status | Request shape | Response shape | Common errors |
+| --- | --- | --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/workspaces` | protected | `200` | query: cursor/search/sort filters | cursor page of workspaces | `401`, `403` |
+| `POST` | `/api/v1/workspaces` | protected | `201` | JSON: workspace create payload | workspace object | `401`, `403`, `409`, `422` |
+| `GET` | `/api/v1/workspaces/{workspaceId}` | protected | `200` | path: `workspaceId` | workspace object | `401`, `403`, `404` |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}` | protected | `200` | path + JSON patch | workspace object | `401`, `403`, `404`, `409`, `422` |
+| `DELETE` | `/api/v1/workspaces/{workspaceId}` | protected | `204` | path | empty | `401`, `403`, `404` |
+| `PUT` | `/api/v1/workspaces/{workspaceId}/default` | protected | `204` | path | empty | `401`, `403` |
+| `GET` | `/api/v1/workspaces/{workspaceId}/members` | protected | `200` | path + cursor/search/sort filters | cursor page of workspace members | `401`, `403` |
+| `POST` | `/api/v1/workspaces/{workspaceId}/members` | protected | `201` | path + JSON member create payload | workspace member object | `401`, `403`, `404`, `409`, `422` |
+| `PUT` | `/api/v1/workspaces/{workspaceId}/members/{userId}` | protected | `200` | path + JSON member role set | workspace member object | `401`, `403`, `404`, `422` |
+| `DELETE` | `/api/v1/workspaces/{workspaceId}/members/{userId}` | protected | `204` | path | empty | `401`, `403`, `404` |
+
+## Core Endpoint Details
+
+### `GET /api/v1/workspaces`
+
+- Supports cursor pagination and structured filters.
+- Returns only workspaces visible to the authenticated principal.
+
+### `POST /api/v1/workspaces`
+
+- Requires tenant-level permission to create workspaces.
+- `slug` conflicts return `409 Conflict`.
+
+### `GET /api/v1/workspaces/{workspaceId}/members`
+
+- Use for membership and role audits.
+- Combine with query filters for targeted checks.
+
+## Error Handling
+
+- `401 Unauthorized`: no valid auth context.
+- `403 Forbidden`: principal lacks required global or workspace permissions.
+- `404 Not Found`: workspace or user does not exist in scope.
+- `409 Conflict`: uniqueness/state conflicts (for example duplicate slug).
+- `422 Unprocessable Content`: payload shape/validation failure.
+
+See [Errors and Problem Details](errors-and-problem-details.md) for shared response format.
+
+## Related Guides
+
+- [Authenticate with API Key](../../how-to/api-authenticate-with-api-key.md)

--- a/docs/standards/documentation-maintenance.md
+++ b/docs/standards/documentation-maintenance.md
@@ -28,6 +28,7 @@ Update docs whenever these change:
 npx --yes markdownlint-cli2 "docs/**/*.md" "README.md" "CONTRIBUTING.md" "backend/**/README.md"
 FILES="$(find docs -type f -name '*.md' -print) README.md CONTRIBUTING.md $(find backend -mindepth 2 -maxdepth 2 -name README.md -print)"
 lychee --no-progress $FILES
+python3 scripts/docs/check_api_docs_coverage.py
 ```
 
 ## Done Criteria

--- a/docs/standards/documentation-style-guide.md
+++ b/docs/standards/documentation-style-guide.md
@@ -32,6 +32,31 @@ For reference pages:
 3. Facts/tables
 4. Examples
 
+For API reference pages (`docs/reference/api/*`):
+
+1. Purpose
+2. Authentication requirements
+3. Endpoint matrix (`method`, `path`, `auth`, `status`, `request`, `response`, `errors`)
+4. Core endpoint details
+5. Error handling and recovery
+6. Related how-to links
+
+For API how-to pages (`docs/how-to/api-*.md`):
+
+1. Goal
+2. Before You Start
+3. Steps
+4. Verify
+5. If Something Fails
+6. Parallel examples in `curl`, Python, and PowerShell for each operation
+
+## API Writing Rules
+
+- use exact API field names from OpenAPI (`camelCase` request keys)
+- explicitly state auth transport (`X-API-Key` or session cookie)
+- keep prose task-first and short; push detailed schema to reference pages
+- include concrete failure modes with remediation steps
+
 ## Command Rules
 
 - use fenced `bash` blocks

--- a/frontend/src/types/generated/openapi.d.ts
+++ b/frontend/src/types/generated/openapi.d.ts
@@ -68,7 +68,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Return active SSO providers */
+        /**
+         * Return active SSO providers
+         * @description List public SSO providers currently available for interactive sign-in.
+         */
         get: operations["list_sso_providers_api_v1_auth_sso_providers_get"];
         put?: never;
         post?: never;
@@ -85,7 +88,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Authorize Sso */
+        /**
+         * Start SSO authorization
+         * @description Initiate the OIDC authorization flow and redirect to the configured identity provider.
+         */
         get: operations["authorize_sso_api_v1_auth_sso_authorize_get"];
         put?: never;
         post?: never;
@@ -102,7 +108,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Callback Sso */
+        /**
+         * Complete SSO authorization
+         * @description Handle the OIDC callback, validate the provider response, and establish an ADE session.
+         */
         get: operations["callback_sso_api_v1_auth_sso_callback_get"];
         put?: never;
         post?: never;
@@ -119,10 +128,16 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Return setup status for the first admin user */
+        /**
+         * Return setup status for the first admin user
+         * @description Return setup status for the first admin user.
+         */
         get: operations["get_setup_status_api_v1_auth_setup_get"];
         put?: never;
-        /** Create the first admin user and log them in */
+        /**
+         * Create the first admin user and log them in
+         * @description Create the first admin user and log them in.
+         */
         post: operations["complete_setup_api_v1_auth_setup_post"];
         delete?: never;
         options?: never;
@@ -137,7 +152,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Return configured authentication providers */
+        /**
+         * Return configured authentication providers
+         * @description Return configured authentication providers.
+         */
         get: operations["list_auth_providers_api_v1_auth_providers_get"];
         put?: never;
         post?: never;
@@ -156,7 +174,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Authenticate with local username/password */
+        /**
+         * Authenticate with local username/password
+         * @description Authenticate with local username/password.
+         */
         post: operations["login_local_api_v1_auth_login_post"];
         delete?: never;
         options?: never;
@@ -173,7 +194,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Logout current user and revoke their sessions */
+        /**
+         * Logout current user and revoke their sessions
+         * @description Logout current user and revoke their sessions.
+         */
         post: operations["logout_local_api_v1_auth_logout_post"];
         delete?: never;
         options?: never;
@@ -190,7 +214,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Create a password reset token and schedule delivery */
+        /**
+         * Create a password reset token and schedule delivery
+         * @description Create a password reset token and schedule delivery.
+         */
         post: operations["password_forgot_api_v1_auth_password_forgot_post"];
         delete?: never;
         options?: never;
@@ -207,7 +234,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Consume a password reset token and update credentials */
+        /**
+         * Consume a password reset token and update credentials
+         * @description Consume a password reset token and update credentials.
+         */
         post: operations["password_reset_api_v1_auth_password_reset_post"];
         delete?: never;
         options?: never;
@@ -224,7 +254,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Start TOTP MFA enrollment for the current user */
+        /**
+         * Start TOTP MFA enrollment for the current user
+         * @description Start TOTP MFA enrollment for the current user.
+         */
         post: operations["mfa_enroll_start_api_v1_auth_mfa_totp_enroll_start_post"];
         delete?: never;
         options?: never;
@@ -239,11 +272,17 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Read TOTP MFA status for the current user */
+        /**
+         * Read TOTP MFA status for the current user
+         * @description Read TOTP MFA status for the current user.
+         */
         get: operations["mfa_status_api_v1_auth_mfa_totp_get"];
         put?: never;
         post?: never;
-        /** Disable TOTP for the current user */
+        /**
+         * Disable TOTP for the current user
+         * @description Disable TOTP for the current user.
+         */
         delete: operations["mfa_disable_api_v1_auth_mfa_totp_delete"];
         options?: never;
         head?: never;
@@ -259,7 +298,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Confirm TOTP enrollment with current code */
+        /**
+         * Confirm TOTP enrollment with current code
+         * @description Confirm TOTP enrollment with current code.
+         */
         post: operations["mfa_enroll_confirm_api_v1_auth_mfa_totp_enroll_confirm_post"];
         delete?: never;
         options?: never;
@@ -276,7 +318,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Regenerate recovery codes for current user */
+        /**
+         * Regenerate recovery codes for current user
+         * @description Regenerate recovery codes for current user.
+         */
         post: operations["mfa_regenerate_recovery_codes_api_v1_auth_mfa_totp_recovery_regenerate_post"];
         delete?: never;
         options?: never;
@@ -293,7 +338,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Verify MFA challenge and issue a session */
+        /**
+         * Verify MFA challenge and issue a session
+         * @description Verify MFA challenge and issue a session.
+         */
         post: operations["mfa_verify_challenge_api_v1_auth_mfa_challenge_verify_post"];
         delete?: never;
         options?: never;
@@ -657,10 +705,16 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List workspaces for the authenticated user */
+        /**
+         * List workspaces for the authenticated user
+         * @description List workspaces for the authenticated user.
+         */
         get: operations["list_workspaces_api_v1_workspaces_get"];
         put?: never;
-        /** Create a new workspace */
+        /**
+         * Create a new workspace
+         * @description Create a new workspace.
+         */
         post: operations["create_workspace_api_v1_workspaces_post"];
         delete?: never;
         options?: never;
@@ -675,15 +729,24 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Retrieve workspace context by identifier */
+        /**
+         * Retrieve workspace context by identifier
+         * @description Retrieve workspace context by identifier.
+         */
         get: operations["read_workspace_api_v1_workspaces__workspaceId__get"];
         put?: never;
         post?: never;
-        /** Delete a workspace */
+        /**
+         * Delete a workspace
+         * @description Delete a workspace.
+         */
         delete: operations["delete_workspace_api_v1_workspaces__workspaceId__delete"];
         options?: never;
         head?: never;
-        /** Update workspace metadata */
+        /**
+         * Update workspace metadata
+         * @description Update workspace metadata.
+         */
         patch: operations["update_workspace_api_v1_workspaces__workspaceId__patch"];
         trace?: never;
     };
@@ -695,7 +758,10 @@ export type paths = {
             cookie?: never;
         };
         get?: never;
-        /** Mark a workspace as the caller's default */
+        /**
+         * Mark a workspace as the caller's default
+         * @description Mark a workspace as the caller's default.
+         */
         put: operations["set_default_workspace_api_v1_workspaces__workspaceId__default_put"];
         post?: never;
         delete?: never;
@@ -711,10 +777,16 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List workspace members with their roles */
+        /**
+         * List workspace members with their roles
+         * @description List workspace members with their roles.
+         */
         get: operations["list_workspace_members_api_v1_workspaces__workspaceId__members_get"];
         put?: never;
-        /** Add a workspace member with roles */
+        /**
+         * Add a workspace member with roles
+         * @description Add a workspace member with roles.
+         */
         post: operations["add_workspace_member_api_v1_workspaces__workspaceId__members_post"];
         delete?: never;
         options?: never;
@@ -730,10 +802,16 @@ export type paths = {
             cookie?: never;
         };
         get?: never;
-        /** Replace workspace member roles */
+        /**
+         * Replace workspace member roles
+         * @description Replace workspace member roles.
+         */
         put: operations["update_workspace_member_api_v1_workspaces__workspaceId__members__userId__put"];
         post?: never;
-        /** Remove a workspace member */
+        /**
+         * Remove a workspace member
+         * @description Remove a workspace member.
+         */
         delete: operations["remove_workspace_member_api_v1_workspaces__workspaceId__members__userId__delete"];
         options?: never;
         head?: never;
@@ -747,7 +825,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List document tags */
+        /**
+         * List document tags
+         * @description List document tags.
+         */
         get: operations["list_document_tags_api_v1_workspaces__workspaceId__documents_tags_get"];
         put?: never;
         post?: never;
@@ -764,10 +845,16 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List documents */
+        /**
+         * List documents
+         * @description List documents.
+         */
         get: operations["list_documents_api_v1_workspaces__workspaceId__documents_get"];
         put?: never;
-        /** Upload a document */
+        /**
+         * Upload a document
+         * @description Upload a document.
+         */
         post: operations["upload_document_api_v1_workspaces__workspaceId__documents_post"];
         delete?: never;
         options?: never;
@@ -784,7 +871,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Upload a new document version */
+        /**
+         * Upload a new document version
+         * @description Upload a new document version.
+         */
         post: operations["upload_document_version_api_v1_workspaces__workspaceId__documents__documentId__versions_post"];
         delete?: never;
         options?: never;
@@ -799,10 +889,16 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List saved document views */
+        /**
+         * List saved document views
+         * @description List saved document views.
+         */
         get: operations["list_document_views_api_v1_workspaces__workspaceId__documents_views_get"];
         put?: never;
-        /** Create a saved document view */
+        /**
+         * Create a saved document view
+         * @description Create a saved document view.
+         */
         post: operations["create_document_view_api_v1_workspaces__workspaceId__documents_views_post"];
         delete?: never;
         options?: never;
@@ -820,11 +916,17 @@ export type paths = {
         get?: never;
         put?: never;
         post?: never;
-        /** Delete a saved document view */
+        /**
+         * Delete a saved document view
+         * @description Delete a saved document view.
+         */
         delete: operations["delete_document_view_api_v1_workspaces__workspaceId__documents_views__viewId__delete"];
         options?: never;
         head?: never;
-        /** Update a saved document view */
+        /**
+         * Update a saved document view
+         * @description Update a saved document view.
+         */
         patch: operations["update_document_view_api_v1_workspaces__workspaceId__documents_views__viewId__patch"];
         trace?: never;
     };
@@ -835,7 +937,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Stream document changes */
+        /**
+         * Stream document changes
+         * @description Stream document changes.
+         */
         get: operations["stream_document_changes_api_v1_workspaces__workspaceId__documents_stream_get"];
         put?: never;
         post?: never;
@@ -852,7 +957,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List document changes since token */
+        /**
+         * List document changes since token
+         * @description List document changes since token.
+         */
         get: operations["list_document_changes_delta_api_v1_workspaces__workspaceId__documents_delta_get"];
         put?: never;
         post?: never;
@@ -869,15 +977,24 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Retrieve document metadata */
+        /**
+         * Retrieve document metadata
+         * @description Retrieve document metadata.
+         */
         get: operations["read_document_api_v1_workspaces__workspaceId__documents__documentId__get"];
         put?: never;
         post?: never;
-        /** Soft delete a document */
+        /**
+         * Soft delete a document
+         * @description Soft delete a document.
+         */
         delete: operations["delete_document_api_v1_workspaces__workspaceId__documents__documentId__delete"];
         options?: never;
         head?: never;
-        /** Update document metadata, assignment, or name */
+        /**
+         * Update document metadata, assignment, or name
+         * @description Update document metadata, assignment, or name.
+         */
         patch: operations["update_document_api_v1_workspaces__workspaceId__documents__documentId__patch"];
         trace?: never;
     };
@@ -890,7 +1007,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Update tags on multiple documents */
+        /**
+         * Update tags on multiple documents
+         * @description Update tags on multiple documents.
+         */
         post: operations["patch_document_tags_batch_api_v1_workspaces__workspaceId__documents_batch_tags_post"];
         delete?: never;
         options?: never;
@@ -906,13 +1026,19 @@ export type paths = {
             cookie?: never;
         };
         get?: never;
-        /** Replace document tags */
+        /**
+         * Replace document tags
+         * @description Replace document tags.
+         */
         put: operations["replace_document_tags_api_v1_workspaces__workspaceId__documents__documentId__tags_put"];
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
-        /** Update document tags */
+        /**
+         * Update document tags
+         * @description Update document tags.
+         */
         patch: operations["patch_document_tags_api_v1_workspaces__workspaceId__documents__documentId__tags_patch"];
         trace?: never;
     };
@@ -923,7 +1049,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Retrieve document list row */
+        /**
+         * Retrieve document list row
+         * @description Retrieve document list row.
+         */
         get: operations["read_document_list_row_api_v1_workspaces__workspaceId__documents__documentId__listrow_get"];
         put?: never;
         post?: never;
@@ -940,10 +1069,16 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List document comments */
+        /**
+         * List document comments
+         * @description List document comments.
+         */
         get: operations["list_document_comments_api_v1_workspaces__workspaceId__documents__documentId__comments_get"];
         put?: never;
-        /** Create a document comment */
+        /**
+         * Create a document comment
+         * @description Create a document comment.
+         */
         post: operations["create_document_comment_api_v1_workspaces__workspaceId__documents__documentId__comments_post"];
         delete?: never;
         options?: never;
@@ -958,7 +1093,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Download latest document artifact */
+        /**
+         * Download latest document artifact
+         * @description Download latest document artifact.
+         */
         get: operations["download_document_api_v1_workspaces__workspaceId__documents__documentId__download_get"];
         put?: never;
         post?: never;
@@ -975,7 +1113,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Download original document version */
+        /**
+         * Download original document version
+         * @description Download original document version.
+         */
         get: operations["download_document_original_api_v1_workspaces__workspaceId__documents__documentId__original_download_get"];
         put?: never;
         post?: never;
@@ -992,7 +1133,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Download a specific document version */
+        /**
+         * Download a specific document version
+         * @description Download a specific document version.
+         */
         get: operations["download_document_version_api_v1_workspaces__workspaceId__documents__documentId__versions__versionNo__download_get"];
         put?: never;
         post?: never;
@@ -1009,7 +1153,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Preview a document worksheet */
+        /**
+         * Preview a document worksheet
+         * @description Preview a document worksheet.
+         */
         get: operations["preview_document_api_v1_workspaces__workspaceId__documents__documentId__preview_get"];
         put?: never;
         post?: never;
@@ -1026,7 +1173,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List worksheets for a document */
+        /**
+         * List worksheets for a document
+         * @description List worksheets for a document.
+         */
         get: operations["list_document_sheets_endpoint_api_v1_workspaces__workspaceId__documents__documentId__sheets_get"];
         put?: never;
         post?: never;
@@ -1045,7 +1195,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Restore a soft-deleted document */
+        /**
+         * Restore a soft-deleted document
+         * @description Restore a soft-deleted document.
+         */
         post: operations["restore_document_api_v1_workspaces__workspaceId__documents__documentId__restore_post"];
         delete?: never;
         options?: never;
@@ -1062,7 +1215,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Soft delete multiple documents */
+        /**
+         * Soft delete multiple documents
+         * @description Soft delete multiple documents.
+         */
         post: operations["delete_documents_batch_api_v1_workspaces__workspaceId__documents_batch_delete_post"];
         delete?: never;
         options?: never;
@@ -1079,7 +1235,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Restore multiple soft-deleted documents */
+        /**
+         * Restore multiple soft-deleted documents
+         * @description Restore multiple soft-deleted documents.
+         */
         post: operations["restore_documents_batch_api_v1_workspaces__workspaceId__documents_batch_restore_post"];
         delete?: never;
         options?: never;
@@ -1094,10 +1253,16 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List configurations for a workspace */
+        /**
+         * List configurations for a workspace
+         * @description List configurations for a workspace.
+         */
         get: operations["list_configurations_api_v1_workspaces__workspaceId__configurations_get"];
         put?: never;
-        /** Create a configuration from a template or clone */
+        /**
+         * Create a configuration from a template or clone
+         * @description Create a configuration from a template or clone.
+         */
         post: operations["create_configuration_api_v1_workspaces__workspaceId__configurations_post"];
         delete?: never;
         options?: never;
@@ -1112,7 +1277,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Retrieve workspace configuration timeline */
+        /**
+         * Retrieve workspace configuration timeline
+         * @description Retrieve workspace configuration timeline.
+         */
         get: operations["read_workspace_configuration_history_api_v1_workspaces__workspaceId__configurations_history_get"];
         put?: never;
         post?: never;
@@ -1129,14 +1297,20 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Retrieve configuration metadata */
+        /**
+         * Retrieve configuration metadata
+         * @description Retrieve configuration metadata.
+         */
         get: operations["read_configuration_api_v1_workspaces__workspaceId__configurations__configurationId__get"];
         put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
-        /** Update editable metadata for a draft configuration */
+        /**
+         * Update editable metadata for a draft configuration
+         * @description Update editable metadata for a draft configuration.
+         */
         patch: operations["update_configuration_api_v1_workspaces__workspaceId__configurations__configurationId__patch"];
         trace?: never;
     };
@@ -1149,7 +1323,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Restore a previous configuration as a new draft */
+        /**
+         * Restore a previous configuration as a new draft
+         * @description Restore a previous configuration as a new draft.
+         */
         post: operations["restore_configuration_api_v1_workspaces__workspaceId__configurations__configurationId__restore_post"];
         delete?: never;
         options?: never;
@@ -1166,7 +1343,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Create a configuration from an uploaded archive */
+        /**
+         * Create a configuration from an uploaded archive
+         * @description Create a configuration from an uploaded archive.
+         */
         post: operations["import_configuration_api_v1_workspaces__workspaceId__configurations_import_post"];
         delete?: never;
         options?: never;
@@ -1183,7 +1363,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Archive a draft or active configuration */
+        /**
+         * Archive a draft or active configuration
+         * @description Archive a draft or active configuration.
+         */
         post: operations["archive_configuration_endpoint_api_v1_workspaces__workspaceId__configurations__configurationId__archive_post"];
         delete?: never;
         options?: never;
@@ -1198,7 +1381,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Export Config */
+        /**
+         * Export a configuration archive
+         * @description Export the selected configuration as a ZIP archive.
+         */
         get: operations["export_config_api_v1_workspaces__workspaceId__configurations__configurationId__export_get"];
         put?: never;
         post?: never;
@@ -1216,7 +1402,10 @@ export type paths = {
             cookie?: never;
         };
         get?: never;
-        /** Replace a draft configuration from an uploaded archive */
+        /**
+         * Replace a draft configuration from an uploaded archive
+         * @description Replace a draft configuration from an uploaded archive.
+         */
         put: operations["replace_configuration_from_archive_api_v1_workspaces__workspaceId__configurations__configurationId__import_put"];
         post?: never;
         delete?: never;
@@ -1232,7 +1421,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List editable files and directories */
+        /**
+         * List editable files and directories
+         * @description List editable files and directories.
+         */
         get: operations["list_config_files_api_v1_workspaces__workspaceId__configurations__configurationId__files_get"];
         put?: never;
         post?: never;
@@ -1249,17 +1441,32 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Read Config File */
+        /**
+         * Read configuration file content
+         * @description Read a file from a draft configuration as JSON (`format=json`) or raw bytes. Supports ETag and HTTP range semantics.
+         */
         get: operations["read_config_file_api_v1_workspaces__workspaceId__configurations__configurationId__files__filePath__get"];
-        /** Upsert Config File */
+        /**
+         * Create or replace a configuration file
+         * @description Write file content into a draft configuration path. Supports conditional writes with `If-Match` and `If-None-Match`.
+         */
         put: operations["upsert_config_file_api_v1_workspaces__workspaceId__configurations__configurationId__files__filePath__put"];
         post?: never;
-        /** Delete Config File */
+        /**
+         * Delete a configuration file
+         * @description Delete a file from a draft configuration with optional optimistic concurrency checks.
+         */
         delete: operations["delete_config_file_api_v1_workspaces__workspaceId__configurations__configurationId__files__filePath__delete"];
         options?: never;
-        /** Head Config File */
+        /**
+         * Head Config File
+         * @description Head Config File.
+         */
         head: operations["head_config_file_api_v1_workspaces__workspaceId__configurations__configurationId__files__filePath__head"];
-        /** Rename or move a file */
+        /**
+         * Rename or move a file
+         * @description Rename or move a file.
+         */
         patch: operations["rename_config_file_api_v1_workspaces__workspaceId__configurations__configurationId__files__filePath__patch"];
         trace?: never;
     };
@@ -1271,10 +1478,16 @@ export type paths = {
             cookie?: never;
         };
         get?: never;
-        /** Create Config Directory */
+        /**
+         * Create a configuration directory
+         * @description Create a directory path in a draft configuration.
+         */
         put: operations["create_config_directory_api_v1_workspaces__workspaceId__configurations__configurationId__directories__directoryPath__put"];
         post?: never;
-        /** Delete Config Directory */
+        /**
+         * Delete a configuration directory
+         * @description Delete a directory path from a draft configuration.
+         */
         delete: operations["delete_config_directory_api_v1_workspaces__workspaceId__configurations__configurationId__directories__directoryPath__delete"];
         options?: never;
         head?: never;
@@ -1288,12 +1501,15 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List Workspace Runs Endpoint */
+        /**
+         * List runs in a workspace
+         * @description Return a cursor-paginated run list for the workspace with filtering, search, and sorting.
+         */
         get: operations["list_workspace_runs_endpoint_api_v1_workspaces__workspaceId__runs_get"];
         put?: never;
         /**
-         * Create Workspace Run Endpoint
-         * @description Create a run for ``workspace_id`` and enqueue execution.
+         * Create and enqueue a run
+         * @description Create a run in the target workspace and enqueue it for worker processing. When `configuration_id` is omitted, the active workspace configuration is used.
          */
         post: operations["create_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs_post"];
         delete?: never;
@@ -1312,8 +1528,8 @@ export type paths = {
         get?: never;
         put?: never;
         /**
-         * Create Workspace Runs Batch Endpoint
-         * @description Create multiple runs for ``workspace_id`` and enqueue execution.
+         * Create and enqueue runs in batch
+         * @description Create one run per document in `document_ids` and enqueue all runs as a single all-or-nothing operation.
          */
         post: operations["create_workspace_runs_batch_endpoint_api_v1_workspaces__workspaceId__runs_batch_post"];
         delete?: never;
@@ -1329,7 +1545,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Get Workspace Run Endpoint */
+        /**
+         * Get run details
+         * @description Return a single run resource for the requested workspace and run identifier.
+         */
         get: operations["get_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__get"];
         put?: never;
         post?: never;
@@ -1348,7 +1567,10 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Cancel Workspace Run Endpoint */
+        /**
+         * Cancel a run
+         * @description Request cancellation for a run that is still cancellable.
+         */
         post: operations["cancel_workspace_run_endpoint_api_v1_workspaces__workspaceId__runs__runId__cancel_post"];
         delete?: never;
         options?: never;
@@ -1363,7 +1585,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Get Workspace Run Metrics Endpoint */
+        /**
+         * Get run metrics
+         * @description Return derived run metrics from worker events, including evaluation, validation, and workbook statistics.
+         */
         get: operations["get_workspace_run_metrics_endpoint_api_v1_workspaces__workspaceId__runs__runId__metrics_get"];
         put?: never;
         post?: never;
@@ -1380,7 +1605,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List Workspace Run Fields Endpoint */
+        /**
+         * List run field detection results
+         * @description Return field-level detection outcomes captured for the run.
+         */
         get: operations["list_workspace_run_fields_endpoint_api_v1_workspaces__workspaceId__runs__runId__fields_get"];
         put?: never;
         post?: never;
@@ -1397,7 +1625,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List Workspace Run Columns Endpoint */
+        /**
+         * List run column mappings
+         * @description Return detected input columns and mapping metadata for the run.
+         */
         get: operations["list_workspace_run_columns_endpoint_api_v1_workspaces__workspaceId__runs__runId__columns_get"];
         put?: never;
         post?: never;
@@ -1414,7 +1645,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Get run input metadata */
+        /**
+         * Get run input metadata
+         * @description Return the input document/version metadata associated with the run.
+         */
         get: operations["get_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_get"];
         put?: never;
         post?: never;
@@ -1431,7 +1665,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Download run input file */
+        /**
+         * Download run input file
+         * @description Download the exact input file version used by this run.
+         */
         get: operations["download_workspace_run_input_endpoint_api_v1_workspaces__workspaceId__runs__runId__input_download_get"];
         put?: never;
         post?: never;
@@ -1448,7 +1685,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Stream run events (SSE) */
+        /**
+         * Stream run events (SSE)
+         * @description Stream run events using Server-Sent Events. Use `cursor` or `Last-Event-ID` to resume from a prior position.
+         */
         get: operations["stream_workspace_run_events_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_stream_get"];
         put?: never;
         post?: never;
@@ -1465,7 +1705,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Download run events (NDJSON log) */
+        /**
+         * Download run events (NDJSON log)
+         * @description Download the persisted NDJSON event log for the run.
+         */
         get: operations["download_workspace_run_events_file_endpoint_api_v1_workspaces__workspaceId__runs__runId__events_download_get"];
         put?: never;
         post?: never;
@@ -1482,10 +1725,16 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Get run output metadata */
+        /**
+         * Get run output metadata
+         * @description Return output file metadata, readiness, and download link information.
+         */
         get: operations["get_workspace_run_output_metadata_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_get"];
         put?: never;
-        /** Upload manual run output */
+        /**
+         * Upload manual run output
+         * @description Upload an output artifact for a run managed manually outside worker execution.
+         */
         post: operations["upload_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_post"];
         delete?: never;
         options?: never;
@@ -1500,7 +1749,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Download run output file */
+        /**
+         * Download run output file
+         * @description Download the latest output file artifact associated with the run.
+         */
         get: operations["download_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_download_get"];
         put?: never;
         post?: never;
@@ -1517,7 +1769,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** List run output worksheets */
+        /**
+         * List run output worksheets
+         * @description List worksheets available in the run output artifact when sheet introspection is supported.
+         */
         get: operations["list_workspace_run_output_sheets_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_sheets_get"];
         put?: never;
         post?: never;
@@ -1534,7 +1789,10 @@ export type paths = {
             path?: never;
             cookie?: never;
         };
-        /** Preview run output worksheet */
+        /**
+         * Preview run output worksheet
+         * @description Return a bounded preview of run output worksheet data with optional sheet selection and trimming controls.
+         */
         get: operations["preview_workspace_run_output_endpoint_api_v1_workspaces__workspaceId__runs__runId__output_preview_get"];
         put?: never;
         post?: never;

--- a/scripts/docs/check_api_docs_coverage.py
+++ b/scripts/docs/check_api_docs_coverage.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Validate API docs coverage and quality gates for top workflow docs."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPENAPI_PATH = REPO_ROOT / "backend" / "src" / "ade_api" / "openapi.json"
+
+REFERENCE_FILES: dict[str, Path] = {
+    "auth": REPO_ROOT / "docs" / "reference" / "api" / "authentication.md",
+    "workspaces": REPO_ROOT / "docs" / "reference" / "api" / "workspaces.md",
+    "configurations": REPO_ROOT / "docs" / "reference" / "api" / "configurations.md",
+    "documents": REPO_ROOT / "docs" / "reference" / "api" / "documents.md",
+    "runs": REPO_ROOT / "docs" / "reference" / "api" / "runs.md",
+}
+
+HOWTO_FILES: list[Path] = [
+    REPO_ROOT / "docs" / "how-to" / "api-authenticate-with-api-key.md",
+    REPO_ROOT / "docs" / "how-to" / "api-manage-configurations.md",
+    REPO_ROOT / "docs" / "how-to" / "api-upload-and-queue-runs.md",
+    REPO_ROOT / "docs" / "how-to" / "api-create-and-monitor-runs.md",
+]
+
+METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+BANNED_SUMMARY_PATTERNS = [re.compile(r"\bEndpoint\b", re.IGNORECASE)]
+
+TABLE_ENDPOINT_PATTERN = re.compile(
+    r"\|\s*`?(GET|POST|PUT|PATCH|DELETE)`?\s*\|\s*`?(/api/v1/[^`|\s]+)`?\s*\|"
+)
+INLINE_ENDPOINT_PATTERN = re.compile(r"\b(GET|POST|PUT|PATCH|DELETE)\s+(/api/v1/[^\s`]+)")
+
+
+def infer_domain(tags: set[str]) -> str | None:
+    if tags.intersection({"auth", "me"}):
+        return "auth"
+    if "workspaces" in tags:
+        return "workspaces"
+    if "configurations" in tags:
+        return "configurations"
+    if "documents" in tags:
+        return "documents"
+    if "runs" in tags:
+        return "runs"
+    return None
+
+
+def parse_reference_endpoints(text: str) -> set[tuple[str, str]]:
+    found: set[tuple[str, str]] = set()
+    for method, path in TABLE_ENDPOINT_PATTERN.findall(text):
+        found.add((method.upper(), path))
+    for method, path in INLINE_ENDPOINT_PATTERN.findall(text):
+        found.add((method.upper(), path))
+    return found
+
+
+def load_top_workflow_operations(schema: dict) -> dict[tuple[str, str], str]:
+    operations: dict[tuple[str, str], str] = {}
+
+    for path, path_item in schema.get("paths", {}).items():
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            method_upper = method.upper()
+            if method_upper not in METHODS:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            tags = {str(tag) for tag in operation.get("tags", []) if isinstance(tag, str)}
+            domain = infer_domain(tags)
+            if domain is None:
+                continue
+            operations[(method_upper, path)] = domain
+
+    return operations
+
+
+def check_reference_coverage(schema: dict) -> list[str]:
+    errors: list[str] = []
+    expected = load_top_workflow_operations(schema)
+
+    missing_files = [path for path in REFERENCE_FILES.values() if not path.exists()]
+    if missing_files:
+        for path in missing_files:
+            errors.append(f"Missing reference file: {path.relative_to(REPO_ROOT)}")
+        return errors
+
+    parsed_by_file: dict[str, set[tuple[str, str]]] = {}
+    file_hits: defaultdict[tuple[str, str], list[str]] = defaultdict(list)
+
+    for domain, file_path in REFERENCE_FILES.items():
+        endpoints = parse_reference_endpoints(file_path.read_text(encoding="utf-8"))
+        parsed_by_file[domain] = endpoints
+        for endpoint in endpoints:
+            file_hits[endpoint].append(domain)
+
+    for endpoint, domain in sorted(expected.items(), key=lambda item: (item[0][1], item[0][0])):
+        method, path = endpoint
+        if endpoint not in parsed_by_file[domain]:
+            errors.append(
+                f"Missing endpoint in expected reference page: {method} {path} -> {domain}"
+            )
+            continue
+
+        domains = file_hits.get(endpoint, [])
+        wrong_domains = sorted({entry for entry in domains if entry != domain})
+        if wrong_domains:
+            errors.append(
+                "Endpoint appears in multiple domain pages: "
+                f"{method} {path} (expected {domain}, also in {', '.join(wrong_domains)})"
+            )
+
+    return errors
+
+
+def check_howto_examples() -> list[str]:
+    errors: list[str] = []
+
+    for file_path in HOWTO_FILES:
+        rel = file_path.relative_to(REPO_ROOT)
+        if not file_path.exists():
+            errors.append(f"Missing API how-to file: {rel}")
+            continue
+
+        content = file_path.read_text(encoding="utf-8")
+        if "curl " not in content and "curl\\n" not in content:
+            errors.append(f"Missing curl example in {rel}")
+        if "```python" not in content:
+            errors.append(f"Missing Python example block in {rel}")
+        if "```powershell" not in content:
+            errors.append(f"Missing PowerShell example block in {rel}")
+
+    return errors
+
+
+def check_banned_summaries(schema: dict) -> list[str]:
+    errors: list[str] = []
+
+    expected = load_top_workflow_operations(schema)
+    for (method, path), _domain in sorted(expected.items(), key=lambda item: (item[0][1], item[0][0])):
+        operation = schema["paths"][path][method.lower()]
+        summary = str(operation.get("summary", "")).strip()
+        for pattern in BANNED_SUMMARY_PATTERNS:
+            if pattern.search(summary):
+                errors.append(
+                    f"Banned summary pattern in OpenAPI: {method} {path} -> {summary!r}"
+                )
+                break
+
+    return errors
+
+
+def main() -> int:
+    if not OPENAPI_PATH.exists():
+        print(f"error: missing OpenAPI schema at {OPENAPI_PATH.relative_to(REPO_ROOT)}")
+        print("run: cd backend && uv run ade api types")
+        return 1
+
+    schema = json.loads(OPENAPI_PATH.read_text(encoding="utf-8"))
+
+    errors: list[str] = []
+    errors.extend(check_reference_coverage(schema))
+    errors.extend(check_howto_examples())
+    errors.extend(check_banned_summaries(schema))
+
+    if errors:
+        print("API docs coverage check failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("API docs coverage check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- add a new API reference hub and domain reference pages for auth, workspaces, configurations, documents, runs, and errors\n- add standardized API how-to guides with curl/Python/PowerShell parity\n- update docs navigation and capability map to route users to the new API structure\n- add API docs coverage check passed. to enforce top-workflow endpoint coverage and how-to language parity\n- improve OpenAPI metadata for top workflows (summary/description normalization + key request/response examples), then regenerate OpenAPI and frontend types\n\n## Validation\n- 📝 wrote OpenAPI schema to /Users/justinkropp/.codex/worktrees/c86a/automatic-data-extractor/backend/src/ade_api/openapi.json
✨ openapi-typescript 7.12.0
🚀 /Users/justinkropp/.codex/worktrees/c86a/automatic-data-extractor/backend/src/ade_api/openapi.json → /Users/justinkropp/.codex/worktrees/c86a/automatic-data-extractor/frontend/src/types/generated/openapi.d.ts [175.6ms]
generated frontend/src/types/generated/openapi.d.ts\n- API docs coverage check passed.\n- ============================= test session starts ==============================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/justinkropp/.codex/worktrees/c86a/automatic-data-extractor/backend
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 132 items

tests/api/unit/common/test_cursor_listing.py .                           [  0%]
tests/api/unit/common/test_infra_cli.py ...                              [  3%]
tests/api/unit/common/test_list_filters.py .                             [  3%]
tests/api/unit/common/test_local_dev_profile.py ....                     [  6%]
tests/api/unit/common/test_root_cli.py ........                          [ 12%]
tests/api/unit/common/test_search.py .......                             [ 18%]
tests/api/unit/common/test_server_commands.py .........                  [ 25%]
tests/api/unit/common/test_web_cli.py ....                               [ 28%]
tests/api/unit/core/auth/test_pipeline.py ....                           [ 31%]
tests/api/unit/features/configs/test_deps_digest.py ...                  [ 33%]
tests/api/unit/features/configs/test_etag.py ..........                  [ 40%]
tests/api/unit/features/configs/test_templates.py ..                     [ 42%]
tests/api/unit/features/documents/test_document_change_tokens.py ..      [ 43%]
tests/api/unit/features/documents/test_view_presets.py ...               [ 46%]
tests/api/unit/features/test_sse_streams.py ..                           [ 47%]
tests/api/unit/infra/test_storage_blob.py .....                          [ 51%]
tests/api/unit/settings/test_settings_defaults.py ....                   [ 54%]
tests/api/unit/settings/test_settings_env.py ..................          [ 68%]
tests/api/unit/settings/test_settings_storage.py ..........              [ 75%]
tests/api/unit/shared/test_db_engine.py ...                              [ 78%]
tests/api/unit/shared/test_db_lifecycle.py .                             [ 78%]
tests/api/unit/shared/test_db_settings.py ...                            [ 81%]
tests/api/unit/shared/test_encoding.py ...                               [ 83%]
tests/api/unit/shared/test_lifecycles.py ....                            [ 86%]
tests/api/unit/shared/test_logging_behavior.py ......                    [ 90%]
tests/api/unit/shared/test_no_async_db_imports.py .                      [ 91%]
tests/api/unit/test_ids.py ..                                            [ 93%]
tests/api/unit/test_responses.py ....                                    [ 96%]
tests/api/unit/test_settings_database.py ...                             [ 98%]
tests/api/unit/test_storage_layout.py ..                                 [100%]

============================= 132 passed in 1.22s ==============================\n\n## Notes\n-  currently reports many pre-existing repo-wide violations unrelated to this change\n-  is not installed in this environment, so link check was not executed locally