### PR TITLE
fix: improve login MFA UX with smart single-code input

### DIFF
--- a/frontend/src/pages/Login/__tests__/Login.test.tsx
+++ b/frontend/src/pages/Login/__tests__/Login.test.tsx
@@ -1,11 +1,24 @@
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/api";
 import { render, screen } from "@/test/test-utils";
 import LoginScreen from "@/pages/Login";
 
 const mockUseSessionQuery = vi.fn();
 const mockUseSetupStatusQuery = vi.fn();
 const mockUseAuthProvidersQuery = vi.fn();
+const mockCreateSession = vi.fn();
+const mockVerifyMfaChallenge = vi.fn();
+
+vi.mock("@/api/auth/api", async () => {
+  const actual = await vi.importActual<typeof import("@/api/auth/api")>("@/api/auth/api");
+  return {
+    ...actual,
+    createSession: (...args: unknown[]) => mockCreateSession(...args),
+    verifyMfaChallenge: (...args: unknown[]) => mockVerifyMfaChallenge(...args),
+  };
+});
 
 vi.mock("@/hooks/auth/useSessionQuery", () => ({
   useSessionQuery: () => mockUseSessionQuery(),
@@ -29,6 +42,8 @@ describe("LoginScreen SSO UX", () => {
     mockUseSessionQuery.mockReset();
     mockUseSetupStatusQuery.mockReset();
     mockUseAuthProvidersQuery.mockReset();
+    mockCreateSession.mockReset();
+    mockVerifyMfaChallenge.mockReset();
 
     mockUseSessionQuery.mockReturnValue({
       session: null,
@@ -55,6 +70,50 @@ describe("LoginScreen SSO UX", () => {
       isError: false,
       isFetching: false,
       isLoading: false,
+    });
+
+    mockCreateSession.mockResolvedValue({
+      kind: "session",
+      session: {
+        user: {
+          id: "user-1",
+          email: "user@example.com",
+          display_name: "User",
+          global_roles: [],
+          workspace_roles: {},
+          is_active: true,
+          preferred_workspace_id: null,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          roles: [],
+          permissions: [],
+        },
+        workspaces: [],
+        roles: [],
+        permissions: [],
+        return_to: "/",
+      },
+      mfaSetupRecommended: false,
+      mfaSetupRequired: false,
+    });
+    mockVerifyMfaChallenge.mockResolvedValue({
+      user: {
+        id: "user-1",
+        email: "user@example.com",
+        display_name: "User",
+        global_roles: [],
+        workspace_roles: {},
+        is_active: true,
+        preferred_workspace_id: null,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        roles: [],
+        permissions: [],
+      },
+      workspaces: [],
+      roles: [],
+      permissions: [],
+      return_to: "/",
     });
   });
 
@@ -261,5 +320,261 @@ describe("LoginScreen SSO UX", () => {
     expect(
       screen.getByText("Password reset is unavailable. Contact your administrator."),
     ).toBeInTheDocument();
+  });
+
+  it("uses password-manager friendly metadata on password login fields", () => {
+    renderWithPath("/login");
+
+    const emailInput = screen.getByLabelText(/email address/i);
+    expect(emailInput).toHaveAttribute("autocomplete", "username");
+    expect(emailInput).toHaveAttribute("autocapitalize", "none");
+    expect(emailInput).toHaveAttribute("autocorrect", "off");
+    expect(emailInput).toHaveAttribute("spellcheck", "false");
+
+    const passwordInput = screen.getByLabelText(/password/i);
+    expect(passwordInput).toHaveAttribute("autocomplete", "current-password");
+    expect(passwordInput).toHaveAttribute("autocapitalize", "none");
+    expect(passwordInput).toHaveAttribute("autocorrect", "off");
+    expect(passwordInput).toHaveAttribute("spellcheck", "false");
+  });
+
+  it("shows an email-login separator when both SSO and password login are available", () => {
+    mockUseAuthProvidersQuery.mockReturnValue({
+      data: {
+        forceSso: false,
+        passwordResetEnabled: true,
+        providers: [
+          {
+            id: "okta",
+            label: "Okta",
+            type: "oidc",
+            startUrl: "/api/v1/auth/sso/okta/authorize",
+          },
+        ],
+      },
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+    });
+
+    renderWithPath("/login");
+
+    expect(screen.getByText("or continue with email")).toBeInTheDocument();
+  });
+
+  it("switches to the MFA challenge step with one smart input", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+
+    renderWithPath("/login");
+
+    await user.type(screen.getByLabelText(/email address/i), "user@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(await screen.findByText("Step 2 of 2")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Verify your identity" })).toBeInTheDocument();
+    expect(screen.queryByText("Verification method")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Authenticator app" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument();
+  });
+
+  it("keeps one-time-code autocomplete on MFA input", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+    renderWithPath("/login");
+
+    await user.type(screen.getByLabelText(/email address/i), "user@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    const codeInput = await screen.findByLabelText(/verification code/i);
+    expect(codeInput).toHaveAttribute("autocomplete", "one-time-code");
+  });
+
+  it("detects OTP-style input and submits a 6-digit code", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+    mockVerifyMfaChallenge.mockRejectedValueOnce(new Error("keep-on-mfa"));
+    renderWithPath("/login");
+
+    await user.type(screen.getByLabelText(/email address/i), "user@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    const codeInput = await screen.findByLabelText(/verification code/i);
+    expect(codeInput).toHaveAttribute("inputmode", "numeric");
+
+    await user.type(codeInput, "12 34 56");
+    expect(codeInput).toHaveValue("123456");
+    await user.click(screen.getByRole("button", { name: "Verify and continue" }));
+
+    expect(mockVerifyMfaChallenge).toHaveBeenLastCalledWith({
+      challengeToken: "challenge-1",
+      code: "123456",
+    });
+  });
+
+  it("auto-detects recovery codes and submits normalized recovery format", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+    mockVerifyMfaChallenge.mockRejectedValueOnce(new Error("keep-on-mfa"));
+    renderWithPath("/login");
+
+    await user.type(screen.getByLabelText(/email address/i), "user@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    const codeInput = await screen.findByLabelText(/verification code/i);
+    await user.type(codeInput, "ab12-3cd4xx");
+
+    expect(codeInput).toHaveValue("AB12-3CD4");
+    expect(codeInput).toHaveAttribute("inputmode", "text");
+    expect(screen.getByText("Recovery code detected.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Verify and continue" }));
+    expect(mockVerifyMfaChallenge).toHaveBeenLastCalledWith({
+      challengeToken: "challenge-1",
+      code: "AB12-3CD4",
+    });
+  });
+
+  it("shows strict field-level validation for ambiguous 7-digit input", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+    renderWithPath("/login");
+
+    await user.type(screen.getByLabelText(/email address/i), "user@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await user.type(await screen.findByLabelText(/verification code/i), "1234567");
+    await user.click(screen.getByRole("button", { name: "Verify and continue" }));
+
+    expect(
+      await screen.findByText("Enter a 6-digit authenticator code or an 8-character recovery code."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("reveals subtle fallback guidance after two invalid submissions", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+    mockVerifyMfaChallenge
+      .mockRejectedValueOnce(
+        new ApiError(
+          "Invalid one-time password.",
+          400,
+          { detail: "Invalid one-time password." } as unknown as ApiError["problem"],
+        ),
+      )
+      .mockRejectedValueOnce(
+        new ApiError(
+          "Invalid one-time password.",
+          400,
+          { detail: "Invalid one-time password." } as unknown as ApiError["problem"],
+        ),
+      );
+    renderWithPath("/login");
+
+    await user.type(screen.getByLabelText(/email address/i), "user@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    const codeInput = await screen.findByLabelText(/verification code/i);
+    await user.type(codeInput, "123456");
+    await user.click(screen.getByRole("button", { name: "Verify and continue" }));
+    await user.click(screen.getByRole("button", { name: "Verify and continue" }));
+
+    expect(await screen.findByText("Having trouble with your code?")).toBeInTheDocument();
+    expect(
+      screen.getByText("This field also accepts recovery codes (example: AB12-3CD4)."),
+    ).toBeInTheDocument();
+  });
+
+  it("maps MFA API errors with assertive alerts", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+    mockVerifyMfaChallenge.mockRejectedValueOnce(
+      new ApiError(
+        "Invalid one-time password.",
+        400,
+        { detail: "Invalid one-time password." } as unknown as ApiError["problem"],
+      ),
+    );
+    renderWithPath("/login");
+
+    await user.type(screen.getByLabelText(/email address/i), "user@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await user.type(await screen.findByLabelText(/verification code/i), "123456");
+    await user.click(screen.getByRole("button", { name: "Verify and continue" }));
+
+    const errorAlert = await screen.findByRole("alert");
+    expect(errorAlert).toHaveAttribute("aria-live", "assertive");
+    expect(errorAlert).toHaveTextContent("That code wasn't accepted. Check the code and try again.");
+  });
+
+  it("maps expired MFA challenge errors to a restart message", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+    mockVerifyMfaChallenge.mockRejectedValueOnce(
+      new ApiError(
+        "MFA challenge is invalid or expired.",
+        400,
+        { detail: "MFA challenge is invalid or expired." } as unknown as ApiError["problem"],
+      ),
+    );
+    renderWithPath("/login");
+
+    await user.type(screen.getByLabelText(/email address/i), "user@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await user.type(await screen.findByLabelText(/verification code/i), "123456");
+    await user.click(screen.getByRole("button", { name: "Verify and continue" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Your verification session expired. Sign in again.",
+    );
+  });
+
+  it("keeps the email value when returning from MFA to password login", async () => {
+    const user = userEvent.setup();
+    mockCreateSession.mockResolvedValueOnce({
+      kind: "mfa_required",
+      challengeToken: "challenge-1",
+    });
+    renderWithPath("/login");
+
+    const emailInput = screen.getByLabelText(/email address/i);
+    await user.type(emailInput, "remember.me@example.com");
+    await user.type(screen.getByLabelText(/password/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await user.click(await screen.findByRole("button", { name: "Back to password login" }));
+
+    expect(await screen.findByLabelText(/email address/i)).toHaveValue("remember.me@example.com");
   });
 });

--- a/frontend/src/pages/Login/__tests__/mfaCode.test.ts
+++ b/frontend/src/pages/Login/__tests__/mfaCode.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMfaInputError,
+  formatRecoveryCode,
+  parseMfaCode,
+} from "@/pages/Login/mfaCode";
+
+describe("mfaCode helpers", () => {
+  it("detects OTP codes and marks complete only at 6 digits", () => {
+    const parsed = parseMfaCode("123456");
+    expect(parsed.kind).toBe("otp");
+    expect(parsed.displayValue).toBe("123456");
+    expect(parsed.submitValue).toBe("123456");
+    expect(parsed.isComplete).toBe(true);
+  });
+
+  it("detects recovery code shapes and formats to XXXX-XXXX", () => {
+    const parsed = parseMfaCode("ab12-3cd4xx");
+    expect(parsed.kind).toBe("recovery");
+    expect(parsed.displayValue).toBe("AB12-3CD4");
+    expect(parsed.submitValue).toBe("AB12-3CD4");
+    expect(parsed.isComplete).toBe(true);
+  });
+
+  it("returns unknown for ambiguous seven-digit numeric input", () => {
+    const parsed = parseMfaCode("1234567");
+    expect(parsed.kind).toBe("unknown");
+    expect(parsed.isComplete).toBe(false);
+  });
+
+  it("formats recovery code helper output", () => {
+    expect(formatRecoveryCode("ab12-3cd4")).toBe("AB12-3CD4");
+  });
+
+  it("builds strict input errors for incomplete or invalid shapes", () => {
+    const parsed = parseMfaCode("12345");
+    expect(buildMfaInputError(parsed)).toBe(
+      "Enter a 6-digit authenticator code or an 8-character recovery code.",
+    );
+  });
+});

--- a/frontend/src/pages/Login/mfaCode.ts
+++ b/frontend/src/pages/Login/mfaCode.ts
@@ -1,0 +1,86 @@
+export type DetectedMfaCodeKind = "otp" | "recovery" | "unknown";
+
+const OTP_CODE_LENGTH = 6;
+const RECOVERY_CODE_LENGTH = 8;
+const RECOVERY_GROUP_LENGTH = 4;
+
+export type ParsedMfaCode = Readonly<{
+  kind: DetectedMfaCodeKind;
+  alnum: string;
+  digits: string;
+  hasAlpha: boolean;
+  hasHyphen: boolean;
+  displayValue: string;
+  submitValue: string;
+  isOtpComplete: boolean;
+  isRecoveryComplete: boolean;
+  isComplete: boolean;
+}>;
+
+function normalizeAlnum(raw: string): string {
+  return raw.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, RECOVERY_CODE_LENGTH);
+}
+
+function normalizeDigits(alnum: string): string {
+  return alnum.replace(/\D/g, "");
+}
+
+function detectMfaCodeKind(
+  alnum: string,
+  digits: string,
+  hasAlpha: boolean,
+  hasHyphen: boolean,
+): DetectedMfaCodeKind {
+  if (alnum.length === 0) {
+    return "unknown";
+  }
+  if (hasAlpha || hasHyphen || alnum.length === RECOVERY_CODE_LENGTH) {
+    return "recovery";
+  }
+  if (alnum.length <= OTP_CODE_LENGTH && digits.length === alnum.length) {
+    return "otp";
+  }
+  return "unknown";
+}
+
+export function formatRecoveryCode(alnum: string): string {
+  const normalized = normalizeAlnum(alnum);
+  if (normalized.length <= RECOVERY_GROUP_LENGTH) {
+    return normalized;
+  }
+  return `${normalized.slice(0, RECOVERY_GROUP_LENGTH)}-${normalized.slice(RECOVERY_GROUP_LENGTH)}`;
+}
+
+export function parseMfaCode(raw: string): ParsedMfaCode {
+  const hasHyphen = raw.includes("-");
+  const alnum = normalizeAlnum(raw);
+  const digits = normalizeDigits(alnum);
+  const hasAlpha = /[A-Z]/.test(alnum);
+  const kind = detectMfaCodeKind(alnum, digits, hasAlpha, hasHyphen);
+
+  const displayValue = kind === "recovery" ? formatRecoveryCode(alnum) : alnum;
+  const submitValue = kind === "recovery" ? formatRecoveryCode(alnum) : digits.slice(0, OTP_CODE_LENGTH);
+  const isOtpComplete = kind === "otp" && digits.length === OTP_CODE_LENGTH;
+  const isRecoveryComplete = kind === "recovery" && alnum.length === RECOVERY_CODE_LENGTH;
+  const isComplete = isOtpComplete || isRecoveryComplete;
+
+  return {
+    kind,
+    alnum,
+    digits,
+    hasAlpha,
+    hasHyphen,
+    displayValue,
+    submitValue,
+    isOtpComplete,
+    isRecoveryComplete,
+    isComplete,
+  };
+}
+
+export function buildMfaInputError(parsed: ParsedMfaCode): string | null {
+  if (parsed.isComplete) {
+    return null;
+  }
+  return "Enter a 6-digit authenticator code or an 8-character recovery code.";
+}


### PR DESCRIPTION
## Summary
This PR hardens the ADE login + MFA challenge experience with a smart single-input flow that supports both authenticator codes and recovery codes without adding extra toggles.

It keeps browser/password-manager autofill semantics intact, improves mobile and accessibility behavior, and adds focused MFA coverage in frontend tests.

## What Changed
### Login form semantics (password phase)
- Set email field `autocomplete="username"` (keeps `type="email"`).
- Added `autoCapitalize="none"`, `autoCorrect="off"`, and `spellCheck={false}` on email and password fields.
- Added visible `or continue with email` separator when both SSO and password login are available.

### MFA UX (single smart input)
- Replaced method-toggle MFA UI with one `Verification code` input.
- Added deterministic parser-based detection for:
  - 6-digit authenticator codes
  - 8-character recovery codes (`XXXXXXXX` / `XXXX-XXXX`)
- Preserved `autocomplete="one-time-code"` and added dynamic `inputMode` (`numeric` vs `text`) based on detected kind.
- Normalized recovery display/submit value to `AB12-3CD4` format.
- Added strict client validation for ambiguous/invalid shapes.

### Error handling and accessibility
- Promoted API errors to assertive alerts (`role="alert"`, `aria-live="assertive"`).
- Added specific MFA error mapping for common backend messages:
  - invalid OTP
  - expired/invalid MFA challenge
- Added polite detection feedback (`Recovery code detected.`).
- Added subtle fallback guidance after repeated MFA failures.
- Preserved email value when returning from MFA back to password login.

### Internal helper module
- Added `frontend/src/pages/Login/mfaCode.ts` with pure helpers:
  - `parseMfaCode`
  - `formatRecoveryCode`
  - `buildMfaInputError`
  - internal types for detected/parsed code kind.

## Tests
Added/updated coverage in:
- `frontend/src/pages/Login/__tests__/Login.test.tsx`
- `frontend/src/pages/Login/__tests__/mfaCode.test.ts`

Covered scenarios include:
- password-manager metadata on login fields
- MFA transition and single-input rendering
- OTP + recovery auto-detection and submit normalization
- strict ambiguous-input validation
- assertive API error semantics
- fallback hint after repeated invalid attempts
- back-to-password preserving email

## Validation
- `cd backend && uv run ade web test` ✅
- `cd backend && uv run ade web lint` ✅
- `cd backend && uv run ade test` ✅

## Scope
- No backend API changes.
- No passkeys / remembered-device bypass in this PR.
