### PR TITLE
fix(api): enable API docs by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@
 # ADE_SERVICES=api,worker,web                                           # api,worker,web
 # ADE_DB_MIGRATE_ON_START=true                                          # true|false
 # ADE_PUBLIC_WEB_URL=http://localhost:8000
-# ADE_API_DOCS_ENABLED=true                                             # true|false; exposes ReDoc at /api and Swagger UI at /api/swagger
+# ADE_API_DOCS_ENABLED=true                                             # true|false; default true (set false to disable docs routes)
 # ADE_API_DOCS_ACCESS_MODE=authenticated                                # authenticated|public; default authenticated
 
 # Capacity and scaling.

--- a/backend/src/ade_api/settings.py
+++ b/backend/src/ade_api/settings.py
@@ -60,7 +60,7 @@ class Settings(
     app_name: str = "Automatic Data Extractor API"
     app_version: str = "unknown"
     app_commit_sha: str = "unknown"
-    api_docs_enabled: bool = False
+    api_docs_enabled: bool = True
     api_docs_access_mode: Literal["authenticated", "public"] = "authenticated"
     docs_url: str = "/api/swagger"
     redoc_url: str = "/api"

--- a/backend/tests/api/unit/settings/test_settings_defaults.py
+++ b/backend/tests/api/unit/settings/test_settings_defaults.py
@@ -22,7 +22,7 @@ def test_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.app_name == "Automatic Data Extractor API"
     assert settings.app_version == "unknown"
     assert settings.app_commit_sha == "unknown"
-    assert settings.api_docs_enabled is False
+    assert settings.api_docs_enabled is True
     assert settings.api_docs_access_mode == "authenticated"
     assert settings.docs_url == "/api/swagger"
     assert settings.redoc_url == "/api"

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -54,9 +54,9 @@ Common API options:
 - `ade-api start --processes N`
 - `ade-api dev --processes N` (disables reload when `N > 1`)
 
-API docs (opt-in):
+API docs:
 
-- Set `ADE_API_DOCS_ENABLED=true` to expose:
+- API docs are enabled by default. Set `ADE_API_DOCS_ENABLED=false` to disable:
   - ReDoc at `/api`
   - Swagger UI at `/api/swagger`
   - OpenAPI JSON at `/api/openapi.json`

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -42,7 +42,7 @@ If one of these is missing, production startup will fail.
 | `ADE_DB_MIGRATE_ON_START` | root CLI | optional | `true` | auto-runs migrations with `ade start/dev` |
 | `ADE_API_PORT` | API CLI (`ade-api`) | optional | `8001` | API bind port for native CLI runs |
 | `ADE_WEB_PORT` | web CLI (`ade web dev`) | optional | `8000` | Vite web dev server port for native CLI runs |
-| `ADE_API_DOCS_ENABLED` | API | optional | `false` | enable built-in API docs: ReDoc at `/api`, Swagger UI at `/api/swagger`, and OpenAPI JSON at `/api/openapi.json` |
+| `ADE_API_DOCS_ENABLED` | API | optional | `true` | enable built-in API docs: ReDoc at `/api`, Swagger UI at `/api/swagger`, and OpenAPI JSON at `/api/openapi.json` (`false` disables all three routes) |
 | `ADE_API_DOCS_ACCESS_MODE` | API | optional | `authenticated` | docs access policy when enabled: `authenticated` (default) or `public` |
 | `ADE_INTERNAL_API_URL` | web/nginx/vite | optional | `http://localhost:8001` | must be origin only (no path/query) |
 | `ADE_DATA_DIR` | API, worker | optional | `backend/data` (repo) or `/app/data` (container) | writable runtime data path; mount this path for persistence in ACA |

--- a/docs/tutorials/local-quickstart.md
+++ b/docs/tutorials/local-quickstart.md
@@ -42,17 +42,18 @@ curl -sS http://localhost:8000/api/v1/info
 
 You should get JSON responses (not connection errors).
 
-## Optional: Enable Built-In API Docs
+## Optional: Make Built-In API Docs Public
 
-API docs are opt-in. To enable ReDoc + Swagger UI locally:
+API docs are enabled by default with authenticated access.
+To make ReDoc + Swagger UI public locally:
 
 ```bash
-echo "ADE_API_DOCS_ENABLED=true" >> .env
 echo "ADE_API_DOCS_ACCESS_MODE=public" >> .env
 docker compose up --build -d
 ```
 
 Use `ADE_API_DOCS_ACCESS_MODE=authenticated` (default) to require sign-in.
+Set `ADE_API_DOCS_ENABLED=false` if you want to disable docs entirely.
 After changing `.env`, always rerun `docker compose up --build -d` so API/web
 containers restart with the new values.
 
@@ -80,7 +81,7 @@ docker compose down -v
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| `404` on `/api` or `/api/swagger` | docs are disabled | set `ADE_API_DOCS_ENABLED=true` and restart containers |
+| `404` on `/api` or `/api/swagger` | docs were explicitly disabled | set `ADE_API_DOCS_ENABLED=true` and restart containers |
 | `/api` shows the SPA page instead of ReDoc | stale web container/nginx config | rerun `docker compose up --build -d` |
 | `403` with `csrf_failed` in Swagger "Try it out" | session auth without CSRF cookie/header | sign in first or use `X-API-Key` auth in Swagger |
 | Wrong request target in Swagger | incorrect base URL/proxy origin | verify `ADE_PUBLIC_WEB_URL` and open docs from web port `:8000` |


### PR DESCRIPTION
## Summary
- Change API docs default to enabled (`api_docs_enabled=True`).
- Keep default access mode as `authenticated`.
- Update tests and docs to reflect the new default behavior.

## Changes
- backend default setting now enables docs routes by default.
- updated settings default unit test expectation.
- updated docs/env references that previously described docs as opt-in.

## Validation
- `cd backend && uv run ade test`
