### PR TITLE
fix(ci): publish production stage image in docker-image workflow

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -183,6 +183,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          target: production
           build-args: |
             APP_VERSION=${{ steps.app-meta.outputs.value }}
             APP_COMMIT_SHA=${{ steps.app-meta.outputs.sha }}


### PR DESCRIPTION
## Summary
- set `docker/build-push-action` target to `production` in `.github/workflows/docker-image.yaml`
- prevent GHCR branch/release tags from publishing the Dockerfile final stage (`devcontainer`)
- ensure `main` and `development` tags point to runtime images

## Test Evidence
- `cd backend && uv run ade test`
