### PR TITLE
feat(infra): add cloudflare fronting automation for container apps

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,5 +1,6 @@
 # Infra
 
-Azure infrastructure documentation and Bicep templates are in:
+Infrastructure documentation and automation are in:
 
 - [`infra/azure/README.md`](./azure/README.md)
+- [`infra/cloudflare/README.md`](./cloudflare/README.md)

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,0 +1,162 @@
+# ADE Cloudflare + Azure Container Apps
+
+`infra/cloudflare` contains a Bash-first runbook and helper scripts for putting an existing Azure Container App behind Cloudflare with a custom subdomain and BYO certificate.
+
+## Why BYO Certificate
+
+This flow intentionally uses **bring your own certificate** (for example, Cloudflare Origin CA) instead of Azure managed certificates.
+
+- Azure managed certificate issuance/renewal for subdomains requires a CNAME that points directly to the Container App FQDN.
+- Azure explicitly calls out intermediate CNAME services (for example, Cloudflare) as blockers for managed certificate issuance/renewal.
+- BYO certificate avoids that coupling and works with Cloudflare proxied traffic when Cloudflare SSL mode is `Full (strict)`.
+
+References:
+
+- https://learn.microsoft.com/en-us/azure/container-apps/custom-domains-managed-certificates
+- https://learn.microsoft.com/en-us/azure/container-apps/custom-domains-certificates
+- https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/
+- https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full-strict/
+
+## Scope
+
+This package is v1 by design:
+
+- Subdomain only (for example, `app.example.com`)
+- Single hostname per script run
+- Bash only
+- Azure side scripted
+- Cloudflare dashboard configuration documented (not scripted)
+
+## Files
+
+- `infra/cloudflare/deploy.sh.example`: Azure custom-domain bind automation for one hostname.
+- `infra/cloudflare/scripts/prepare-origin-cert-pfx.sh`: converts PEM cert+key to PFX for Azure upload.
+- `infra/cloudflare/validate.sh`: shell syntax checks for Cloudflare infra scripts.
+
+## Prerequisites
+
+- Azure CLI (`az`) authenticated and authorized for the target subscription/resource group.
+- Existing Azure Container App and Container Apps environment.
+- Container App ingress enabled and external/public.
+- Cloudflare zone for your domain.
+- Cloudflare Origin CA certificate (or other compatible BYO cert) and private key.
+- `openssl` for PEM -> PFX conversion.
+- `dig` (recommended) or `nslookup` if using DNS polling in deploy script.
+
+## Quick Start
+
+1. Copy the deploy template:
+
+   ```bash
+   cp infra/cloudflare/deploy.sh.example infra/cloudflare/deploy.sh
+   chmod +x infra/cloudflare/deploy.sh
+   ```
+
+1. Create a Cloudflare Origin CA cert manually in Cloudflare:
+   - Cloudflare dashboard -> `SSL/TLS` -> `Origin Server` -> `Create Certificate`
+   - Include the exact hostname you will bind (or an approved wildcard policy)
+   - Save cert and private key securely
+
+1. Convert cert material to PFX for Azure:
+
+   ```bash
+   chmod +x infra/cloudflare/scripts/prepare-origin-cert-pfx.sh
+   infra/cloudflare/scripts/prepare-origin-cert-pfx.sh \
+     ./certs/app.example.com.crt.pem \
+     ./certs/app.example.com.key.pem \
+     ./certs/app.example.com.pfx \
+     '<PFX_PASSWORD>'
+   ```
+
+1. Edit `infra/cloudflare/deploy.sh` inputs.
+
+1. Run deployment:
+
+   ```bash
+   ./infra/cloudflare/deploy.sh
+   ```
+
+1. Follow post-bind Cloudflare cutover instructions printed by the script:
+   - Toggle CNAME from DNS-only to Proxied (orange cloud)
+   - Set SSL/TLS mode to `Full (strict)`
+
+## Input Contract (`deploy.sh.example`)
+
+| Input | Required | Purpose |
+| --- | --- | --- |
+| `subscription_id` | yes | Azure subscription ID |
+| `resource_group_name` | yes | Resource group containing Container App |
+| `container_app_name` | yes | Container App name |
+| `container_apps_environment_name` | yes | Container Apps environment name |
+| `domain_name` | yes | Subdomain FQDN to bind (for example `app.example.com`) |
+| `certificate_name` | yes | Environment-scoped certificate name used by bind |
+| `certificate_file` | yes | Local path to certificate (`.pfx` preferred, `.pem` supported) |
+| `certificate_password` | depends | Password for `certificate_file` if encrypted/required |
+| `wait_for_dns` | yes | `true` to poll DNS before bind, `false` for manual wait |
+| `dns_poll_seconds` | yes | DNS poll interval in seconds |
+
+Additional default:
+
+- `dns_timeout_seconds`: max wait duration for DNS polling.
+
+## End-to-End Runbook
+
+1. Prepare origin certificate in Cloudflare.
+1. Convert PEM materials to PFX (`prepare-origin-cert-pfx.sh`).
+1. Run `deploy.sh` and note the DNS instructions:
+   - CNAME: `<subdomain>` -> `<container-app-fqdn>`
+   - TXT: `asuid.<subdomain>`
+1. In Cloudflare DNS, create required records:
+   - Keep CNAME **DNS-only** (gray cloud) while Azure hostname add/bind is being validated.
+   - Confirm external resolvers can see a CNAME response to the Container App FQDN and the TXT `asuid.*` value.
+1. Let script complete:
+   - `az containerapp hostname add`
+   - `az containerapp env certificate upload`
+   - `az containerapp hostname bind --validation-method CNAME`
+1. After successful bind:
+   - Toggle CNAME to **Proxied** (orange cloud)
+   - Set Cloudflare SSL/TLS mode to `Full (strict)`
+   - Verify HTTPS path
+
+## Validation and Test Scenarios
+
+Use this checklist after implementation:
+
+1. Happy path:
+   - New subdomain with DNS-only CNAME + TXT
+   - Script succeeds
+   - Proxied toggle works
+1. Idempotent rerun:
+   - Re-running script does not perform destructive changes
+1. DNS lag:
+   - Polling waits and times out with actionable guidance if records are not visible
+1. Invalid certificate:
+   - Upload/bind fails with actionable next steps
+1. Wrong proxy timing:
+   - Bind fails when CNAME is proxied too early; resolved by switching to DNS-only and retrying
+1. Post-cutover verification:
+   - `az containerapp hostname list` includes hostname
+   - `curl -I https://<domain>` returns HTTPS response through Cloudflare
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| `hostname bind` fails validation | CNAME proxied (orange cloud) during validation | Set CNAME to DNS-only, verify CNAME/TXT, rerun |
+| `hostname bind` fails but CNAME looks configured in dashboard | CNAME flattening behavior prevents resolvers from returning a CNAME answer | Verify `dig +short CNAME <domain>` returns the Container App FQDN during validation window |
+| Script times out waiting for DNS | DNS propagation delay or wrong record values | Check `dig` outputs for CNAME/TXT and correct them |
+| Certificate upload fails | Wrong file format/password | Recreate `.pfx` and verify password |
+| `526` at Cloudflare edge | Cloudflare strict validation failing against origin cert | Ensure cert hostname coverage and unexpired cert; keep SSL mode `Full (strict)` |
+| Custom domain not listed as secured in Azure | Bind command failed or partial bind state | Check `az containerapp hostname list`, fix DNS/cert, rerun bind |
+
+## Security Notes
+
+- Never commit private keys, certificate passwords, or generated `.pfx` files.
+- Keep certificate material in a secure local path or secret store.
+- Cloudflare Origin CA certificates are intended for Cloudflare-to-origin encryption; if proxying is disabled, browsers may not trust origin certs.
+
+## Validation Command
+
+```bash
+bash infra/cloudflare/validate.sh
+```

--- a/infra/cloudflare/deploy.sh.example
+++ b/infra/cloudflare/deploy.sh.example
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------
+# Inputs: Azure context
+# -----------------------------
+subscription_id="<SUBSCRIPTION_ID>"
+resource_group_name="<RESOURCE_GROUP_NAME>"
+container_app_name="<CONTAINER_APP_NAME>"
+container_apps_environment_name="<CONTAINER_APPS_ENVIRONMENT_NAME>"
+
+# -----------------------------
+# Inputs: Domain + certificate
+# -----------------------------
+domain_name="app.example.com"
+certificate_name="cf-origin-app-example-com"
+certificate_file="./infra/cloudflare/certs/app.example.com.pfx"
+certificate_password="<PFX_PASSWORD>"
+
+# -----------------------------
+# Inputs: DNS wait/poll controls
+# -----------------------------
+wait_for_dns="true"
+dns_poll_seconds="20"
+dns_timeout_seconds="900"
+
+log() {
+  printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    fail "Required command not found: $command_name"
+  fi
+}
+
+require_az_login() {
+  if ! az account show >/dev/null 2>&1; then
+    log "No active Azure session found. Starting login..."
+    az login --use-device-code >/dev/null
+  fi
+}
+
+is_placeholder() {
+  local value="$1"
+  [[ "$value" == \<* && "$value" == *\> ]]
+}
+
+normalize_fqdn() {
+  local value="$1"
+  value="${value%.}"
+  echo "${value,,}"
+}
+
+hostname_exists() {
+  local hostname="$1"
+  local hostname_entries_json
+
+  hostname_entries_json="$(az containerapp hostname list \
+    -g "$resource_group_name" \
+    -n "$container_app_name" \
+    -o json 2>/dev/null || echo '[]')"
+
+  if printf '%s' "$hostname_entries_json" | grep -Fq "\"$hostname\""; then
+    return 0
+  fi
+
+  return 1
+}
+
+resolve_cname() {
+  local hostname="$1"
+  if command -v dig >/dev/null 2>&1; then
+    dig +short CNAME "$hostname" | head -n1 | tr -d '"' | tr -d '[:space:]'
+    return
+  fi
+
+  nslookup -type=CNAME "$hostname" 2>/dev/null \
+    | sed -n 's/.*canonical name = //p' \
+    | head -n1 \
+    | tr -d '"' \
+    | tr -d '[:space:]'
+}
+
+resolve_txt() {
+  local hostname="$1"
+  if command -v dig >/dev/null 2>&1; then
+    dig +short TXT "$hostname" | tr -d '"' | tr '\n' ' '
+    return
+  fi
+
+  nslookup -type=TXT "$hostname" 2>/dev/null \
+    | sed -n 's/.*text = "\(.*\)"/\1/p' \
+    | tr '\n' ' '
+}
+
+wait_for_dns_records() {
+  local cname_hostname="$1"
+  local cname_target_expected="$2"
+  local txt_hostname="$3"
+  local txt_value_expected="$4"
+  local deadline=$((SECONDS + dns_timeout_seconds))
+
+  log "Waiting for DNS propagation..."
+  log "Expected CNAME: $cname_hostname -> $cname_target_expected"
+  log "Expected TXT:   $txt_hostname -> $txt_value_expected"
+
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    local resolved_cname resolved_txt normalized_expected normalized_actual
+    local cname_ok="false"
+    local txt_ok="false"
+
+    resolved_cname="$(resolve_cname "$cname_hostname" || true)"
+    resolved_txt="$(resolve_txt "$txt_hostname" || true)"
+
+    normalized_expected="$(normalize_fqdn "$cname_target_expected")"
+    normalized_actual="$(normalize_fqdn "${resolved_cname:-}")"
+
+    if [ -n "$normalized_actual" ] && [ "$normalized_actual" = "$normalized_expected" ]; then
+      cname_ok="true"
+    fi
+
+    if [ -n "$resolved_txt" ] && [[ "$resolved_txt" == *"$txt_value_expected"* ]]; then
+      txt_ok="true"
+    fi
+
+    if [ "$cname_ok" = "true" ] && [ "$txt_ok" = "true" ]; then
+      log "DNS records are visible."
+      return 0
+    fi
+
+    log "DNS not ready yet (cname_ok=$cname_ok txt_ok=$txt_ok). Sleeping ${dns_poll_seconds}s..."
+    sleep "$dns_poll_seconds"
+  done
+
+  fail "Timed out waiting for DNS records. Ensure CNAME is DNS-only and values match expected records."
+}
+
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  fail "Bash 4+ is required."
+fi
+
+require_command az
+
+if [ "$wait_for_dns" = "true" ]; then
+  if ! command -v dig >/dev/null 2>&1 && ! command -v nslookup >/dev/null 2>&1; then
+    fail "DNS polling requires either 'dig' or 'nslookup'. Install one or set wait_for_dns='false'."
+  fi
+fi
+
+[ -n "$subscription_id" ] || fail "subscription_id is required."
+[ -n "$resource_group_name" ] || fail "resource_group_name is required."
+[ -n "$container_app_name" ] || fail "container_app_name is required."
+[ -n "$container_apps_environment_name" ] || fail "container_apps_environment_name is required."
+[ -n "$domain_name" ] || fail "domain_name is required."
+[ -n "$certificate_name" ] || fail "certificate_name is required."
+[ -n "$certificate_file" ] || fail "certificate_file is required."
+
+is_placeholder "$subscription_id" && fail "subscription_id still has a placeholder value."
+is_placeholder "$resource_group_name" && fail "resource_group_name still has a placeholder value."
+is_placeholder "$container_app_name" && fail "container_app_name still has a placeholder value."
+is_placeholder "$container_apps_environment_name" && fail "container_apps_environment_name still has a placeholder value."
+is_placeholder "$certificate_name" && fail "certificate_name still has a placeholder value."
+is_placeholder "$certificate_file" && fail "certificate_file still has a placeholder value."
+
+if [[ "$domain_name" != *.*.* ]]; then
+  fail "domain_name must be a subdomain FQDN (example: app.example.com)."
+fi
+
+if [[ "$wait_for_dns" != "true" && "$wait_for_dns" != "false" ]]; then
+  fail "wait_for_dns must be either 'true' or 'false'."
+fi
+
+if [[ "$certificate_name" != "${certificate_name,,}" ]]; then
+  fail "certificate_name must be lowercase."
+fi
+
+if ! [[ "$dns_poll_seconds" =~ ^[0-9]+$ ]] || [ "$dns_poll_seconds" -lt 1 ]; then
+  fail "dns_poll_seconds must be a positive integer."
+fi
+
+if ! [[ "$dns_timeout_seconds" =~ ^[0-9]+$ ]] || [ "$dns_timeout_seconds" -lt 1 ]; then
+  fail "dns_timeout_seconds must be a positive integer."
+fi
+
+if [ ! -f "$certificate_file" ]; then
+  fail "certificate_file does not exist: $certificate_file"
+fi
+
+case "$certificate_file" in
+  *.pfx|*.pem)
+    ;;
+  *)
+    fail "certificate_file must end with .pfx or .pem"
+    ;;
+esac
+
+if [[ "$certificate_file" == *.pfx ]] && { [ -z "$certificate_password" ] || is_placeholder "$certificate_password"; }; then
+  fail "certificate_password is required for .pfx certificate_file."
+fi
+
+require_az_login
+az config set extension.use_dynamic_install=yes_without_prompt >/dev/null
+az account set --subscription "$subscription_id"
+
+log "Resolving Azure resources..."
+container_app_id="$(az containerapp show -g "$resource_group_name" -n "$container_app_name" --query id -o tsv 2>/dev/null || true)"
+[ -n "$container_app_id" ] || fail "Container App not found: $container_app_name in $resource_group_name"
+
+environment_id="$(az containerapp env show -g "$resource_group_name" -n "$container_apps_environment_name" --query id -o tsv 2>/dev/null || true)"
+[ -n "$environment_id" ] || fail "Container Apps environment not found: $container_apps_environment_name in $resource_group_name"
+
+container_app_environment_id="$(az containerapp show -g "$resource_group_name" -n "$container_app_name" --query properties.managedEnvironmentId -o tsv)"
+if [ "${container_app_environment_id,,}" != "${environment_id,,}" ]; then
+  fail "Container App is not attached to environment '$container_apps_environment_name'."
+fi
+
+ingress_external="$(az containerapp show -g "$resource_group_name" -n "$container_app_name" --query properties.configuration.ingress.external -o tsv)"
+if [ "$ingress_external" != "true" ]; then
+  fail "Container App ingress must be external/public for this workflow."
+fi
+
+container_app_fqdn="$(az containerapp show -g "$resource_group_name" -n "$container_app_name" --query properties.configuration.ingress.fqdn -o tsv)"
+if [ -z "$container_app_fqdn" ] || [ "$container_app_fqdn" = "null" ]; then
+  fail "Unable to resolve container app ingress FQDN."
+fi
+container_app_fqdn="${container_app_fqdn%.}"
+
+custom_domain_verification_id="$(az containerapp show -g "$resource_group_name" -n "$container_app_name" --query properties.customDomainVerificationId -o tsv)"
+if [ -z "$custom_domain_verification_id" ] || [ "$custom_domain_verification_id" = "null" ]; then
+  fail "Unable to resolve customDomainVerificationId from container app."
+fi
+
+txt_record_name="asuid.${domain_name}"
+
+echo
+echo "Required Cloudflare DNS records (create/update before bind):"
+echo "  1) CNAME"
+echo "     Name:  ${domain_name}"
+echo "     Value: ${container_app_fqdn}"
+echo "     Proxy: DNS-only (gray cloud) until Azure bind succeeds"
+echo
+echo "  2) TXT"
+echo "     Name:  ${txt_record_name}"
+echo "     Value: ${custom_domain_verification_id}"
+echo
+echo "Manual DNS verification commands:"
+echo "  dig +short CNAME ${domain_name}"
+echo "  dig +short TXT ${txt_record_name}"
+echo
+
+if [ "$wait_for_dns" = "true" ]; then
+  wait_for_dns_records "$domain_name" "$container_app_fqdn" "$txt_record_name" "$custom_domain_verification_id"
+else
+  log "Skipping DNS wait (wait_for_dns=false). Continue only after DNS is propagated."
+fi
+
+if ! hostname_exists "$domain_name"; then
+  log "Adding hostname to container app..."
+  if ! az containerapp hostname add \
+    --hostname "$domain_name" \
+    -g "$resource_group_name" \
+    -n "$container_app_name" >/dev/null; then
+    if hostname_exists "$domain_name"; then
+      log "Hostname add reported an error, but hostname is already present. Continuing."
+    else
+      fail "Failed to add hostname '$domain_name' to container app."
+    fi
+  fi
+else
+  log "Hostname already exists on container app. Continuing."
+fi
+
+log "Uploading certificate to Container Apps environment (idempotent update by certificate_name)..."
+upload_args=(
+  containerapp env certificate upload
+  -g "$resource_group_name"
+  --name "$container_apps_environment_name"
+  --certificate-file "$certificate_file"
+  --certificate-name "$certificate_name"
+)
+
+if [ -n "$certificate_password" ] && ! is_placeholder "$certificate_password"; then
+  upload_args+=(--password "$certificate_password")
+fi
+
+az "${upload_args[@]}" >/dev/null
+
+log "Binding hostname to certificate..."
+if ! az containerapp hostname bind \
+  --hostname "$domain_name" \
+  -g "$resource_group_name" \
+  -n "$container_app_name" \
+  --environment "$container_apps_environment_name" \
+  --certificate "$certificate_name" \
+  --validation-method CNAME >/dev/null; then
+  fail "Hostname bind failed. Verify CNAME/TXT records and keep CNAME DNS-only during bind."
+fi
+
+echo
+log "Azure bind completed."
+az containerapp hostname list \
+  -g "$resource_group_name" \
+  -n "$container_app_name" \
+  -o table || true
+
+echo
+echo "Post-bind Cloudflare cutover:"
+echo "  1) Switch CNAME '${domain_name}' from DNS-only to Proxied (orange cloud)."
+echo "  2) Set Cloudflare SSL/TLS mode to 'Full (strict)'."
+echo "  3) Verify traffic through Cloudflare:"
+echo "     curl -I https://${domain_name}"
+echo
+echo "Reference docs:"
+echo "  - https://learn.microsoft.com/en-us/azure/container-apps/custom-domains-certificates"
+echo "  - https://developers.cloudflare.com/dns/proxy-status/"
+echo "  - https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full-strict/"

--- a/infra/cloudflare/scripts/prepare-origin-cert-pfx.sh
+++ b/infra/cloudflare/scripts/prepare-origin-cert-pfx.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  prepare-origin-cert-pfx.sh <origin-cert.pem> <origin-key.pem> <output.pfx> <pfx-password>
+
+Example:
+  prepare-origin-cert-pfx.sh \
+    ./certs/app.example.com.crt.pem \
+    ./certs/app.example.com.key.pem \
+    ./certs/app.example.com.pfx \
+    'StrongPassword123!'
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    fail "Required command not found: $command_name"
+  fi
+}
+
+if [ "$#" -ne 4 ]; then
+  usage
+  exit 1
+fi
+
+origin_certificate_pem="$1"
+origin_private_key_pem="$2"
+output_pfx_path="$3"
+pfx_password="$4"
+
+require_command openssl
+
+[ -f "$origin_certificate_pem" ] || fail "Origin certificate file not found: $origin_certificate_pem"
+[ -f "$origin_private_key_pem" ] || fail "Origin private key file not found: $origin_private_key_pem"
+[ -n "$pfx_password" ] || fail "PFX password cannot be empty."
+
+mkdir -p "$(dirname "$output_pfx_path")"
+umask 077
+
+tmp_output="${output_pfx_path}.tmp"
+cleanup() {
+  rm -f "$tmp_output"
+}
+trap cleanup EXIT
+
+openssl pkcs12 -export \
+  -out "$tmp_output" \
+  -inkey "$origin_private_key_pem" \
+  -in "$origin_certificate_pem" \
+  -passout "pass:${pfx_password}"
+
+mv "$tmp_output" "$output_pfx_path"
+chmod 600 "$output_pfx_path"
+
+echo "Wrote PFX certificate: $output_pfx_path"

--- a/infra/cloudflare/validate.sh
+++ b/infra/cloudflare/validate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[shell] infra/cloudflare/deploy.sh.example"
+bash -n infra/cloudflare/deploy.sh.example
+
+echo "[shell] infra/cloudflare/scripts/prepare-origin-cert-pfx.sh"
+bash -n infra/cloudflare/scripts/prepare-origin-cert-pfx.sh
+
+if command -v shellcheck >/dev/null 2>&1; then
+  echo "[shellcheck] infra/cloudflare/deploy.sh.example"
+  shellcheck infra/cloudflare/deploy.sh.example
+  echo "[shellcheck] infra/cloudflare/scripts/prepare-origin-cert-pfx.sh"
+  shellcheck infra/cloudflare/scripts/prepare-origin-cert-pfx.sh
+fi
+
+echo "Infra Cloudflare validation passed."


### PR DESCRIPTION
## Summary
- add new `infra/cloudflare` automation/docs package for Azure Container Apps custom domains behind Cloudflare
- add Bash deployment template to script Azure custom-domain + BYO certificate bind flow
- add helper script to convert Cloudflare Origin cert PEM materials into PFX for Azure upload
- add Cloudflare infra validation script and link Cloudflare docs from `infra/README.md`

## Test Evidence
- `cd backend && uv run ade test` (pass)
- `bash infra/cloudflare/validate.sh` (pass)
