### PR TITLE
fix(release): trigger Release Please after squash merge

### DIFF
--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -18,6 +18,12 @@ Explain how ADE versions and container images are produced, including rebuild re
 3. Merging the release PR updates `VERSION`/`CHANGELOG` and creates GitHub release tag `vX.Y.Z`.
 4. Publishing that release triggers `docker-image.yaml` and publishes images.
 
+### Conventional commit requirement on `main`
+
+Release Please only increments versions from parseable Conventional Commit messages on `main`.
+If a squash-merged PR lands with a non-conventional title, Release Please can skip release creation for that push.
+When needed, add a follow-up commit with a valid Conventional Commit type (`fix:`, `feat:`, `deps:`), or force a specific version with a `Release-As: X.Y.Z` footer.
+
 ## Current Workflow Targets
 
 - `release-please.yaml` runs on pushes to `main`.


### PR DESCRIPTION
## Summary
- Document that Release Please requires parseable Conventional Commit messages on `main`.
- Add explicit guidance for squash-merge scenarios and `Release-As` usage.

## Why
- The previous promotion merge used a non-conventional squash title, so Release Please skipped creating a release.
- This commit uses a conventional message and includes a `Release-As: 1.8.0` footer to force the intended release version.

## Validation
- `cd backend && uv run ade test`
