### PR TITLE
fix: use canonical filters for document system views

### DIFF
--- a/backend/src/ade_api/features/documents/schemas.py
+++ b/backend/src/ade_api/features/documents/schemas.py
@@ -9,8 +9,8 @@ from typing import Any, Literal
 
 from pydantic import Field, field_validator, model_validator
 
-from ade_api.common.ids import UUIDStr
 from ade_api.common.cursor_listing import CursorPage
+from ade_api.common.ids import UUIDStr
 from ade_api.common.schema import BaseSchema
 from ade_api.features.runs.schemas import RunColumnResource, RunFieldResource, RunMetricsResource
 from ade_db.models import FileVersionOrigin, RunStatus
@@ -483,8 +483,6 @@ class DocumentViewQueryState(BaseSchema):
     sort: list[dict[str, Any]] = Field(default_factory=list)
     filters: list[dict[str, Any]] = Field(default_factory=list)
     join_operator: Literal["and", "or"] | None = Field(default="and", alias="joinOperator")
-    filter_flag: str | None = Field(default=None, alias="filterFlag")
-    simple_filters: dict[str, Any] | None = Field(default=None, alias="simpleFilters")
 
 
 class DocumentViewTableState(BaseSchema):

--- a/backend/src/ade_api/features/documents/view_presets.py
+++ b/backend/src/ade_api/features/documents/view_presets.py
@@ -39,9 +39,16 @@ SYSTEM_DOCUMENT_VIEW_PRESETS: tuple[SystemDocumentViewPreset, ...] = (
             "lifecycle": "active",
             "q": None,
             "sort": [{"id": "createdAt", "desc": True}],
-            "filters": [],
+            "filters": [
+                {
+                    "id": "assigneeId",
+                    "operator": "inArray",
+                    "value": ["me"],
+                    "variant": "multiSelect",
+                    "filterId": "system-assigned-to-me",
+                }
+            ],
             "joinOperator": "and",
-            "simpleFilters": {"assigneeId": ["me"]},
         },
     ),
     SystemDocumentViewPreset(
@@ -52,9 +59,16 @@ SYSTEM_DOCUMENT_VIEW_PRESETS: tuple[SystemDocumentViewPreset, ...] = (
             "lifecycle": "active",
             "q": None,
             "sort": [{"id": "createdAt", "desc": True}],
-            "filters": [],
+            "filters": [
+                {
+                    "id": "assigneeId",
+                    "operator": "isEmpty",
+                    "value": "",
+                    "variant": "multiSelect",
+                    "filterId": "system-unassigned",
+                }
+            ],
             "joinOperator": "and",
-            "simpleFilters": {"assigneeId": ["__empty__"]},
         },
     ),
     SystemDocumentViewPreset(

--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -16548,29 +16548,6 @@
             ],
             "title": "Joinoperator",
             "default": "and"
-          },
-          "filterFlag": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filterflag"
-          },
-          "simpleFilters": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Simplefilters"
           }
         },
         "additionalProperties": false,

--- a/frontend/src/pages/Workspace/sections/Documents/list/state/__tests__/queryState.test.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/list/state/__tests__/queryState.test.ts
@@ -103,4 +103,69 @@ describe("queryState", () => {
       lifecycle: "deleted",
     });
   });
+
+  it("parses assigned-to-me system view query state", () => {
+    const snapshot = parseViewQueryStateToSnapshot({
+      lifecycle: "active",
+      q: null,
+      filters: [
+        {
+          id: "assigneeId",
+          operator: "inArray",
+          value: ["me"],
+          variant: "multiSelect",
+          filterId: "system-assigned-to-me",
+        },
+      ],
+    });
+
+    expect(snapshot.filters).toEqual([
+      {
+        id: "assigneeId",
+        operator: "inArray",
+        value: ["me"],
+        variant: "multiSelect",
+        filterId: "system-assigned-to-me",
+      },
+    ]);
+  });
+
+  it("parses unassigned system view query state", () => {
+    const snapshot = parseViewQueryStateToSnapshot({
+      lifecycle: "active",
+      q: null,
+      filters: [
+        {
+          id: "assigneeId",
+          operator: "isEmpty",
+          value: "",
+          variant: "multiSelect",
+          filterId: "system-unassigned",
+        },
+      ],
+    });
+
+    expect(snapshot.filters).toEqual([
+      {
+        id: "assigneeId",
+        operator: "isEmpty",
+        value: "",
+        variant: "multiSelect",
+        filterId: "system-unassigned",
+      },
+    ]);
+
+    const resolved = resolveListFiltersForApi({
+      snapshot,
+      currentUserId: "user-123",
+    });
+
+    expect(resolved.filters).toEqual([
+      {
+        id: "assigneeId",
+        operator: "isEmpty",
+        value: "",
+      },
+    ]);
+  });
 });

--- a/frontend/src/types/generated/openapi.d.ts
+++ b/frontend/src/types/generated/openapi.d.ts
@@ -3181,12 +3181,6 @@ export type components = {
              * @default and
              */
             joinOperator: ("and" | "or") | null;
-            /** Filterflag */
-            filterFlag?: string | null;
-            /** Simplefilters */
-            simpleFilters?: {
-                [key: string]: unknown;
-            } | null;
         };
         /**
          * DocumentViewTableState


### PR DESCRIPTION
## Summary
- switch document system view presets to canonical queryState.filters payloads
- remove legacy document view query fields (filterFlag/simpleFilters) from API schema
- update backend/frontend tests and regenerate OpenAPI/types to match the canonical contract

## Validation
- ADE_DATABASE_URL='postgresql+psycopg://ade:ade@localhost:5432/ade?sslmode=disable' ADE_SECRET_KEY='test-secret-key-for-tests-please-change' ADE_BLOB_CONNECTION_STRING='UseDevelopmentStorage=true' uv run pytest tests/api/integration/documents/test_documents_views.py
- npm --prefix frontend run test -- src/pages/Workspace/sections/Documents/list/state/__tests__/queryState.test.ts
- npm --prefix frontend run lint -- src/pages/Workspace/sections/Documents/list/state/queryState.ts src/pages/Workspace/sections/Documents/list/state/__tests__/queryState.test.ts