### PR TITLE
fix(test): standardize integration architecture and CI gates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
   # Web (npm) dependencies
   # -----------------------------
   - package-ecosystem: "npm"
-    directory: "/apps/ade-web"
+    directory: "/frontend"
     target-branch: "development"
     schedule:
       interval: "monthly"
@@ -20,7 +20,7 @@ updates:
   # API + Worker (uv) dependencies
   # -----------------------------
   - package-ecosystem: "uv"
-    directory: "/"
+    directory: "/backend"
     target-branch: "development"
     schedule:
       interval: "monthly"

--- a/.github/workflows/ci-pr-gates.yaml
+++ b/.github/workflows/ci-pr-gates.yaml
@@ -10,8 +10,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  strict-green:
-    name: Strict Green Checks
+  backend-lint-types:
+    name: Backend Lint + API Types
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Sync backend environment
+        working-directory: backend
+        run: uv sync --frozen
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm --prefix frontend ci
+
+      - name: Run backend lint and API type generation
+        working-directory: backend
+        run: |
+          uv run ade api lint
+          uv run ade api types
+
+      - name: Assert generated API artifacts are committed
+        run: |
+          git diff --exit-code -- backend/src/ade_api/openapi.json frontend/src/types/generated/openapi.d.ts
+
+  backend-unit:
+    name: Backend Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Sync backend environment
+        working-directory: backend
+        run: uv sync --frozen
+
+      - name: Run backend unit suites
+        working-directory: backend
+        run: |
+          uv run ade api test
+          uv run ade worker test
+
+  backend-api-integration:
+    name: Backend API Integration
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -36,10 +102,7 @@ jobs:
       CI: "true"
       ADE_TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@127.0.0.1:5432/ade_test?sslmode=disable
       ADE_TEST_BLOB_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
-      # Keep runtime settings valid during module import in test collection.
-      ADE_DATABASE_URL: postgresql+psycopg://postgres:postgres@127.0.0.1:5432/ade_test?sslmode=disable
-      ADE_BLOB_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
-      ADE_SECRET_KEY: test-secret-key-for-ci-only-do-not-use-in-prod
+      ADE_TEST_DATABASE_NAME_PREFIX: ade_api_test
 
     steps:
       - name: Checkout
@@ -53,6 +116,82 @@ jobs:
       - name: Install uv
         run: python -m pip install --upgrade pip uv
 
+      - name: Sync backend environment
+        working-directory: backend
+        run: uv sync --frozen
+
+      - name: Run API integration tests
+        working-directory: backend
+        run: uv run ade api test integration
+
+  backend-worker-integration:
+    name: Backend Worker Integration
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ade_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10000
+
+    env:
+      CI: "true"
+      ADE_TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@127.0.0.1:5432/ade_test?sslmode=disable
+      ADE_TEST_BLOB_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
+      ADE_TEST_DATABASE_NAME_PREFIX: ade_worker_test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Sync backend environment
+        working-directory: backend
+        run: uv sync --frozen
+
+      - name: Run worker integration tests
+        working-directory: backend
+        run: uv run ade worker test integration
+
+  frontend-checks:
+    name: Frontend Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Sync backend environment
+        working-directory: backend
+        run: uv sync --frozen
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -63,20 +202,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm --prefix frontend ci
 
-      - name: Sync backend environment
-        working-directory: backend
-        run: uv sync --frozen
-
-      - name: Run strict green matrix
+      - name: Run frontend checks
         working-directory: backend
         run: |
-          uv run ade api lint
-          uv run ade api test
-          uv run ade api test integration
-          uv run ade worker test
-          uv run ade worker test integration
-          uv run ade api types
           uv run ade web lint
           uv run ade web typecheck
           uv run ade web test
-          uv run ade test

--- a/backend/src/ade_api/asgi.py
+++ b/backend/src/ade_api/asgi.py
@@ -1,0 +1,9 @@
+"""ASGI compatibility module for hosts that require an application object."""
+
+from __future__ import annotations
+
+from .main import create_app
+
+app = create_app()
+
+__all__ = ["app"]

--- a/backend/src/ade_api/main.py
+++ b/backend/src/ade_api/main.py
@@ -81,6 +81,3 @@ __all__ = [
     "API_PREFIX",
     "create_app",
 ]
-
-# ASGI entrypoint used by uvicorn / gunicorn.
-app = create_app()

--- a/backend/src/ade_api/openapi.json
+++ b/backend/src/ade_api/openapi.json
@@ -1126,12 +1126,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -1161,12 +1158,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -1329,12 +1323,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -1364,12 +1355,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -1839,12 +1827,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -1874,12 +1859,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -2373,12 +2355,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -2408,12 +2387,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -2967,12 +2943,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -3002,12 +2975,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -3154,12 +3124,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -3189,12 +3156,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -3648,12 +3612,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -3683,12 +3644,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -4602,12 +4560,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -4637,12 +4592,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -5215,12 +5167,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -5250,12 +5199,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -5697,12 +5643,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -5732,12 +5675,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -6101,12 +6041,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -6136,12 +6073,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -7861,12 +7795,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -7896,12 +7827,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -9142,12 +9070,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -9177,12 +9102,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."
@@ -11562,12 +11484,9 @@
                 }
               ],
               "description": "URL-encoded JSON array of filter objects.",
-              "examples": {
-                "statusIn": {
-                  "summary": "Status filter",
-                  "value": "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
-                }
-              },
+              "examples": [
+                "[{\"id\":\"status\",\"operator\":\"in\",\"value\":[\"processing\",\"failed\"]}]"
+              ],
               "title": "Filters"
             },
             "description": "URL-encoded JSON array of filter objects."
@@ -11597,12 +11516,9 @@
                 }
               ],
               "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored.",
-              "examples": {
-                "multiToken": {
-                  "summary": "Search multiple tokens",
-                  "value": "acme invoice"
-                }
-              },
+              "examples": [
+                "acme invoice"
+              ],
               "title": "Q"
             },
             "description": "Free-text search string. Tokens are whitespace-separated, matched case-insensitively as substrings; tokens shorter than 2 characters are ignored."

--- a/backend/src/ade_cli/main.py
+++ b/backend/src/ade_cli/main.py
@@ -23,7 +23,8 @@ from .db import app as db_app
 from .infra import app as infra_app
 from .local_dev import missing_core_runtime_env
 from .storage import app as storage_app
-from .web import app as web_app, resolve_public_web_url
+from .web import app as web_app
+from .web import resolve_public_web_url
 from .worker import app as worker_app
 
 SERVICE_ORDER = ("api", "worker", "web")
@@ -287,7 +288,7 @@ def dev(
     run_many(_build_processes(mode="dev", selected=selected), cwd=REPO_ROOT)
 
 
-@app.command(name="test", help="Run API, worker, and web tests.")
+@app.command(name="test", help="Run API unit tests, worker unit tests, and web tests.")
 def test() -> None:
     env = _clean_test_env()
     run([sys.executable, "-m", "ade_api", "test"], cwd=REPO_ROOT, env=env)

--- a/backend/tests/api/integration/test_csrf_guards.py
+++ b/backend/tests/api/integration/test_csrf_guards.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import inspect
 from collections.abc import Iterable
 
+import pytest
 from fastapi.routing import APIRoute
 
 from ade_api.core.http import require_csrf
 from ade_api.main import create_app
 
-app = create_app()
+
+@pytest.fixture()
+def app(empty_database_settings):
+    return create_app(settings=empty_database_settings)
 
 MUTATING_METHODS: set[str] = {"POST", "PUT", "PATCH", "DELETE"}
 CSRF_ROUTE_ALLOWLIST: set[tuple[str, str]] = {
@@ -40,7 +44,7 @@ def _has_require_csrf(route: APIRoute) -> bool:
     return any(call is require_csrf for call in _dependency_calls(route))
 
 
-def test_mutating_routes_require_csrf() -> None:
+def test_mutating_routes_require_csrf(app) -> None:
     """All mutating routes should include the CSRF dependency unless allowlisted."""
 
     for route in app.router.routes:

--- a/backend/tests/api/integration/test_route_naming.py
+++ b/backend/tests/api/integration/test_route_naming.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import pytest
 from fastapi.routing import APIRoute
 
 from ade_api.main import create_app
 
-app = create_app()
+
+@pytest.fixture()
+def app(empty_database_settings):
+    return create_app(settings=empty_database_settings)
 
 
-def test_routes_use_lower_camel_case_segments() -> None:
+def test_routes_use_lower_camel_case_segments(app) -> None:
     """Ensure no route segment contains '-' or ':' characters."""
 
     for route in app.router.routes:

--- a/backend/tests/api/unit/common/test_worker_cli.py
+++ b/backend/tests/api/unit/common/test_worker_cli.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from ade_cli import worker
+
+
+def test_worker_run_tests_unit_scrubs_ade_env(monkeypatch):
+    captured: dict[str, object] = {}
+
+    monkeypatch.setenv("ADE_DATABASE_URL", "postgresql+psycopg://runtime")
+    monkeypatch.setenv("ADE_TEST_DATABASE_URL", "postgresql+psycopg://integration")
+    monkeypatch.setattr(
+        worker,
+        "run",
+        lambda command, *, cwd, env=None: captured.update(
+            {"command": list(command), "cwd": cwd, "env": env}
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(worker.app, ["test"])
+
+    assert result.exit_code == 0
+    env = captured["env"]
+    assert "ADE_DATABASE_URL" not in env
+    assert "ADE_TEST_DATABASE_URL" not in env
+
+
+def test_worker_run_tests_integration_preserves_ade_test_env(monkeypatch):
+    captured: dict[str, object] = {}
+
+    monkeypatch.setenv("ADE_DATABASE_URL", "postgresql+psycopg://runtime")
+    monkeypatch.setenv("ADE_TEST_DATABASE_URL", "postgresql+psycopg://integration")
+    monkeypatch.setattr(
+        worker,
+        "run",
+        lambda command, *, cwd, env=None: captured.update(
+            {"command": list(command), "cwd": cwd, "env": env}
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(worker.app, ["test", "integration"])
+
+    assert result.exit_code == 0
+    env = captured["env"]
+    assert env["ADE_TEST_DATABASE_URL"] == "postgresql+psycopg://integration"
+    assert "ADE_DATABASE_URL" not in env
+
+
+def test_worker_run_tests_integration_requires_test_database_url(monkeypatch):
+    monkeypatch.delenv("ADE_TEST_DATABASE_URL", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(worker.app, ["test", "integration"])
+
+    assert result.exit_code == 1
+    assert "ADE_TEST_DATABASE_URL" in result.output

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,8 @@ import pytest
 
 
 def pytest_collection_modifyitems(config, items) -> None:
+    """Auto-tag tests by directory convention (unit/integration)."""
+
     for item in items:
         parts = Path(str(item.fspath)).parts
         if "integration" in parts:

--- a/backend/tests/integration_support.py
+++ b/backend/tests/integration_support.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from uuid import uuid4
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import URL, Engine, make_url
+from sqlalchemy.pool import NullPool
+
+TEST_ENV_PREFIX = "ADE_TEST_"
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True, slots=True)
+class IsolatedTestDatabase:
+    name: str
+    database_url: URL
+    admin_url: URL
+
+
+def test_env(name: str, default: str | None = None) -> str | None:
+    return os.getenv(f"{TEST_ENV_PREFIX}{name}", default)
+
+
+def require_test_env(name: str) -> str:
+    value = test_env(name)
+    if value and value.strip():
+        return value
+    raise RuntimeError(
+        "Integration tests require "
+        f"{TEST_ENV_PREFIX}{name}. Set it in the environment before running pytest."
+    )
+
+
+def _to_psycopg_driver(url: URL) -> URL:
+    if url.drivername in {"postgresql", "postgres"}:
+        return url.set(drivername="postgresql+psycopg")
+    if url.drivername.startswith("postgresql+"):
+        return url.set(drivername="postgresql+psycopg")
+    return url
+
+
+def _is_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in _TRUE_VALUES
+
+
+def _sanitize_database_name(name: str, *, fallback: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9_]", "_", name).strip("_")
+    return sanitized or fallback
+
+
+def _assert_safe_database_name(name: str) -> None:
+    allow_non_test = _is_truthy(test_env("ALLOW_NON_TEST_DATABASE", ""))
+    if "test" not in name.lower() and not allow_non_test:
+        raise RuntimeError(
+            "Refusing to use non-test database name "
+            f"{name!r}. Include 'test' in the name, or set "
+            f"{TEST_ENV_PREFIX}ALLOW_NON_TEST_DATABASE=true to override."
+        )
+
+
+def _build_admin_url(url: URL) -> URL:
+    admin_database = _sanitize_database_name(
+        test_env("DATABASE_ADMIN_DB", "postgres") or "postgres",
+        fallback="postgres",
+    )
+    return url.set(database=admin_database)
+
+
+def resolve_isolated_test_database(*, default_prefix: str = "ade_test") -> IsolatedTestDatabase:
+    base_url = make_url(require_test_env("DATABASE_URL"))
+    explicit_name = test_env("DATABASE_NAME")
+    if explicit_name:
+        database_name = _sanitize_database_name(explicit_name, fallback=default_prefix)
+    else:
+        prefix = _sanitize_database_name(
+            test_env("DATABASE_NAME_PREFIX", default_prefix) or default_prefix,
+            fallback=default_prefix,
+        )
+        database_name = f"{prefix}_{uuid4().hex[:8]}"
+
+    _assert_safe_database_name(database_name)
+    isolated_url = _to_psycopg_driver(base_url.set(database=database_name))
+    admin_url = _to_psycopg_driver(_build_admin_url(base_url))
+    return IsolatedTestDatabase(
+        name=database_name,
+        database_url=isolated_url,
+        admin_url=admin_url,
+    )
+
+
+def _build_engine(url: URL) -> Engine:
+    return create_engine(
+        url.render_as_string(hide_password=False),
+        poolclass=NullPool,
+        future=True,
+    )
+
+
+def create_isolated_test_database(database: IsolatedTestDatabase) -> None:
+    engine = _build_engine(database.admin_url)
+    try:
+        with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+            exists = conn.execute(
+                text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
+                {"db_name": database.name},
+            ).scalar()
+            if not exists:
+                conn.exec_driver_sql(f'CREATE DATABASE "{database.name}"')
+    finally:
+        engine.dispose()
+
+
+def drop_isolated_test_database(database: IsolatedTestDatabase) -> None:
+    engine = _build_engine(database.admin_url)
+    try:
+        with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+            conn.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :db_name
+                      AND pid <> pg_backend_pid();
+                    """
+                ),
+                {"db_name": database.name},
+            )
+            conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{database.name}"')
+    finally:
+        engine.dispose()
+
+
+__all__ = [
+    "IsolatedTestDatabase",
+    "TEST_ENV_PREFIX",
+    "create_isolated_test_database",
+    "drop_isolated_test_database",
+    "require_test_env",
+    "resolve_isolated_test_database",
+    "test_env",
+]

--- a/backend/tests/worker/integration/conftest.py
+++ b/backend/tests/worker/integration/conftest.py
@@ -1,154 +1,66 @@
 from __future__ import annotations
 
-import os
-import re
 from collections.abc import Iterator
-from pathlib import Path
-from uuid import uuid4
 
 import pytest
-from dotenv import dotenv_values
 from sqlalchemy import text
-from sqlalchemy.engine import make_url
 
 from ade_db.engine import build_engine
+from ade_db.migrations_runner import run_migrations
 from ade_db.schema import metadata
 from ade_worker.settings import Settings
-from paths import REPO_ROOT
+from tests.integration_support import (
+    IsolatedTestDatabase,
+    create_isolated_test_database,
+    drop_isolated_test_database,
+    resolve_isolated_test_database,
+    test_env,
+)
 
 
-def _load_dotenv(path: Path | None = None) -> dict[str, str]:
-    dotenv_path = path or (REPO_ROOT / ".env")
-    if not dotenv_path.exists():
-        return {}
-    values: dict[str, str] = {}
-    for key, value in dotenv_values(dotenv_path).items():
-        if not key or value in {None, ""}:
-            continue
-        values.setdefault(key, value)
-    return values
-
-
-_DOTENV = _load_dotenv()
-
-
-def _env(name: str, default: str | None = None) -> str | None:
-    key_test = f"ADE_TEST_{name}"
-    key = f"ADE_{name}"
-    return (
-        os.getenv(key_test)
-        or os.getenv(key)
-        or _DOTENV.get(key_test)
-        or _DOTENV.get(key)
-        or default
-    )
-
-
-def _sanitize_db_name(name: str) -> str:
-    sanitized = re.sub(r"[^A-Za-z0-9_]", "_", name).strip("_")
-    return sanitized or "ade_worker_test"
-
-
-def _resolve_test_database_name() -> str:
-    explicit = _env("DATABASE_NAME")
-    if explicit:
-        return _sanitize_db_name(explicit)
-    prefix = _env("DATABASE_NAME_PREFIX") or "ade_worker_test"
-    prefix = _sanitize_db_name(prefix)
-    suffix = uuid4().hex[:8]
-    return f"{prefix}_{suffix}"
-
-
-def _build_test_settings() -> Settings:
-    auth_mode = (_env("DATABASE_AUTH_MODE") or "password").strip().lower()
-    base_url = _env("DATABASE_URL")
-    if not base_url:
-        raise RuntimeError(
-            "Integration tests require ADE_DATABASE_URL (or ADE_TEST_DATABASE_URL). "
-            "Set it in .env or the environment."
-        )
-    url = make_url(base_url).set(database=_resolve_test_database_name())
-    blob_container = _env("BLOB_CONTAINER") or "ade-test"
-    blob_connection_string = _env("BLOB_CONNECTION_STRING")
-    blob_account_url = _env("BLOB_ACCOUNT_URL")
+def _build_test_settings(*, database_url: str) -> Settings:
+    auth_mode = (test_env("DATABASE_AUTH_MODE") or "password").strip().lower()
+    blob_container = test_env("BLOB_CONTAINER") or "ade-test"
+    blob_connection_string = test_env("BLOB_CONNECTION_STRING")
+    blob_account_url = test_env("BLOB_ACCOUNT_URL")
     if not blob_connection_string and not blob_account_url:
         blob_connection_string = "UseDevelopmentStorage=true"
     return Settings(
         _env_file=None,
-        database_url=url.render_as_string(hide_password=False),
+        database_url=database_url,
         database_auth_mode=auth_mode,
-        database_sslrootcert=_env("DATABASE_SSLROOTCERT"),
+        database_sslrootcert=test_env("DATABASE_SSLROOTCERT"),
         blob_container=blob_container,
         blob_connection_string=blob_connection_string,
         blob_account_url=blob_account_url,
     )
 
 
-def _build_admin_settings(settings: Settings) -> Settings:
-    url = make_url(str(settings.database_url)).set(database="postgres")
-    payload = settings.model_dump()
-    payload["database_url"] = url.render_as_string(hide_password=False)
-    return Settings.model_validate(payload)
-
-
-def _create_database(settings: Settings) -> None:
-    admin_settings = _build_admin_settings(settings)
-    db_name = make_url(str(settings.database_url)).database
-    if not db_name:
-        raise RuntimeError("Test database name was empty; check ADE_TEST_DATABASE_NAME settings.")
-    engine = build_engine(admin_settings)
+@pytest.fixture(scope="session")
+def isolated_test_database() -> Iterator[IsolatedTestDatabase]:
+    database = resolve_isolated_test_database(default_prefix="ade_worker_test")
+    create_isolated_test_database(database)
     try:
-        with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
-            exists = conn.execute(
-                text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
-                {"db_name": db_name},
-            ).scalar()
-            if not exists:
-                conn.exec_driver_sql(f'CREATE DATABASE "{db_name}";')
+        yield database
     finally:
-        engine.dispose()
-
-
-def _drop_database(settings: Settings) -> None:
-    admin_settings = _build_admin_settings(settings)
-    db_name = make_url(str(settings.database_url)).database
-    if not db_name:
-        return
-    engine = build_engine(admin_settings)
-    try:
-        with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
-            conn.execute(
-                text(
-                    """
-                    SELECT pg_terminate_backend(pid)
-                    FROM pg_stat_activity
-                    WHERE datname = :db_name
-                      AND pid <> pg_backend_pid();
-                    """
-                ),
-                {"db_name": db_name},
-            )
-            conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{db_name}";')
-    finally:
-        engine.dispose()
+        drop_isolated_test_database(database)
 
 
 @pytest.fixture(scope="session")
-def base_settings() -> Settings:
-    return _build_test_settings()
+def base_settings(isolated_test_database: IsolatedTestDatabase) -> Settings:
+    return _build_test_settings(
+        database_url=isolated_test_database.database_url.render_as_string(hide_password=False)
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _database_lifecycle(base_settings: Settings) -> Iterator[None]:
-    _create_database(base_settings)
-    yield
-    _drop_database(base_settings)
+def _migrate_database(base_settings: Settings) -> None:
+    run_migrations(base_settings)
 
 
 @pytest.fixture(scope="session")
-def engine(base_settings: Settings, _database_lifecycle: None):
+def engine(base_settings: Settings, _migrate_database: None):
     engine = build_engine(base_settings)
-    metadata.create_all(engine)
     try:
         yield engine
     finally:

--- a/docs/how-to/run-local-dev-loop.md
+++ b/docs/how-to/run-local-dev-loop.md
@@ -110,10 +110,23 @@ cd backend && uv run ade web dev
 
 ## Tests and Lint
 
-All tests:
+Default test pass (API unit + worker unit + web tests):
 
 ```bash
 cd backend && uv run ade test
+```
+
+Integration suites (requires explicit `ADE_TEST_*` settings):
+
+```bash
+cd backend && \
+ADE_TEST_DATABASE_URL='postgresql+psycopg://postgres:postgres@127.0.0.1:5432/ade_test?sslmode=disable' \
+ADE_TEST_BLOB_CONNECTION_STRING='UseDevelopmentStorage=true' \
+uv run ade api test integration
+
+cd backend && \
+ADE_TEST_DATABASE_URL='postgresql+psycopg://postgres:postgres@127.0.0.1:5432/ade_test?sslmode=disable' \
+uv run ade worker test integration
 ```
 
 Service-level checks:

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -22,7 +22,7 @@ cd backend && uv run ade --help
 | --- | --- |
 | `ade start` | Start API + worker + web |
 | `ade dev` | Start API + worker + web in dev mode |
-| `ade test` | Run API, worker, and web tests |
+| `ade test` | Run API unit + worker unit + web tests (excludes integration suites) |
 | `ade reset` | Reset DB/storage/local state (destructive) |
 | `ade api ...` | Run API subcommands |
 | `ade worker ...` | Run worker subcommands |
@@ -44,7 +44,7 @@ Key options for `ade start`/`ade dev`:
 | --- | --- |
 | `ade-api dev` | Run API in development mode |
 | `ade-api start` | Run API in production-style mode |
-| `ade-api test <suite>` | Run tests (`unit`, `integration`, `all`) |
+| `ade-api test <suite>` | Run tests (`unit`, `integration`, `all`; default `unit`) |
 | `ade-api lint` | Run lint/type checks |
 | `ade-api routes` | Print route list |
 | `ade-api types` | Generate OpenAPI + TypeScript types |
@@ -60,7 +60,7 @@ Common API options:
 | --- | --- |
 | `ade-worker start` | Start worker |
 | `ade-worker dev` | Start worker in dev mode |
-| `ade-worker test <suite>` | Run tests (`unit`, `integration`, `all`) |
+| `ade-worker test <suite>` | Run tests (`unit`, `integration`, `all`; default `unit`) |
 | `ade-worker gc` | Run one garbage-collection pass |
 
 ## DB CLI: `ade-db`
@@ -102,4 +102,22 @@ cd backend && uv run ade dev --open
 cd backend && uv run ade start --services worker --no-migrate
 cd backend && uv run ade db migrate
 cd backend && uv run ade api types
+```
+
+## Integration Test Prerequisites
+
+Integration suites use explicit `ADE_TEST_*` settings and do not read runtime `ADE_*` values.
+
+At minimum set:
+
+- `ADE_TEST_DATABASE_URL`
+- `ADE_TEST_BLOB_CONNECTION_STRING` (recommended for API integration coverage)
+
+Example:
+
+```bash
+cd backend && \
+ADE_TEST_DATABASE_URL='postgresql+psycopg://postgres:postgres@127.0.0.1:5432/ade_test?sslmode=disable' \
+ADE_TEST_BLOB_CONNECTION_STRING='UseDevelopmentStorage=true' \
+uv run ade api test integration
 ```


### PR DESCRIPTION
## Summary
Standardize ADE backend test/integration architecture and CI gates around explicit test env contracts, app-factory boot, and migration-backed integration databases.

## Problem Fixes
- Fixes CLI integration test env scrubbing that removed required `ADE_TEST_*` variables.
- Removes import-time API app/settings side effects from `ade_api.main`.
- Standardizes API and worker integration suites on isolated, migration-backed test databases.
- Splits monolithic PR gate workflow into focused jobs.
- Fixes Dependabot update paths for this repo layout.
- Aligns CLI docs with actual unit vs integration test behavior.

## Key Changes
- API app boot:
  - `backend/src/ade_api/main.py` now exports factory-only `create_app(...)`.
  - Added `backend/src/ade_api/asgi.py` compatibility module (`app = create_app()`).
  - CLI now runs Uvicorn with factory target `ade_api.main:create_app --factory`.
- CLI test contract:
  - Unit suites scrub all `ADE_*`.
  - Integration/all suites preserve only `ADE_TEST_*` and fail fast unless `ADE_TEST_DATABASE_URL` is present.
- Integration test setup:
  - Added shared helper `backend/tests/integration_support.py` for isolated DB lifecycle + safety checks.
  - API and worker integration conftests now use isolated DBs created from `ADE_TEST_DATABASE_URL` and run Alembic migrations.
  - Worker integration no longer uses `metadata.create_all()`.
- CI and dependencies:
  - Reworked `.github/workflows/ci-pr-gates.yaml` into separate jobs for backend lint/types, backend unit, API integration, worker integration, and frontend checks.
  - Added generated artifact drift gate (`openapi.json`, `openapi.d.ts`).
  - Corrected Dependabot directories to `/frontend` and `/backend`.
- Docs:
  - Updated CLI reference and local dev loop docs to clearly separate default unit aggregate from integration suites and required `ADE_TEST_*` env vars.

## Verification
Commands executed locally:
- `cd backend && uv run ade api lint` ✅
- `cd backend && uv run ade api test` ✅
- `cd backend && uv run ade worker test` ✅
- `cd backend && uv run ade web lint && uv run ade web typecheck && uv run ade web test` ✅
- `cd backend && uv run ade test` ✅
- `cd backend && uv run python -c "import ade_api.main; print('ok')"` ✅
- `cd backend && uv run ade api test integration` (without `ADE_TEST_DATABASE_URL`) -> expected fast-fail ✅
- `cd backend && uv run ade worker test integration` (without `ADE_TEST_DATABASE_URL`) -> expected fast-fail ✅
- With local infra (`uv run ade infra up -d --wait`) and explicit `ADE_TEST_*`:
  - `uv run ade api test integration` ✅ (`238 passed`)
  - `uv run ade worker test integration` ✅ (`14 passed`)

## Notes
- `backend/src/ade_api/openapi.json` was regenerated and is included.
