### PR TITLE
fix(api): preserve document stream cursor on SSE connect

### DIFF
--- a/backend/src/ade_api/features/documents/router.py
+++ b/backend/src/ade_api/features/documents/router.py
@@ -627,10 +627,11 @@ async def stream_document_changes(
             with session_factory() as session:
                 return get_latest_document_change_id(session, workspace_id)
 
-        try:
-            token_value = await asyncio.to_thread(_current_token)
-        except Exception:
-            token_value = start_token
+        if start_token is None:
+            try:
+                token_value = await asyncio.to_thread(_current_token)
+            except Exception:
+                token_value = start_token
 
         ready_id = str(token_value) if token_value is not None else None
         yield sse_json("ready", {"lastId": ready_id})


### PR DESCRIPTION
## Summary
- preserve the caller-supplied documents stream resume token (`cursor`/`Last-Event-ID`) on connect
- only resolve latest DB token when no resume token is provided
- add integration coverage asserting `ready.lastId` honors `cursor=0`

## Why
Issue #289: stream setup was overwriting provided cursor state with the latest change id, which broke reconnect/resume semantics.

## Validation
- `cd backend && uv run ade api test`
- `cd backend && uv run pytest tests/api/integration/documents/test_documents_change_stream.py -q` *(fails locally: missing `ADE_TEST_DATABASE_URL` in this environment)*

Closes #289
