### PR TITLE
fix(auth): prevent premature redirect during MFA setup

### DIFF
--- a/frontend/src/pages/MfaSetup/__tests__/MfaSetup.test.tsx
+++ b/frontend/src/pages/MfaSetup/__tests__/MfaSetup.test.tsx
@@ -1,0 +1,105 @@
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import type { MfaStatusResponse } from "@/api/auth/api";
+import { AllProviders } from "@/test/test-utils";
+import MfaSetupPage from "@/pages/MfaSetup";
+
+const mockFetchMfaStatus = vi.fn();
+
+vi.mock("@/api/auth/api", async () => {
+  const actual = await vi.importActual<typeof import("@/api/auth/api")>("@/api/auth/api");
+  return {
+    ...actual,
+    fetchMfaStatus: (...args: unknown[]) => mockFetchMfaStatus(...args),
+  };
+});
+
+vi.mock("@/features/mfa-setup", () => ({
+  MfaSetupFlow: ({
+    onRefreshMfaStatus,
+    onFlowComplete,
+  }: {
+    readonly onRefreshMfaStatus: () => Promise<void>;
+    readonly onFlowComplete?: () => void;
+  }) => (
+    <div data-testid="mfa-setup-flow">
+      <button type="button" onClick={() => void onRefreshMfaStatus()}>
+        Refresh status
+      </button>
+      <button type="button" onClick={() => onFlowComplete?.()}>
+        Complete flow
+      </button>
+    </div>
+  ),
+}));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <span data-testid="location">{`${location.pathname}${location.search}`}</span>;
+}
+
+function RouteShell({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <AllProviders>
+      <LocationDisplay />
+      {children}
+    </AllProviders>
+  );
+}
+
+function renderWithHistory(path = "/mfa/setup") {
+  return rtlRender(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/workspaces" element={<RouteShell>Workspaces</RouteShell>} />
+        <Route path="/mfa/setup" element={<RouteShell><MfaSetupPage /></RouteShell>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const REQUIRED_ONBOARDING_STATUS: MfaStatusResponse = {
+  enabled: false,
+  enrolledAt: null,
+  recoveryCodesRemaining: null,
+  onboardingRecommended: false,
+  onboardingRequired: true,
+  skipAllowed: false,
+};
+
+const ENABLED_STATUS: MfaStatusResponse = {
+  enabled: true,
+  enrolledAt: "2026-01-01T00:00:00Z",
+  recoveryCodesRemaining: 10,
+  onboardingRecommended: false,
+  onboardingRequired: false,
+  skipAllowed: false,
+};
+
+describe("MfaSetupPage", () => {
+  beforeEach(() => {
+    mockFetchMfaStatus.mockReset();
+  });
+
+  it("stays on setup after enrollment verification until the flow is explicitly completed", async () => {
+    mockFetchMfaStatus
+      .mockResolvedValueOnce(REQUIRED_ONBOARDING_STATUS)
+      .mockResolvedValueOnce(ENABLED_STATUS);
+
+    const user = userEvent.setup();
+    renderWithHistory("/mfa/setup?returnTo=/workspaces");
+
+    await screen.findByTestId("mfa-setup-flow");
+    expect(screen.getByTestId("location")).toHaveTextContent("/mfa/setup?returnTo=/workspaces");
+
+    await user.click(screen.getByRole("button", { name: "Refresh status" }));
+    await waitFor(() => expect(mockFetchMfaStatus).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("location")).toHaveTextContent("/mfa/setup?returnTo=/workspaces");
+
+    await user.click(screen.getByRole("button", { name: "Complete flow" }));
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("/workspaces"));
+  });
+});

--- a/frontend/src/pages/MfaSetup/index.tsx
+++ b/frontend/src/pages/MfaSetup/index.tsx
@@ -59,13 +59,6 @@ export default function MfaSetupPage() {
     void refreshStatus();
   }, [refreshStatus]);
 
-  useEffect(() => {
-    if (!mfaStatus?.enabled) {
-      return;
-    }
-    navigate(returnTo, { replace: true });
-  }, [mfaStatus?.enabled, navigate, returnTo]);
-
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background px-6">


### PR DESCRIPTION
## Summary
- remove page-level redirect from  that navigated away as soon as  became true
- keep navigation controlled by explicit flow completion () and skip action ()
- add a regression test that reproduces the status-refresh timing issue and verifies no redirect happens before completion

## Root cause
The setup flow refreshes MFA status immediately after OTP verification to reflect new server state. Because the page also redirected whenever , users were navigated away before completing recovery-code acknowledgement.

## Validation
- 
> ade-web@0.0.0 test
> vitest run src/pages/MfaSetup/__tests__/MfaSetup.test.tsx


 RUN  v4.0.18 /Users/justinkropp/.codex/worktrees/0671/automatic-data-extractor/frontend

 ✓ src/pages/MfaSetup/__tests__/MfaSetup.test.tsx (1 test) 93ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  01:24:16
   Duration  735ms (transform 128ms, setup 73ms, import 179ms, tests 93ms, environment 297ms)
- 
> ade-web@0.0.0 test
> vitest run


 RUN  v4.0.18 /Users/justinkropp/.codex/worktrees/0671/automatic-data-extractor/frontend

 ✓ src/app/layouts/__tests__/AuthenticatedLayout.test.tsx (8 tests) 422ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/components/__tests__/ConfigurationImportDialog.test.tsx (6 tests) 617ms
 ✓ src/pages/ResetPassword/__tests__/ResetPassword.test.tsx (6 tests) 801ms
 ✓ src/app/layouts/components/topbar/__tests__/UnifiedTopbarControls.test.tsx (9 tests) 840ms
 ✓ src/pages/Workspace/sections/Documents/list/upload/ReprocessPreflightDialog.test.tsx (3 tests) 526ms
 ✓ src/pages/Workspace/sections/Documents/list/table/cells/__tests__/DocumentNameCell.test.tsx (3 tests) 684ms
     ✓ supports inline rename via F2 + Enter  348ms
 ✓ src/components/data-table/__tests__/data-table.test.tsx (5 tests) 432ms
 ✓ src/pages/OrganizationSettings/__tests__/systemSsoSettingsPage.test.tsx (4 tests) 493ms
 ✓ src/pages/ForgotPassword/__tests__/ForgotPassword.test.tsx (5 tests) 478ms
 ✓ src/pages/Workspace/sections/Documents/detail/components/__tests__/DocumentTicketHeader.test.tsx (1 test) 409ms
     ✓ uses unified download as primary and exposes original in the menu  407ms
 ✓ src/pages/Workspace/sections/Documents/shared/ui/__tests__/RenameDocumentDialog.test.tsx (3 tests) 481ms
 ✓ src/pages/Login/__tests__/Login.test.tsx (17 tests) 2448ms
     ✓ reveals subtle fallback guidance after two invalid submissions  407ms
 ✓ src/pages/Workspace/sections/Documents/list/upload/UploadPreflightDialog.test.tsx (3 tests) 622ms
 ✓ src/pages/OrganizationSettings/components/__tests__/settingsPrimitives.test.tsx (5 tests) 288ms
 ✓ src/pages/OrganizationSettings/components/__tests__/OrganizationSettingsTopbarSearch.test.tsx (2 tests) 354ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/workbench/state/__tests__/useUnsavedChangesGuard.test.tsx (2 tests) 342ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/workbench/components/__tests__/PublishConfigurationDialog.test.tsx (4 tests) 259ms
 ✓ src/providers/auth/__tests__/RequireSession.test.tsx (8 tests) 341ms
 ✓ src/pages/Workspaces/__tests__/WorkspacesScreen.test.tsx (2 tests) 324ms
 ✓ src/__tests__/App.test.tsx (18 tests) 3924ms
     ✓ renders /  391ms
     ✓ renders /forgot-password  309ms
     ✓ renders /account  326ms
     ✓ renders /login  307ms
     ✓ renders /mfa/setup  309ms
     ✓ renders /reset-password  305ms
     ✓ renders /setup  304ms
     ✓ renders /organization  317ms
     ✓ renders /workspaces  319ms
     ✓ renders /workspaces/new  320ms
     ✓ renders /workspaces/ws-1  306ms
     ✓ falls back to the not found screen  315ms
 ✓ src/providers/theme/__tests__/modeTransition.test.ts (8 tests) 147ms
 ✓ src/components/ui/tabs/__tests__/Tabs.test.tsx (2 tests) 352ms
 ✓ src/features/sso-setup/__tests__/SsoSetupFlow.test.tsx (5 tests) 4938ms
     ✓ disables continue on test step until validation passes  1587ms
     ✓ saves provider after successful validation  1458ms
     ✓ skips validation for edit-only non-connection changes  301ms
     ✓ shows actionable validation remediation for issuer mismatch  1351ms
 ✓ src/api/auth/__tests__/api.test.ts (15 tests) 47ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/workbench/state/__tests__/useWorkbenchFiles.test.tsx (4 tests) 102ms
 ✓ src/components/ui/__tests__/context-menu-simple.test.tsx (2 tests) 259ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/workbench/__tests__/Workbench.publish-flow.test.tsx (5 tests) 276ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/workbench/components/__tests__/EditorArea.test.tsx (5 tests) 177ms
 ✓ src/lib/uploads/__tests__/queue.test.ts (3 tests) 28ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/workbench/utils/__tests__/tree.test.ts (3 tests) 29ms
 ✓ src/app/layouts/components/topbar/__tests__/AuthenticatedTopbarContext.test.tsx (2 tests) 58ms
 ✓ src/api/runs/__tests__/api.test.ts (15 tests) 35ms
 ✓ src/providers/theme/__tests__/ThemeProvider.modeTransition.test.tsx (3 tests) 63ms
 ✓ src/pages/MfaSetup/__tests__/MfaSetup.test.tsx (1 test) 385ms
     ✓ stays on setup after enrollment verification until the flow is explicitly completed  383ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/workbench/components/__tests__/consoleFormatting.test.tsx (4 tests) 67ms
 ✓ src/pages/Workspace/sections/Documents/list/table/__tests__/DocumentsTable.context-menu.test.tsx (1 test) 535ms
     ✓ opens custom row context menu on right click  534ms
 ✓ src/pages/Workspace/sections/Documents/shared/hooks/__tests__/useRenameDocumentMutation.test.tsx (4 tests) 49ms
 ✓ src/api/configurations/__tests__/api.test.ts (4 tests) 7ms
 ✓ src/api/__tests__/uiErrors.test.ts (3 tests) 3ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/workbench/state/__tests__/workbenchSearchParams.test.ts (4 tests) 5ms
 ✓ src/pages/Workspace/sections/Documents/detail/tabs/activity/model.test.ts (3 tests) 8ms
 ✓ src/pages/Workspace/sections/Documents/list/state/__tests__/queryState.test.ts (5 tests) 3ms
 ✓ src/api/admin/__tests__/api-keys.test.ts (2 tests) 20ms
 ✓ src/api/__tests__/errors.test.ts (8 tests) 7ms
 ✓ src/pages/Workspace/sections/Documents/list/upload/sheetSelection.test.ts (6 tests) 3ms
 ✓ src/pages/Workspace/__tests__/resolveWorkspaceSection.test.tsx (8 tests) 6ms
 ✓ src/api/admin/__tests__/roles.test.ts (2 tests) 4ms
 ✓ src/pages/Workspace/sections/Settings/__tests__/settingsNav.test.ts (5 tests) 6ms
 ✓ src/api/workspaces/__tests__/api.test.ts (4 tests) 4ms
 ✓ src/pages/Workspace/hooks/presence/__tests__/presenceParticipants.test.ts (4 tests) 6ms
 ✓ src/api/admin/__tests__/users.test.ts (2 tests) 7ms
 ✓ src/api/admin/__tests__/sso.test.ts (5 tests) 7ms
 ✓ src/api/me/__tests__/api.test.ts (2 tests) 6ms
 ✓ src/api/documents/__tests__/api.test.ts (6 tests) 9ms
 ✓ src/api/admin/__tests__/settings.test.ts (2 tests) 7ms
 ✓ src/pages/OrganizationSettings/__tests__/settingsNav.test.tsx (6 tests) 6ms
 ✓ src/api/api-keys/__tests__/api.test.ts (3 tests) 8ms
 ✓ src/api/__tests__/pagination.test.ts (2 tests) 3ms
 ✓ src/pages/Workspace/sections/Documents/detail/tabs/preview/__tests__/state.test.ts (4 tests) 5ms
 ✓ src/pages/Workspace/sections/ConfigurationEditor/utils/__tests__/configs.test.ts (4 tests) 2ms
 ✓ src/pages/Login/__tests__/mfaCode.test.ts (5 tests) 3ms
 ✓ src/pages/Workspace/sections/Documents/shared/__tests__/navigation.test.ts (4 tests) 3ms
 ✓ src/config/__tests__/ports.test.ts (3 tests) 3ms
 ✓ src/pages/Workspace/sections/Documents/list/table/actions/__tests__/documentRowActions.test.ts (3 tests) 4ms
 ✓ src/pages/OrganizationSettings/__tests__/apiKeysSettingsPage.test.ts (2 tests) 2ms

 Test Files  65 passed (65)
      Tests  307 passed (307)
   Start at  01:24:18
   Duration  11.48s (transform 5.60s, setup 8.83s, import 16.40s, tests 22.79s, environment 38.59s)
- 
> ade-web@0.0.0 lint
> eslint "src/**/*.{ts,tsx}" --max-warnings=0