### PR TITLE
fix(web): remove vulnerable workbook parsing from upload preflight

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,7 +55,6 @@
         "react-router-dom": "^7.13.0",
         "tailwind-merge": "^3.4.0",
         "tw-animate-css": "^1.4.0",
-        "xlsx": "^0.18.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -187,6 +186,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -561,6 +561,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -601,6 +602,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -672,6 +674,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1423,6 +1426,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
       "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.6",
         "@floating-ui/utils": "^0.2.10",
@@ -4151,6 +4155,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -4334,8 +4339,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4438,6 +4442,7 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4448,6 +4453,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4494,6 +4500,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4888,6 +4895,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4903,15 +4911,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/agent-base": {
@@ -5269,6 +5268,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5379,19 +5379,6 @@
       "integrity": "sha512-+VsMpRr64jYgKq2IeFUNel3vCZH/IzS+iXSHxmUV3IUH5dXlC9xHz4AwtPZisDxZ5MWcuK0V+TXgPKFPiZnxzg==",
       "license": "MIT"
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5473,15 +5460,6 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5525,18 +5503,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -5825,8 +5791,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -6148,6 +6113,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6658,15 +6624,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fsevents": {
@@ -7618,6 +7575,7 @@
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -8038,7 +7996,8 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -8084,7 +8043,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8132,6 +8090,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
       "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8186,6 +8145,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -8557,6 +8517,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8647,7 +8608,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8663,7 +8623,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8720,6 +8679,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8750,6 +8710,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8774,6 +8735,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8799,8 +8761,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-number-format": {
       "version": "5.4.4",
@@ -8874,6 +8835,7 @@
       "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
       "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "classnames": "^2.2.5",
         "prop-types": "^15.5.8",
@@ -8885,6 +8847,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
       "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -8907,6 +8870,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
       "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-router": "7.13.0"
       },
@@ -9360,18 +9324,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/stackback": {
@@ -9896,6 +9848,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10062,6 +10015,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10152,6 +10106,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -10400,24 +10355,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10440,27 +10377,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {
@@ -10597,6 +10513,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,6 @@
     "react-router-dom": "^7.13.0",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0",
-    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/frontend/src/pages/Workspace/sections/Documents/list/upload/UploadPreflightDialog.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/upload/UploadPreflightDialog.tsx
@@ -3,9 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { UploadManagerQueueItem } from "./useUploadManager";
 import {
   buildUploadRunOptions,
-  readWorkbookSheetNames,
   supportsWorkbookSheetSelection,
-  type UploadSheetScope,
 } from "./sheetSelection";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -47,27 +45,15 @@ export function UploadPreflightDialog({
   configMissing,
 }: UploadPreflightDialogProps) {
   const [localFiles, setLocalFiles] = useState<PreflightFile[]>([]);
-  const [sheetScope, setSheetScope] = useState<UploadSheetScope>("active");
-  const [selectedSheets, setSelectedSheets] = useState<string[]>([]);
-  const [workbookSheets, setWorkbookSheets] = useState<string[]>([]);
-  const [isLoadingWorkbookSheets, setIsLoadingWorkbookSheets] = useState(false);
-  const [workbookSheetError, setWorkbookSheetError] = useState<string | null>(null);
+  const [sheetScope, setSheetScope] = useState<"active" | "all">("active");
 
   useEffect(() => {
     if (!open) {
       setLocalFiles([]);
       setSheetScope("active");
-      setSelectedSheets([]);
-      setWorkbookSheets([]);
-      setIsLoadingWorkbookSheets(false);
-      setWorkbookSheetError(null);
       return;
     }
     setSheetScope("active");
-    setSelectedSheets([]);
-    setWorkbookSheets([]);
-    setIsLoadingWorkbookSheets(false);
-    setWorkbookSheetError(null);
     setLocalFiles(
       files.map((file) => ({
         id: stableId(),
@@ -77,82 +63,11 @@ export function UploadPreflightDialog({
     );
   }, [files, open]);
 
-  const singleWorkbookFile = useMemo(() => {
-    if (localFiles.length !== 1) {
-      return null;
-    }
-    const [entry] = localFiles;
-    if (!entry || !supportsWorkbookSheetSelection(entry.type)) {
-      return null;
-    }
-    return entry;
-  }, [localFiles]);
-
-  useEffect(() => {
-    let cancelled = false;
-    if (!singleWorkbookFile) {
-      setWorkbookSheets([]);
-      setIsLoadingWorkbookSheets(false);
-      setWorkbookSheetError(null);
-      setSelectedSheets([]);
-      setSheetScope((current) => (current === "selected" ? "active" : current));
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    setIsLoadingWorkbookSheets(true);
-    setWorkbookSheetError(null);
-    setWorkbookSheets([]);
-    readWorkbookSheetNames(singleWorkbookFile.file)
-      .then((sheetNames) => {
-        if (cancelled) return;
-        setWorkbookSheets(sheetNames);
-        if (sheetNames.length === 0) {
-          setSheetScope((current) => (current === "selected" ? "active" : current));
-          setSelectedSheets([]);
-          setWorkbookSheetError("No worksheets were found in this workbook.");
-          return;
-        }
-        setSelectedSheets((current) =>
-          current.filter((sheetName) => sheetNames.includes(sheetName)),
-        );
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setSheetScope((current) => (current === "selected" ? "active" : current));
-        setSelectedSheets([]);
-        setWorkbookSheetError("Unable to read worksheet names for this workbook.");
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setIsLoadingWorkbookSheets(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [singleWorkbookFile]);
-
-  const normalizedSelectedSheets = useMemo(() => {
-    const available = new Set(workbookSheets);
-    const unique = new Set<string>();
-    for (const sheetName of selectedSheets) {
-      if (!available.has(sheetName)) {
-        continue;
-      }
-      unique.add(sheetName);
-    }
-    return Array.from(unique);
-  }, [selectedSheets, workbookSheets]);
-
-  const specificScopeEnabled =
-    Boolean(singleWorkbookFile) && workbookSheets.length > 0 && !isLoadingWorkbookSheets;
-  const allSheetsSelected =
-    workbookSheets.length > 0 && normalizedSelectedSheets.length === workbookSheets.length;
-  const confirmationDisabled =
-    localFiles.length === 0 ||
-    (sheetScope === "selected" &&
-      (!specificScopeEnabled || normalizedSelectedSheets.length === 0));
+  const hasWorkbookUpload = useMemo(
+    () => localFiles.some((entry) => supportsWorkbookSheetSelection(entry.type)),
+    [localFiles],
+  );
+  const confirmationDisabled = localFiles.length === 0;
   const scopeAppliesLabel =
     localFiles.length <= 1 ? "Applies to this upload." : `Applies to all ${localFiles.length} queued files.`;
 
@@ -166,21 +81,9 @@ export function UploadPreflightDialog({
     setLocalFiles((prev) => prev.filter((entry) => entry.id !== id));
   };
 
-  const toggleSheetSelection = (sheetName: string) => {
-    setSelectedSheets((current) =>
-      current.includes(sheetName)
-        ? current.filter((value) => value !== sheetName)
-        : [...current, sheetName],
-    );
-  };
-
-  const selectAllSheets = () => {
-    setSelectedSheets(workbookSheets);
-  };
-
   const handleConfirm = () => {
     if (!localFiles.length) return;
-    const runOptions = buildUploadRunOptions(sheetScope, normalizedSelectedSheets);
+    const runOptions = buildUploadRunOptions(sheetScope, []);
     const items: UploadManagerQueueItem[] = localFiles.map((entry) => ({
       file: entry.file,
       runOptions,
@@ -272,116 +175,12 @@ export function UploadPreflightDialog({
               </span>
             </div>
 
-            {singleWorkbookFile ? (
-              <div
-                className={cn(
-                  "flex items-start gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
-                  sheetScope === "selected"
-                    ? "border-primary/70 bg-primary/5"
-                    : "border-border bg-background hover:border-primary/40",
-                  !specificScopeEnabled && "opacity-60",
-                )}
-              >
-                <input
-                  id="upload-sheet-scope-selected"
-                  type="radio"
-                  name="upload-sheet-scope"
-                  className="mt-0.5 h-4 w-4"
-                  checked={sheetScope === "selected"}
-                  onChange={() => setSheetScope("selected")}
-                  disabled={!specificScopeEnabled}
-                />
-                <span className="space-y-0.5">
-                  <label htmlFor="upload-sheet-scope-selected" className="block font-medium text-foreground">
-                    Specific sheets
-                  </label>
-                  <span className="block text-xs text-muted-foreground">
-                    Choose one or more worksheets from this file.
-                  </span>
-                </span>
-              </div>
-            ) : null}
           </div>
 
-          {singleWorkbookFile ? (
-            <div
-              className={cn(
-                "rounded-lg border border-border bg-background p-2 transition-opacity",
-                sheetScope !== "selected" && "opacity-80",
-              )}
-            >
-              {isLoadingWorkbookSheets ? (
-                <p className="text-xs text-muted-foreground">Loading worksheets…</p>
-              ) : workbookSheetError ? (
-                <Alert tone="warning" className="text-xs">
-                  {workbookSheetError}
-                </Alert>
-              ) : workbookSheets.length > 0 ? (
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-xs font-medium text-foreground">
-                      Worksheets ({workbookSheets.length.toLocaleString()})
-                    </p>
-                    <div className="flex items-center gap-1">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-xs"
-                        onClick={selectAllSheets}
-                        disabled={sheetScope !== "selected" || allSheetsSelected}
-                      >
-                        Select all
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-xs"
-                        onClick={() => setSelectedSheets([])}
-                        disabled={sheetScope !== "selected" || normalizedSelectedSheets.length === 0}
-                      >
-                        Clear
-                      </Button>
-                    </div>
-                  </div>
-                  <div className="max-h-36 space-y-1 overflow-y-auto rounded-md border border-border p-1">
-                    {workbookSheets.map((sheetName) => {
-                      const checked = normalizedSelectedSheets.includes(sheetName);
-                      return (
-                        <label
-                          key={sheetName}
-                          className={cn(
-                            "flex items-center gap-2 rounded px-2 py-1 text-xs text-foreground",
-                            sheetScope === "selected" ? "hover:bg-muted" : "opacity-80",
-                          )}
-                        >
-                          <input
-                            type="checkbox"
-                            className="h-4 w-4"
-                            checked={checked}
-                            onChange={() => toggleSheetSelection(sheetName)}
-                            disabled={sheetScope !== "selected"}
-                          />
-                          <span className="truncate">{sheetName}</span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {sheetScope === "selected"
-                      ? normalizedSelectedSheets.length === 0
-                        ? "Select at least one worksheet to continue."
-                        : `${normalizedSelectedSheets.length.toLocaleString()} worksheet${
-                            normalizedSelectedSheets.length === 1 ? "" : "s"
-                          } selected.`
-                      : "Switch to Specific sheets to choose worksheets manually."}
-                  </p>
-                </div>
-              ) : (
-                <p className="text-xs text-muted-foreground">No worksheets available for selection.</p>
-              )}
-            </div>
+          {hasWorkbookUpload ? (
+            <Alert tone="warning" className="text-xs">
+              Worksheet-level selection is unavailable for direct uploads. Upload with Active sheet only or All sheets, then use reprocess for specific worksheets.
+            </Alert>
           ) : null}
         </div>
 

--- a/frontend/src/pages/Workspace/sections/Documents/list/upload/sheetSelection.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/list/upload/sheetSelection.ts
@@ -38,9 +38,3 @@ export function buildUploadRunOptions(
   }
   return { active_sheet_only: true };
 }
-
-export async function readWorkbookSheetNames(file: File): Promise<string[]> {
-  const { read } = await import("xlsx");
-  const workbook = read(await file.arrayBuffer(), { type: "array", bookSheets: true });
-  return normalizeSheetNames(workbook.SheetNames ?? []);
-}


### PR DESCRIPTION
## Summary
- remove client-side workbook sheet-name parsing from upload preflight
- remove `xlsx` dependency from frontend to eliminate the known vulnerable parser path
- keep upload options to `Active sheet only` and `All sheets`, and show an explicit warning for workbook uploads
- update upload preflight tests for the new safe behavior

## Why
Issue #285 identified that we were parsing attacker-controlled workbook bytes in-browser via `xlsx@^0.18.5`, with high-severity advisories and no available npm patch line for this package.

## Validation
- `cd backend && uv run ade web test`
- `cd backend && uv run ade web lint`
- `npm --prefix frontend audit --json` (0 vulnerabilities)

Closes #285
