### PR TITLE
feat(web): polish organic theme mode transition

### DIFF
--- a/frontend/src/app/layouts/components/topbar/UnifiedTopbarControls.tsx
+++ b/frontend/src/app/layouts/components/topbar/UnifiedTopbarControls.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
 import clsx from "clsx";
 import { useNavigate } from "react-router-dom";
 import { Laptop, Moon, Palette, Sun } from "lucide-react";
@@ -29,6 +29,34 @@ const WEB_VERSION_FALLBACK =
   (typeof import.meta.env.VITE_APP_VERSION === "string" ? import.meta.env.VITE_APP_VERSION : "") ||
   (typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : "") ||
   "unknown";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
+const MODE_INTENT_ACTIVE_ATTR = "data-mode-intent-active";
+const MODE_INTENT_TARGET_ATTR = "data-mode-intent-target";
+const MODE_INTENT_X_VAR = "--mode-intent-x";
+const MODE_INTENT_Y_VAR = "--mode-intent-y";
+const MODE_INTENT_STRENGTH_VAR = "--mode-intent-strength";
+const MODE_INTENT_ANGLE_VAR = "--mode-intent-angle";
+const MODE_INTENT_DISTANCE_VAR = "--mode-intent-distance";
+const MODE_BUTTON_INTENT_VAR = "--mode-button-intent";
+const MODE_BUTTON_PARALLAX_VAR = "--mode-button-parallax";
+const MODE_BUTTON_LIMB_VAR = "--mode-button-limb";
+
+const INTENT_NEAR_FIELD_PX = 128;
+const INTENT_HOVER_FLOOR = 0.26;
+const INTENT_MAX = 0.62;
+const INTENT_EASE_OUT_MS = 180;
+const INTENT_FOCUS_PULSE_MS = 260;
+const INTENT_FOCUS_PULSE_STRENGTH = 0.32;
+const INTENT_REDUCED_MOTION_FADE_MS = 120;
+
+function mediaQueryMatches(query: string): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia(query).matches;
+}
 
 export function UnifiedTopbarControls() {
   const session = useSession();
@@ -68,7 +96,132 @@ function ModeControl() {
   const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
   const applyTimeoutRef = useRef<number | null>(null);
   const pressTimeoutRef = useRef<number | null>(null);
+  const intentClearTimeoutRef = useRef<number | null>(null);
+  const intentFocusTimeoutRef = useRef<number | null>(null);
+  const pointerRafRef = useRef<number | null>(null);
+  const centerMeasureRafRef = useRef<number | null>(null);
+  const lastPointerRef = useRef<{ x: number; y: number } | null>(null);
+  const buttonCenterRef = useRef<{ x: number; y: number } | null>(null);
+  const isHoveringRef = useRef(false);
   const isDark = resolvedMode === "dark";
+  const targetMode: "dark" | "light" = isDark ? "light" : "dark";
+
+  const prefersReducedMotion = () => mediaQueryMatches(REDUCED_MOTION_QUERY);
+  const isCoarsePointer = () => mediaQueryMatches(COARSE_POINTER_QUERY);
+  const canUseProximityCue = () => !prefersReducedMotion() && !isCoarsePointer();
+
+  const setButtonIntentVisuals = (strength: number, angleDeg: number) => {
+    if (!toggleButtonRef.current) {
+      return;
+    }
+    const normalizedIntent = Math.min(1, Math.max(0, strength / INTENT_MAX));
+    const parallax = Math.max(-6, Math.min(6, (angleDeg - 90) * 0.055 * normalizedIntent));
+    const limb = normalizedIntent <= 0 ? 0 : Math.min(0.55, normalizedIntent * 0.55);
+    toggleButtonRef.current.style.setProperty(MODE_BUTTON_INTENT_VAR, normalizedIntent.toFixed(3));
+    toggleButtonRef.current.style.setProperty(MODE_BUTTON_PARALLAX_VAR, `${parallax.toFixed(2)}deg`);
+    toggleButtonRef.current.style.setProperty(MODE_BUTTON_LIMB_VAR, limb.toFixed(3));
+  };
+
+  const measureButtonCenter = () => {
+    if (!toggleButtonRef.current) {
+      buttonCenterRef.current = null;
+      return undefined;
+    }
+
+    const rect = toggleButtonRef.current.getBoundingClientRect();
+    const center = {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+    buttonCenterRef.current = center;
+    return center;
+  };
+
+  const scheduleButtonCenterMeasure = () => {
+    if (centerMeasureRafRef.current !== null) {
+      return;
+    }
+    centerMeasureRafRef.current = window.requestAnimationFrame(() => {
+      centerMeasureRafRef.current = null;
+      measureButtonCenter();
+    });
+  };
+
+  const clearIntentCueImmediately = () => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const root = document.documentElement;
+    root.removeAttribute(MODE_INTENT_ACTIVE_ATTR);
+    root.removeAttribute(MODE_INTENT_TARGET_ATTR);
+    root.style.removeProperty(MODE_INTENT_X_VAR);
+    root.style.removeProperty(MODE_INTENT_Y_VAR);
+    root.style.removeProperty(MODE_INTENT_STRENGTH_VAR);
+    root.style.removeProperty(MODE_INTENT_ANGLE_VAR);
+    root.style.removeProperty(MODE_INTENT_DISTANCE_VAR);
+    setButtonIntentVisuals(0, 90);
+  };
+
+  const clearIntentCue = (immediate = false, fadeMs = INTENT_EASE_OUT_MS) => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    if (intentClearTimeoutRef.current !== null) {
+      window.clearTimeout(intentClearTimeoutRef.current);
+      intentClearTimeoutRef.current = null;
+    }
+
+    if (immediate) {
+      clearIntentCueImmediately();
+      return;
+    }
+
+    const root = document.documentElement;
+    if (!root.hasAttribute(MODE_INTENT_ACTIVE_ATTR)) {
+      clearIntentCueImmediately();
+      return;
+    }
+
+    root.style.setProperty(MODE_INTENT_STRENGTH_VAR, "0");
+    setButtonIntentVisuals(0, 90);
+    intentClearTimeoutRef.current = window.setTimeout(() => {
+      clearIntentCueImmediately();
+      intentClearTimeoutRef.current = null;
+    }, fadeMs);
+  };
+
+  const setIntentCue = (
+    origin: { x: number; y: number },
+    strength: number,
+    nextTargetMode: "dark" | "light",
+    pointerAngleDeg = 90,
+    pointerDistancePx = 0,
+  ) => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    if (intentClearTimeoutRef.current !== null) {
+      window.clearTimeout(intentClearTimeoutRef.current);
+      intentClearTimeoutRef.current = null;
+    }
+
+    const normalizedStrength = Math.min(INTENT_MAX, Math.max(0, strength));
+    if (normalizedStrength <= 0) {
+      clearIntentCue();
+      return;
+    }
+
+    const root = document.documentElement;
+    root.setAttribute(MODE_INTENT_ACTIVE_ATTR, "true");
+    root.setAttribute(MODE_INTENT_TARGET_ATTR, nextTargetMode);
+    root.style.setProperty(MODE_INTENT_X_VAR, `${origin.x}px`);
+    root.style.setProperty(MODE_INTENT_Y_VAR, `${origin.y}px`);
+    root.style.setProperty(MODE_INTENT_STRENGTH_VAR, normalizedStrength.toFixed(3));
+    root.style.setProperty(MODE_INTENT_ANGLE_VAR, `${pointerAngleDeg.toFixed(2)}deg`);
+    root.style.setProperty(MODE_INTENT_DISTANCE_VAR, `${pointerDistancePx.toFixed(2)}px`);
+    setButtonIntentVisuals(normalizedStrength, pointerAngleDeg);
+  };
 
   const clearButtonTimers = () => {
     if (applyTimeoutRef.current !== null) {
@@ -82,6 +235,57 @@ function ModeControl() {
   };
 
   useEffect(() => {
+    measureButtonCenter();
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!canUseProximityCue()) {
+        return;
+      }
+      lastPointerRef.current = {
+        x: event.clientX,
+        y: event.clientY,
+      };
+
+      if (pointerRafRef.current !== null) {
+        return;
+      }
+
+      pointerRafRef.current = window.requestAnimationFrame(() => {
+        pointerRafRef.current = null;
+        if (!lastPointerRef.current) {
+          return;
+        }
+
+        const geometry = resolveIntentGeometry(lastPointerRef.current);
+        if (!geometry) {
+          return;
+        }
+
+        const { distance, angleDeg } = geometry;
+        const proximity = Math.max(0, 1 - distance / INTENT_NEAR_FIELD_PX);
+        let strength = proximity * INTENT_MAX;
+
+        if (isHoveringRef.current) {
+          strength = Math.max(strength, INTENT_HOVER_FLOOR);
+        }
+
+        if (strength <= 0) {
+          clearIntentCue();
+          return;
+        }
+
+        setIntentCue(geometry.center, strength, targetMode, angleDeg, distance);
+      });
+    };
+
+    const handleViewportChange = () => {
+      scheduleButtonCenterMeasure();
+    };
+
+    window.addEventListener("pointermove", handlePointerMove, { passive: true });
+    window.addEventListener("resize", handleViewportChange, { passive: true });
+    window.addEventListener("scroll", handleViewportChange, true);
+
     return () => {
       if (applyTimeoutRef.current !== null) {
         window.clearTimeout(applyTimeoutRef.current);
@@ -89,36 +293,84 @@ function ModeControl() {
       if (pressTimeoutRef.current !== null) {
         window.clearTimeout(pressTimeoutRef.current);
       }
+      if (intentClearTimeoutRef.current !== null) {
+        window.clearTimeout(intentClearTimeoutRef.current);
+      }
+      if (intentFocusTimeoutRef.current !== null) {
+        window.clearTimeout(intentFocusTimeoutRef.current);
+      }
+      if (pointerRafRef.current !== null) {
+        window.cancelAnimationFrame(pointerRafRef.current);
+      }
+      if (centerMeasureRafRef.current !== null) {
+        window.cancelAnimationFrame(centerMeasureRafRef.current);
+      }
+
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange, true);
+      clearIntentCueImmediately();
     };
-  }, []);
+  }, [targetMode]);
 
   const resolveOrigin = () => {
-    if (!toggleButtonRef.current) {
+    return buttonCenterRef.current ?? measureButtonCenter();
+  };
+
+  const resolveIntentGeometry = (point: { x: number; y: number }) => {
+    const center = resolveOrigin();
+    if (!center) {
       return undefined;
     }
-    const rect = toggleButtonRef.current.getBoundingClientRect();
+
+    const dx = point.x - center.x;
+    const dy = point.y - center.y;
+    const distance = Math.hypot(dx, dy);
+    const angleDeg = (Math.atan2(dy, dx) * 180) / Math.PI;
     return {
-      x: rect.left + rect.width / 2,
-      y: rect.top + rect.height / 2,
+      center,
+      distance,
+      angleDeg,
     };
   };
 
   const setAnimatedMode = (next: "light" | "dark" | "system") => {
+    const origin = measureButtonCenter() ?? resolveOrigin();
     setModePreference(next, {
       animate: true,
-      origin: resolveOrigin(),
+      origin,
       source: "user",
     });
   };
 
+  const freezeIntentAtCenter = (nextTargetMode: "dark" | "light") => {
+    const origin = measureButtonCenter() ?? resolveOrigin();
+    if (!origin) {
+      return;
+    }
+
+    const reducedMotion = prefersReducedMotion();
+    const strength = reducedMotion
+      ? Math.min(INTENT_HOVER_FLOOR, INTENT_FOCUS_PULSE_STRENGTH * 0.7)
+      : Math.max(INTENT_HOVER_FLOOR, INTENT_FOCUS_PULSE_STRENGTH);
+
+    setIntentCue(origin, strength, nextTargetMode, 90, 0);
+
+    if (reducedMotion) {
+      clearIntentCue(false, INTENT_REDUCED_MOTION_FADE_MS);
+    }
+  };
+
   const handlePrimaryToggle = () => {
-    const next = isDark ? "light" : "dark";
+    const next: "dark" | "light" = isDark ? "light" : "dark";
     clearButtonTimers();
     setIsPressing(true);
     setIconDrift(next === "dark" ? "to-dark" : "to-light");
+    freezeIntentAtCenter(next);
 
     applyTimeoutRef.current = window.setTimeout(() => {
       setAnimatedMode(next);
+      clearIntentCue(false, prefersReducedMotion() ? INTENT_REDUCED_MOTION_FADE_MS : INTENT_EASE_OUT_MS);
       applyTimeoutRef.current = null;
     }, MOTION_PROFILE.buttonPress.leadInMs);
 
@@ -127,6 +379,94 @@ function ModeControl() {
       setIconDrift(null);
       pressTimeoutRef.current = null;
     }, MOTION_PROFILE.buttonPress.durationMs);
+  };
+
+  const handlePointerEnter = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    isHoveringRef.current = true;
+    measureButtonCenter();
+    if (!canUseProximityCue()) {
+      return;
+    }
+
+    const geometry = resolveIntentGeometry({
+      x: event.clientX,
+      y: event.clientY,
+    });
+    const center = geometry?.center ?? resolveOrigin() ?? { x: event.clientX, y: event.clientY };
+    const angle = geometry?.angleDeg ?? 90;
+    const distance = geometry?.distance ?? 0;
+
+    setIntentCue(
+      center,
+      INTENT_HOVER_FLOOR,
+      targetMode,
+      angle,
+      distance,
+    );
+  };
+
+  const handlePointerLeave = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    isHoveringRef.current = false;
+    if (!canUseProximityCue()) {
+      clearIntentCue(true);
+      return;
+    }
+
+    const geometry = resolveIntentGeometry({
+      x: event.clientX,
+      y: event.clientY,
+    });
+    if (!geometry) {
+      clearIntentCue();
+      return;
+    }
+
+    const origin = geometry.center;
+    const { distance, angleDeg } = geometry;
+    const proximity = Math.max(0, 1 - distance / INTENT_NEAR_FIELD_PX);
+    const strength = proximity * INTENT_MAX;
+
+    if (strength <= 0) {
+      clearIntentCue();
+      return;
+    }
+
+    setIntentCue(origin, strength, targetMode, angleDeg, distance);
+  };
+
+  const handlePointerDown = () => {
+    freezeIntentAtCenter(targetMode);
+  };
+
+  const handleFocus = () => {
+    measureButtonCenter();
+    const origin = resolveOrigin();
+    if (!origin) {
+      return;
+    }
+
+    if (intentFocusTimeoutRef.current !== null) {
+      window.clearTimeout(intentFocusTimeoutRef.current);
+      intentFocusTimeoutRef.current = null;
+    }
+
+    const reducedMotion = prefersReducedMotion();
+    const strength = reducedMotion ? INTENT_FOCUS_PULSE_STRENGTH * 0.7 : INTENT_FOCUS_PULSE_STRENGTH;
+    const fadeMs = reducedMotion ? INTENT_REDUCED_MOTION_FADE_MS : INTENT_FOCUS_PULSE_MS;
+
+    setIntentCue(origin, strength, targetMode, 90, 0);
+    intentFocusTimeoutRef.current = window.setTimeout(() => {
+      clearIntentCue(false, fadeMs);
+      intentFocusTimeoutRef.current = null;
+    }, fadeMs);
+  };
+
+  const handleBlur = () => {
+    if (intentFocusTimeoutRef.current !== null) {
+      window.clearTimeout(intentFocusTimeoutRef.current);
+      intentFocusTimeoutRef.current = null;
+    }
+    clearIntentCue(false, prefersReducedMotion() ? INTENT_REDUCED_MOTION_FADE_MS : INTENT_EASE_OUT_MS);
   };
 
   const getModeIcon = (mode: "light" | "dark" | "system") => {
@@ -146,21 +486,25 @@ function ModeControl() {
         type="button"
         data-theme-mode-anchor={WORKSPACE_THEME_MODE_ANCHOR}
         data-pressing={isPressing}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        onPointerDown={handlePointerDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         onClick={handlePrimaryToggle}
         aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
         className={clsx(
           "inline-flex h-8 w-8 items-center justify-center rounded-l-full rounded-r-sm text-foreground transition",
           "data-[pressing=true]:animate-[theme-toggle-press_120ms_ease-out]",
-          "hover:bg-foreground/10 hover:text-foreground",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         )}
       >
         <span
           data-mode-icon
           className={clsx(
-            "inline-flex items-center justify-center transition-transform duration-150",
-            iconDrift === "to-dark" && "rotate-[8deg]",
-            iconDrift === "to-light" && "-rotate-[8deg]",
+            "inline-flex items-center justify-center transition-transform duration-180",
+            iconDrift === "to-dark" && "rotate-[6deg]",
+            iconDrift === "to-light" && "-rotate-[6deg]",
           )}
         >
           <span
@@ -172,7 +516,27 @@ function ModeControl() {
               "data-[drift=to-light]:animate-[theme-icon-drift_80ms_ease-out]",
             )}
           >
-            {isDark ? <Sun className="h-[15px] w-[15px]" /> : <Moon className="h-[15px] w-[15px]" />}
+            <span data-mode-celestial-core className="relative inline-flex h-[15px] w-[15px] items-center justify-center">
+              <span aria-hidden data-mode-icon-orbit />
+              <span aria-hidden data-mode-icon-limb />
+              <span aria-hidden data-mode-icon-arc />
+              <Sun
+                data-mode-sun
+                aria-hidden
+                className={clsx(
+                  "absolute h-[15px] w-[15px] transition-all duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+                  isDark ? "rotate-0 scale-100 opacity-100" : "-rotate-45 scale-75 opacity-0",
+                )}
+              />
+              <Moon
+                data-mode-moon
+                aria-hidden
+                className={clsx(
+                  "absolute h-[15px] w-[15px] transition-all duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+                  isDark ? "rotate-45 scale-75 opacity-0" : "rotate-0 scale-100 opacity-100",
+                )}
+              />
+            </span>
           </span>
         </span>
       </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,24 +12,32 @@ body,
   overflow-x: hidden;
 }
 
-:root[data-mode-transition^="reveal"]::view-transition-old(root),
-:root[data-mode-transition^="reveal"]::view-transition-new(root) {
-  animation: none;
-  mix-blend-mode: normal;
+:root {
+  --mode-intent-x: 50vw;
+  --mode-intent-y: 50vh;
+  --mode-intent-strength: 0;
+  --mode-intent-angle: 90deg;
+  --mode-intent-distance: 0px;
 }
 
 :root[data-mode-transition] {
   isolation: isolate;
 }
 
-:root[data-mode-transition="reveal-expand"]::view-transition-old(root),
-:root[data-mode-transition="reveal-collapse"]::view-transition-new(root) {
+:root[data-mode-transition^="reveal"]::view-transition-old(root),
+:root[data-mode-transition^="reveal"]::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+  transform-origin: var(--mode-transition-origin-x) var(--mode-transition-origin-y);
+}
+
+:root[data-mode-transition^="reveal"]::view-transition-old(root) {
   z-index: 1;
 }
 
-:root[data-mode-transition="reveal-expand"]::view-transition-new(root),
-:root[data-mode-transition="reveal-collapse"]::view-transition-old(root) {
+:root[data-mode-transition^="reveal"]::view-transition-new(root) {
   z-index: 2;
+  will-change: clip-path, filter;
 }
 
 :root[data-mode-transition^="fallback"]::view-transition-old(root),
@@ -37,12 +45,175 @@ body,
   animation: none;
 }
 
+:root[data-mode-intent-active="true"]::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: calc(var(--app-z-popover) - 2);
+  opacity: 1;
+  transition:
+    opacity 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+:root[data-mode-intent-active="true"]::before {
+  filter: blur(calc(1.5px + var(--mode-intent-strength) * 8px));
+  opacity: clamp(0, calc(var(--mode-intent-strength) * 1.08), 0.2);
+}
+
+:root[data-mode-intent-active="true"][data-mode-intent-target="dark"]::before {
+  opacity: clamp(0, calc(var(--mode-intent-strength) * 1.26), 0.24);
+  background:
+    radial-gradient(
+      circle 224px at var(--mode-intent-x) var(--mode-intent-y),
+      rgb(20 28 52 / 0.44) 0%,
+      rgb(27 37 66 / 0.3) 30%,
+      rgb(21 30 54 / 0.2) 55%,
+      rgb(13 17 31 / 0) 82%
+    ),
+    radial-gradient(
+      circle 324px at var(--mode-intent-x) var(--mode-intent-y),
+      rgb(10 15 26 / 0.31) 0%,
+      rgb(10 15 26 / 0) 74%
+    );
+}
+
+:root[data-mode-intent-active="true"][data-mode-intent-target="light"]::before {
+  background:
+    radial-gradient(
+      circle 208px at var(--mode-intent-x) var(--mode-intent-y),
+      rgb(255 254 238 / 0.24) 0%,
+      rgb(255 235 177 / 0.16) 26%,
+      rgb(255 199 120 / 0.11) 52%,
+      rgb(255 171 84 / 0) 84%
+    ),
+    radial-gradient(
+      circle 300px at var(--mode-intent-x) var(--mode-intent-y),
+      rgb(255 220 139 / 0.09) 0%,
+      rgb(255 208 122 / 0) 74%
+    );
+}
+
+[data-theme-mode-anchor] {
+  --mode-button-intent: 0;
+  --mode-button-parallax: 0deg;
+  --mode-button-limb: 0;
+}
+
+[data-theme-mode-anchor] [data-mode-celestial-core] {
+  transform: rotate(var(--mode-button-parallax)) scale(calc(1 + var(--mode-button-intent) * 0.08));
+  transition: transform 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-theme-mode-anchor] [data-mode-icon-orbit] {
+  position: absolute;
+  inset: -4px;
+  border-radius: 999px;
+  pointer-events: none;
+  opacity: clamp(0, calc(var(--mode-button-intent) * 0.72), 0.58);
+  transition:
+    opacity 140ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-theme-mode-anchor] [data-mode-icon-limb],
+[data-theme-mode-anchor] [data-mode-icon-arc] {
+  position: absolute;
+  pointer-events: none;
+  border-radius: 999px;
+}
+
+[data-theme-mode-anchor] [data-mode-icon-limb] {
+  inset: -2px;
+  opacity: clamp(0, var(--mode-button-limb), 0.55);
+  transform: rotate(calc(var(--mode-button-parallax) * -0.7)) scale(calc(0.94 + var(--mode-button-intent) * 0.14));
+  transition:
+    opacity 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-theme-mode-anchor] [data-mode-icon-arc] {
+  inset: -4px;
+  opacity: clamp(0, calc(var(--mode-button-intent) * 0.86), 0.55);
+  transform: rotate(calc(var(--mode-button-parallax) * 1.2));
+  transition:
+    opacity 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+:root[data-mode-intent-target="dark"] [data-theme-mode-anchor] [data-mode-icon-orbit] {
+  background:
+    radial-gradient(circle at 35% 35%, rgb(223 233 255 / 0.52) 0%, rgb(145 168 227 / 0.18) 46%, rgb(70 92 162 / 0) 76%),
+    radial-gradient(circle at 68% 68%, rgb(87 115 176 / 0.32) 0%, rgb(87 115 176 / 0) 70%);
+  filter: blur(0.7px);
+}
+
+:root[data-mode-intent-target="dark"] [data-theme-mode-anchor] [data-mode-icon-limb] {
+  background:
+    radial-gradient(circle at 35% 34%, rgb(232 240 255 / 0.64) 0%, rgb(166 187 238 / 0.23) 52%, rgb(76 99 167 / 0) 80%),
+    radial-gradient(circle at 64% 68%, rgb(68 93 156 / 0.28) 0%, rgb(68 93 156 / 0) 70%);
+  filter: blur(calc(0.35px + var(--mode-button-limb) * 3.6px));
+}
+
+:root[data-mode-intent-target="dark"] [data-theme-mode-anchor] [data-mode-icon-arc] {
+  background: conic-gradient(
+    from 214deg at 50% 50%,
+    rgb(145 174 244 / 0) 0deg 288deg,
+    rgb(214 227 255 / 0.54) 306deg 334deg,
+    rgb(145 174 244 / 0.16) 334deg 348deg,
+    rgb(145 174 244 / 0) 348deg 360deg
+  );
+  filter: blur(calc(0.25px + var(--mode-button-intent) * 1.75px));
+}
+
+:root[data-mode-intent-target="light"] [data-theme-mode-anchor] [data-mode-icon-orbit] {
+  background:
+    radial-gradient(circle at 35% 35%, rgb(255 248 196 / 0.58) 0%, rgb(255 210 134 / 0.24) 46%, rgb(255 185 90 / 0) 76%),
+    radial-gradient(circle at 68% 68%, rgb(255 189 92 / 0.34) 0%, rgb(255 189 92 / 0) 70%);
+  filter: blur(0.8px);
+}
+
+:root[data-mode-intent-target="light"] [data-theme-mode-anchor] [data-mode-icon-limb] {
+  background:
+    radial-gradient(circle at 34% 34%, rgb(255 252 206 / 0.68) 0%, rgb(255 223 145 / 0.28) 52%, rgb(255 191 96 / 0) 80%),
+    radial-gradient(circle at 66% 68%, rgb(255 187 89 / 0.31) 0%, rgb(255 187 89 / 0) 70%);
+  filter: blur(calc(0.35px + var(--mode-button-limb) * 3.6px));
+}
+
+:root[data-mode-intent-target="light"] [data-theme-mode-anchor] [data-mode-icon-arc] {
+  background: conic-gradient(
+    from 214deg at 50% 50%,
+    rgb(255 192 98 / 0) 0deg 288deg,
+    rgb(255 238 170 / 0.58) 306deg 334deg,
+    rgb(255 196 105 / 0.22) 334deg 348deg,
+    rgb(255 192 98 / 0) 348deg 360deg
+  );
+  filter: blur(calc(0.25px + var(--mode-button-intent) * 1.75px));
+}
+
+[data-theme-mode-anchor] [data-mode-sun],
+[data-theme-mode-anchor] [data-mode-moon] {
+  filter: brightness(calc(1 + var(--mode-button-intent) * 0.2));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-mode-intent-active="true"]::before {
+    transition: none;
+  }
+}
+
 @keyframes theme-toggle-press {
   0% {
     transform: scale(1);
   }
-  35% {
-    transform: scale(0.96);
+  30% {
+    transform: scale(0.972);
+  }
+  70% {
+    transform: scale(0.995);
   }
   100% {
     transform: scale(1);
@@ -51,13 +222,13 @@ body,
 
 @keyframes theme-icon-drift {
   0% {
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
   }
-  35% {
-    transform: translateY(-0.5px);
+  40% {
+    transform: translateY(-0.65px) scale(1.03);
   }
   100% {
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
   }
 }
 


### PR DESCRIPTION
## Summary
This PR upgrades the theme mode interaction so it feels premium and intentional while staying maintainable and performant.

## What Changed
- Refined mode transition engine with staged always-expand reveal for both directions.
- Added organic wavefront shaping in the transition keyframes:
  - intent-angle-driven center shear
  - twin-penumbra edge treatment (primary + trailing shadow)
- Brought fallback transition path in line with the primary path (staged progress + trailing penumbra).
- Added expressive pre-click celestial intent cues in topbar mode control:
  - proximity/focus/click handoff cues
  - bounded icon parallax/limb/orbit effects
  - reduced-motion and coarse-pointer guardrails preserved
- Tuned interaction polish per feedback:
  - removed generic hover background fill from the primary mode icon button only
  - anchored proximity cue origin to the mode button center (not pointer location)
  - removed global background wash from intent cue
  - increased dark-target proximity visibility on light mode

## Implementation Notes
- Kept structure easy to reason about:
  - motion tuning in `MOTION_PROFILE`
  - localized intent controller in `ModeControl`
  - no new provider/context added
- Added `ORGANIC_STYLE_VERSION` marker in transition module for style tracking.

## Tests
- Updated and expanded:
  - `frontend/src/providers/theme/__tests__/modeTransition.test.ts`
  - `frontend/src/app/layouts/components/topbar/__tests__/UnifiedTopbarControls.test.tsx`
- Verified locally:
  - `cd backend && uv run ade web lint`
  - `cd backend && uv run ade web test`
