### PR TITLE
chore(ci): tighten Dependabot auto-merge policy for development

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,7 +8,7 @@ updates:
     directory: "/frontend"
     target-branch: "development"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -23,7 +23,7 @@ updates:
     directory: "/backend"
     target-branch: "development"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "deps"
       include: "scope"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -12,7 +12,8 @@ jobs:
     if: >-
       github.actor == 'dependabot[bot]' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.base_ref == 'development'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary
This PR applies two small policy hardening changes for dependency automation:

1. Restrict Dependabot auto-approve/auto-merge workflow to PRs targeting `development` only.
2. Increase Dependabot update cadence from `monthly` to `weekly` for both:
   - `frontend` (`npm`)
   - `backend` (`uv`)

## Why
- Prevents accidental auto-merge behavior outside the intended integration branch.
- Keeps dependency updates smaller and more frequent, which reduces review risk and avoids large monthly update bursts.

## Changes
- `.github/workflows/dependabot-auto-merge.yaml`
  - Added `github.base_ref == 'development'` to the job-level guard.
- `.github/dependabot.yaml`
  - Changed schedule interval from `monthly` to `weekly` for both ecosystems.

## Impact
- Dependabot PRs still require all standard CI checks.
- Minor/patch Dependabot PRs continue to be auto-approved + auto-merged, but only when the PR base is `development`.
- Major updates remain manual.

## Validation
- Workflow renders successfully in GitHub (`gh workflow view`).
- Ran baseline repo test command per contribution guidance:
  - `cd backend && uv run ade test`
  - API and worker suites passed.
  - Frontend suite currently has pre-existing failures on the latest `development` baseline unrelated to these YAML-only changes (timeouts in multiple UI tests).
