### PR TITLE
fix(web): tighten theme intent proximity trigger

### DIFF
--- a/frontend/src/app/layouts/components/topbar/UnifiedTopbarControls.tsx
+++ b/frontend/src/app/layouts/components/topbar/UnifiedTopbarControls.tsx
@@ -43,7 +43,7 @@ const MODE_BUTTON_INTENT_VAR = "--mode-button-intent";
 const MODE_BUTTON_PARALLAX_VAR = "--mode-button-parallax";
 const MODE_BUTTON_LIMB_VAR = "--mode-button-limb";
 
-const INTENT_NEAR_FIELD_PX = 128;
+const INTENT_NEAR_FIELD_PX = 76;
 const INTENT_HOVER_FLOOR = 0.26;
 const INTENT_MAX = 0.62;
 const INTENT_EASE_OUT_MS = 180;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,18 +63,18 @@ body,
 }
 
 :root[data-mode-intent-active="true"][data-mode-intent-target="dark"]::before {
-  opacity: clamp(0, calc(var(--mode-intent-strength) * 1.26), 0.24);
+  opacity: clamp(0, calc(var(--mode-intent-strength) * 1.14), 0.21);
   background:
     radial-gradient(
-      circle 224px at var(--mode-intent-x) var(--mode-intent-y),
-      rgb(20 28 52 / 0.44) 0%,
-      rgb(27 37 66 / 0.3) 30%,
-      rgb(21 30 54 / 0.2) 55%,
+      circle 216px at var(--mode-intent-x) var(--mode-intent-y),
+      rgb(20 28 52 / 0.39) 0%,
+      rgb(27 37 66 / 0.26) 30%,
+      rgb(21 30 54 / 0.17) 55%,
       rgb(13 17 31 / 0) 82%
     ),
     radial-gradient(
-      circle 324px at var(--mode-intent-x) var(--mode-intent-y),
-      rgb(10 15 26 / 0.31) 0%,
+      circle 316px at var(--mode-intent-x) var(--mode-intent-y),
+      rgb(10 15 26 / 0.26) 0%,
       rgb(10 15 26 / 0) 74%
     );
 }


### PR DESCRIPTION
## Summary
This follow-up tunes theme intent proximity so cues stay noticeable but activate only when the pointer is closer to the mode toggle.

## Changes
- Reduced the proximity activation radius in mode control:
  - `INTENT_NEAR_FIELD_PX`: `128 -> 76`
  - File: `frontend/src/app/layouts/components/topbar/UnifiedTopbarControls.tsx`
- Slightly softened dark-target local intent bloom while keeping it visible:
  - reduced dark-target opacity cap/multiplier and gradient spread/alpha values
  - File: `frontend/src/index.css`

## Why
The previous proximity cue was visually good but engaged from too far away. This makes the interaction feel more deliberate while preserving the expressive effect.

## Validation
- `cd frontend && npm run test -- src/app/layouts/components/topbar/__tests__/UnifiedTopbarControls.test.tsx`
- `cd backend && uv run ade web lint`
