### PR TITLE
fix(documents): show date-only in Last Run column

### DIFF
--- a/frontend/src/pages/Workspace/sections/Documents/list/table/documentsColumns.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/documentsColumns.tsx
@@ -243,7 +243,10 @@ export function useDocumentsColumns({
         accessorFn: (row) =>
           row.lastRun?.completedAt ?? row.lastRun?.startedAt ?? row.lastRun?.createdAt ?? null,
         header: ({ column }) => <DataTableColumnHeader column={column} label="Last Run" />,
-        cell: ({ row }) => renderRunSummary(row.original.lastRun),
+        cell: ({ row }) => {
+          const value = row.getValue<string | null>("lastRunAt");
+          return value ? formatTimestamp(value) : <span className="text-muted-foreground">-</span>;
+        },
         meta: {
           label: "Last Run",
           headerClassName: "hidden xl:table-cell",
@@ -397,29 +400,6 @@ export function useDocumentsColumns({
       tagFilterOptions,
       tagOptions,
     ],
-  );
-}
-
-function formatRunStatus(value: string) {
-  if (!value) return "-";
-  const normalized = value.replace(/_/g, " ");
-  return normalized[0]?.toUpperCase() + normalized.slice(1);
-}
-
-function renderRunSummary(run: DocumentRow["lastRun"] | null | undefined) {
-  if (!run) {
-    return <span className="text-muted-foreground">-</span>;
-  }
-
-  const timestamp = run.completedAt ?? run.startedAt ?? run.createdAt;
-  const statusLabel = formatRunStatus(String(run.status));
-  return (
-    <div className="flex min-w-0 flex-col gap-0.5" title={run.errorMessage ?? undefined}>
-      <span className="truncate capitalize">{statusLabel}</span>
-      <span className="truncate text-xs text-muted-foreground">
-        {timestamp ? formatTimestamp(timestamp) : "-"}
-      </span>
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- update Documents table Last Run cell to render timestamp only
- remove status+timestamp summary helper from Last Run column
- keep Run status exclusively in the Run status column

## Testing
- cd backend && uv run ade web lint
- cd backend && uv run ade web test *(fails in existing unrelated SSO setup timeout tests)*