### PR TITLE
fix(infra): use API health probes and restore cloudflare gitignore

### DIFF
--- a/infra/azure/deploy.ps1.example
+++ b/infra/azure/deploy.ps1.example
@@ -55,6 +55,9 @@ $productionContainerAppSecretKey = "<ADE_SECRET_KEY>"
 $productionContainerAppEnvironmentOverrides = '{"ADE_LOG_LEVEL":"INFO","ADE_LOG_FORMAT":"json","ADE_AUTH_DISABLED":"false"}'
 $productionContainerAppMinimumReplicas = "1"
 $productionContainerAppMaximumReplicas = "1"
+$productionContainerAppScalePollingIntervalSeconds = "30"
+$productionContainerAppScaleCooldownPeriodSeconds = "300"
+$productionContainerAppScaleHttpConcurrentRequests = "10"
 
 $developmentContainerAppImage = "ghcr.io/clac-ca/automatic-data-extractor:<DEVELOPMENT_RUNTIME_TAG>"
 $developmentContainerAppPublicWebUrl = ""
@@ -62,6 +65,9 @@ $developmentContainerAppSecretKey = ""
 $developmentContainerAppEnvironmentOverrides = '{"ADE_LOG_LEVEL":"DEBUG","ADE_LOG_FORMAT":"json","ADE_AUTH_DISABLED":"false"}'
 $developmentContainerAppMinimumReplicas = "0"
 $developmentContainerAppMaximumReplicas = "1"
+$developmentContainerAppScalePollingIntervalSeconds = "30"
+$developmentContainerAppScaleCooldownPeriodSeconds = "1800"
+$developmentContainerAppScaleHttpConcurrentRequests = "10"
 
 # -----------------------------
 # Inputs: SSO bootstrap
@@ -505,6 +511,9 @@ $deploymentParameters = @(
     "productionContainerAppEnvironmentOverrides=$productionContainerAppEnvironmentOverrides"
     "productionContainerAppMinimumReplicas=$productionContainerAppMinimumReplicas"
     "productionContainerAppMaximumReplicas=$productionContainerAppMaximumReplicas"
+    "productionContainerAppScalePollingIntervalSeconds=$productionContainerAppScalePollingIntervalSeconds"
+    "productionContainerAppScaleCooldownPeriodSeconds=$productionContainerAppScaleCooldownPeriodSeconds"
+    "productionContainerAppScaleHttpConcurrentRequests=$productionContainerAppScaleHttpConcurrentRequests"
 )
 
 foreach ($entry in $groupMappings.GetEnumerator()) {
@@ -519,6 +528,9 @@ if ($deployDevelopmentEnvironment) {
         "developmentContainerAppEnvironmentOverrides=$developmentContainerAppEnvironmentOverrides"
         "developmentContainerAppMinimumReplicas=$developmentContainerAppMinimumReplicas"
         "developmentContainerAppMaximumReplicas=$developmentContainerAppMaximumReplicas"
+        "developmentContainerAppScalePollingIntervalSeconds=$developmentContainerAppScalePollingIntervalSeconds"
+        "developmentContainerAppScaleCooldownPeriodSeconds=$developmentContainerAppScaleCooldownPeriodSeconds"
+        "developmentContainerAppScaleHttpConcurrentRequests=$developmentContainerAppScaleHttpConcurrentRequests"
     )
 }
 

--- a/infra/azure/deploy.sh.example
+++ b/infra/azure/deploy.sh.example
@@ -56,6 +56,9 @@ production_container_app_secret_key="<ADE_SECRET_KEY>"
 production_container_app_environment_overrides='{"ADE_LOG_LEVEL":"INFO","ADE_LOG_FORMAT":"json","ADE_AUTH_DISABLED":"false"}'
 production_container_app_minimum_replicas="1"
 production_container_app_maximum_replicas="1"
+production_container_app_scale_polling_interval_seconds="30"
+production_container_app_scale_cooldown_period_seconds="300"
+production_container_app_scale_http_concurrent_requests="10"
 
 development_container_app_image="ghcr.io/clac-ca/automatic-data-extractor:<DEVELOPMENT_RUNTIME_TAG>"
 development_container_app_public_web_url=""
@@ -63,6 +66,9 @@ development_container_app_secret_key=""
 development_container_app_environment_overrides='{"ADE_LOG_LEVEL":"DEBUG","ADE_LOG_FORMAT":"json","ADE_AUTH_DISABLED":"false"}'
 development_container_app_minimum_replicas="0"
 development_container_app_maximum_replicas="1"
+development_container_app_scale_polling_interval_seconds="30"
+development_container_app_scale_cooldown_period_seconds="1800"
+development_container_app_scale_http_concurrent_requests="10"
 
 # -----------------------------
 # Inputs: SSO bootstrap
@@ -418,6 +424,9 @@ params=(
   "productionContainerAppEnvironmentOverrides=$production_container_app_environment_overrides"
   "productionContainerAppMinimumReplicas=$production_container_app_minimum_replicas"
   "productionContainerAppMaximumReplicas=$production_container_app_maximum_replicas"
+  "productionContainerAppScalePollingIntervalSeconds=$production_container_app_scale_polling_interval_seconds"
+  "productionContainerAppScaleCooldownPeriodSeconds=$production_container_app_scale_cooldown_period_seconds"
+  "productionContainerAppScaleHttpConcurrentRequests=$production_container_app_scale_http_concurrent_requests"
 )
 
 for mapping in "${mappings[@]}"; do
@@ -433,6 +442,9 @@ if [ "$deploy_development_environment" = "true" ]; then
     "developmentContainerAppEnvironmentOverrides=$development_container_app_environment_overrides"
     "developmentContainerAppMinimumReplicas=$development_container_app_minimum_replicas"
     "developmentContainerAppMaximumReplicas=$development_container_app_maximum_replicas"
+    "developmentContainerAppScalePollingIntervalSeconds=$development_container_app_scale_polling_interval_seconds"
+    "developmentContainerAppScaleCooldownPeriodSeconds=$development_container_app_scale_cooldown_period_seconds"
+    "developmentContainerAppScaleHttpConcurrentRequests=$development_container_app_scale_http_concurrent_requests"
   )
 fi
 

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -116,6 +116,18 @@ param productionContainerAppMinimumReplicas int = 1
 @description('Production Container App maximum replicas.')
 param productionContainerAppMaximumReplicas int = 2
 
+@minValue(1)
+@description('Production Container App scale polling interval in seconds.')
+param productionContainerAppScalePollingIntervalSeconds int = 30
+
+@minValue(0)
+@description('Production Container App scale cooldown period in seconds before scaling to minimum replicas.')
+param productionContainerAppScaleCooldownPeriodSeconds int = 300
+
+@minValue(1)
+@description('Production Container App HTTP concurrent requests threshold per replica for autoscaling.')
+param productionContainerAppScaleHttpConcurrentRequests int = 10
+
 @description('Development Container App image. Empty reuses production image.')
 param developmentContainerAppImage string = ''
 
@@ -136,6 +148,18 @@ param developmentContainerAppMinimumReplicas int = 0
 @minValue(1)
 @description('Development Container App maximum replicas.')
 param developmentContainerAppMaximumReplicas int = 1
+
+@minValue(1)
+@description('Development Container App scale polling interval in seconds.')
+param developmentContainerAppScalePollingIntervalSeconds int = 30
+
+@minValue(0)
+@description('Development Container App scale cooldown period in seconds before scaling to minimum replicas.')
+param developmentContainerAppScaleCooldownPeriodSeconds int = 1800
+
+@minValue(1)
+@description('Development Container App HTTP concurrent requests threshold per replica for autoscaling.')
+param developmentContainerAppScaleHttpConcurrentRequests int = 10
 
 var locationToken = toLower(replace(location, ' ', ''))
 var locationShortToken = take(locationToken, 3)
@@ -243,6 +267,9 @@ module productionContainerApp 'modules/container-app.bicep' = {
     containerAppEnvironmentOverrides: productionContainerAppEnvironmentOverrides
     containerAppMinimumReplicas: productionContainerAppMinimumReplicas
     containerAppMaximumReplicas: productionContainerAppMaximumReplicas
+    containerAppScalePollingIntervalSeconds: productionContainerAppScalePollingIntervalSeconds
+    containerAppScaleCooldownPeriodSeconds: productionContainerAppScaleCooldownPeriodSeconds
+    containerAppScaleHttpConcurrentRequests: productionContainerAppScaleHttpConcurrentRequests
     containerAppsManagedEnvironmentName: observability.outputs.containerAppsManagedEnvironmentName
     containerAppsManagedEnvironmentResourceId: observability.outputs.containerAppsManagedEnvironmentResourceId
     containerAppsManagedEnvironmentDefaultDomain: observability.outputs.containerAppsManagedEnvironmentDefaultDomain
@@ -267,6 +294,9 @@ module developmentContainerApp 'modules/container-app.bicep' = {
     containerAppEnvironmentOverrides: developmentContainerAppEnvironmentOverrides
     containerAppMinimumReplicas: developmentContainerAppMinimumReplicas
     containerAppMaximumReplicas: developmentContainerAppMaximumReplicas
+    containerAppScalePollingIntervalSeconds: developmentContainerAppScalePollingIntervalSeconds
+    containerAppScaleCooldownPeriodSeconds: developmentContainerAppScaleCooldownPeriodSeconds
+    containerAppScaleHttpConcurrentRequests: developmentContainerAppScaleHttpConcurrentRequests
     containerAppsManagedEnvironmentName: observability.outputs.containerAppsManagedEnvironmentName
     containerAppsManagedEnvironmentResourceId: observability.outputs.containerAppsManagedEnvironmentResourceId
     containerAppsManagedEnvironmentDefaultDomain: observability.outputs.containerAppsManagedEnvironmentDefaultDomain


### PR DESCRIPTION
## Summary
- switch Container App startup/readiness/liveness probes to `/api/v1/health`
- expose and wire scale polling/cooldown/http concurrency inputs in deploy examples
- document that re-running infra can overwrite manual portal settings
- restore `infra/cloudflare/.gitignore` so local deploy scripts/certs are never uploaded

## Validation
- `bash infra/azure/validate.sh`
- `cd backend && uv run ade test`

## Ops
- Azure deploy re-applied
- Cloudflare prod/dev domain bind scripts re-ran successfully
