### PR TITLE
fix(infra): ignore local cloudflare scripts and cert files

### DIFF
--- a/infra/cloudflare/.gitignore
+++ b/infra/cloudflare/.gitignore
@@ -1,0 +1,8 @@
+deploy.sh
+deploy.ps1
+deploy.prod.sh
+deploy.dev.sh
+
+# Local certificate/key material
+certs/*
+!certs/.gitkeep


### PR DESCRIPTION
Adds  so local deploy scripts and cert/key material are never uploaded by accident.