### PR TITLE
feat(documents): stabilize rename flow and expand preview

### DIFF
--- a/frontend/src/components/data-table/__tests__/data-table.test.tsx
+++ b/frontend/src/components/data-table/__tests__/data-table.test.tsx
@@ -42,6 +42,7 @@ function TestHarness({
             <div role="option" aria-selected="false" data-row-interactive>
               Faceted option
             </div>
+            <div data-slot="dropdown-menu-content">Open menu content</div>
           </div>
         ),
       },
@@ -141,7 +142,7 @@ describe("DataTable", () => {
     expect(onContext).toHaveBeenCalledTimes(0);
   });
 
-  it("supports row context menu and ignores interactive targets", () => {
+  it("supports row context menu across the full row surface but ignores overlay targets", () => {
     const onActivate = vi.fn();
     const onContext = vi.fn();
     render(<TestHarness onActivate={onActivate} onContext={onContext} />);
@@ -154,7 +155,10 @@ describe("DataTable", () => {
     expect(onContext).toHaveBeenLastCalledWith("doc_1");
 
     fireEvent.contextMenu(screen.getByRole("button", { name: "Inner action" }));
-    expect(onContext).toHaveBeenCalledTimes(1);
+    expect(onContext).toHaveBeenCalledTimes(2);
+
+    fireEvent.contextMenu(screen.getByText("Open menu content"));
+    expect(onContext).toHaveBeenCalledTimes(2);
   });
 
   it("opens row context menu even after prior interactive pointer intent", () => {

--- a/frontend/src/components/data-table/rowInteraction.ts
+++ b/frontend/src/components/data-table/rowInteraction.ts
@@ -28,8 +28,6 @@ const ROW_INTERACTIVE_SELECTOR = [
 ].join(",");
 
 const CONTEXT_MENU_BLOCK_SELECTOR = [
-  "[data-row-interactive]",
-  "[data-ignore-row-click]",
   "[data-radix-popper-content-wrapper]",
   "[data-slot='popover-content']",
   "[data-slot='dropdown-menu-content']",
@@ -37,19 +35,13 @@ const CONTEXT_MENU_BLOCK_SELECTOR = [
   "[cmdk-root]",
   "[cmdk-item]",
   "[cmdk-input]",
-  "button",
-  "a[href]",
-  "input",
-  "select",
-  "textarea",
-  "[role='button']",
+  "[role='dialog']",
+  "[role='menu']",
   "[role='menuitem']",
   "[role='menuitemcheckbox']",
   "[role='menuitemradio']",
-  "[role='combobox']",
   "[role='listbox']",
   "[role='option']",
-  "[role='textbox']",
   "[contenteditable='true']",
 ].join(",");
 

--- a/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/hooks/__tests__/useDocumentPreviewModel.test.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/hooks/__tests__/useDocumentPreviewModel.test.tsx
@@ -109,6 +109,8 @@ describe("useDocumentPreviewModel", () => {
       expect(latestCall?.[1]).toBe("doc-1");
       expect(latestCall?.[2]).toEqual(
         expect.objectContaining({
+          maxRows: 10_000,
+          maxColumns: 10_000,
           trimEmptyRows: true,
           trimEmptyColumns: true,
         }),
@@ -123,6 +125,8 @@ describe("useDocumentPreviewModel", () => {
       expect(latestCall?.[1]).toBe("doc-1");
       expect(latestCall?.[2]).toEqual(
         expect.objectContaining({
+          maxRows: 10_000,
+          maxColumns: 10_000,
           trimEmptyRows: false,
           trimEmptyColumns: false,
         }),

--- a/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/hooks/useDocumentPreviewModel.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/detail/tabs/preview/hooks/useDocumentPreviewModel.ts
@@ -16,8 +16,8 @@ import type { DocumentRow } from "@/pages/Workspace/sections/Documents/shared/ty
 import { getNormalizedPreviewState } from "../state";
 import { buildPreviewCountSummary, type PreviewDisplayPreferences } from "../model";
 
-const DEFAULT_MAX_ROWS = 200;
-const DEFAULT_MAX_COLUMNS = 50;
+const DEFAULT_MAX_ROWS = 10_000;
+const DEFAULT_MAX_COLUMNS = 10_000;
 
 export type PreviewSheet = {
   name: string;

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx
@@ -86,6 +86,11 @@ type BulkTagPatch = {
   remove: string[];
 };
 
+type RenameTarget = {
+  id: string;
+  name: string;
+};
+
 const BULK_DOWNLOAD_WARNING_THRESHOLD = 12;
 const BULK_DOWNLOAD_DELAY_MS = 80;
 const ASSIGN_CHOICE_UNASSIGN = "__unassign__";
@@ -202,6 +207,8 @@ export function DocumentsTableContainer({
   const navigate = useNavigate();
   const [deleteTarget, setDeleteTarget] = useState<DocumentRow | null>(null);
   const [restoreTarget, setRestoreTarget] = useState<DocumentRow | null>(null);
+  const [renameTarget, setRenameTarget] = useState<RenameTarget | null>(null);
+  const [renameError, setRenameError] = useState<string | null>(null);
   const [restoreRenameTarget, setRestoreRenameTarget] = useState<DocumentRow | null>(null);
   const [restoreRenameInitialName, setRestoreRenameInitialName] = useState("");
   const [restoreRenameError, setRestoreRenameError] = useState<string | null>(null);
@@ -218,10 +225,6 @@ export function DocumentsTableContainer({
   const [reprocessTargets, setReprocessTargets] = useState<ReprocessTargetDocument[]>([]);
   const [isReprocessSubmitting, setIsReprocessSubmitting] = useState(false);
   const [selectionResetToken, setSelectionResetToken] = useState(0);
-  const [inlineRenameRequest, setInlineRenameRequest] = useState<{
-    documentId: string;
-    nonce: number;
-  } | null>(null);
   const renameMutation = useRenameDocumentMutation({ workspaceId });
   const canManagePublicViews = hasPermission("workspace.documents.views.public.manage");
   const {
@@ -314,11 +317,12 @@ export function DocumentsTableContainer({
 
   const handledUploadsRef = useRef(new Set<string>());
   const completedUploadsRef = useRef(new Set<string>());
-  const inlineRenameNonceRef = useRef(0);
 
   useEffect(() => {
     setDeleteTarget(null);
     setRestoreTarget(null);
+    setRenameTarget(null);
+    setRenameError(null);
     setRestoreRenameTarget(null);
     setRestoreRenameInitialName("");
     setRestoreRenameError(null);
@@ -337,7 +341,6 @@ export function DocumentsTableContainer({
     setIsReprocessSubmitting(false);
     resetBulkActions();
     setSelectionResetToken(0);
-    setInlineRenameRequest(null);
     setStaleViewKey(null);
     handledUploadsRef.current.clear();
     completedUploadsRef.current.clear();
@@ -1294,9 +1297,30 @@ export function DocumentsTableContainer({
     ],
   );
 
-  const onRenameInline = useCallback(
-    async (document: DocumentRow, nextName: string) => {
-      const current = documentsById[document.id] ?? document;
+  const openRenameDialog = useCallback(
+    (document: RenameTarget) => {
+      renameMutation.reset();
+      setRenameTarget({
+        id: document.id,
+        name: document.name,
+      });
+      setRenameError(null);
+    },
+    [renameMutation],
+  );
+
+  const closeRenameDialog = useCallback(() => {
+    if (renameMutation.isRenaming) return;
+    renameMutation.reset();
+    setRenameTarget(null);
+    setRenameError(null);
+  }, [renameMutation]);
+
+  const confirmRenameDialog = useCallback(
+    async (nextName: string) => {
+      if (!renameTarget) return;
+      const current = documentsById[renameTarget.id] ?? renameTarget;
+      setRenameError(null);
       markRowPending(current.id, "rename");
       try {
         const result = await renameMutation.renameDocument({
@@ -1304,34 +1328,38 @@ export function DocumentsTableContainer({
           currentName: current.name,
           nextName,
         });
-        if (result) {
-          notifyToast({
-            title: "Document renamed.",
-            intent: "success",
-            duration: 2500,
-          });
+        if (!result) {
+          closeRenameDialog();
+          return;
         }
+        notifyToast({
+          title: "Document renamed.",
+          intent: "success",
+          duration: 2500,
+        });
+        closeRenameDialog();
       } catch (error) {
         const description = getRenameDocumentErrorMessage(error);
+        setRenameError(description);
         notifyToast({
           title: "Unable to rename document",
           description,
           intent: "danger",
         });
-        throw new Error(description);
       } finally {
         clearRowPending(current.id, "rename");
       }
     },
-    [clearRowPending, documentsById, markRowPending, notifyToast, renameMutation],
+    [
+      clearRowPending,
+      closeRenameDialog,
+      documentsById,
+      markRowPending,
+      notifyToast,
+      renameMutation,
+      renameTarget,
+    ],
   );
-  const requestInlineRename = useCallback((documentId: string) => {
-    inlineRenameNonceRef.current += 1;
-    setInlineRenameRequest({
-      documentId,
-      nonce: inlineRenameNonceRef.current,
-    });
-  }, []);
 
   const onDeleteRequest = useCallback((document: DocumentRow) => {
     setDeleteTarget(document);
@@ -1565,7 +1593,7 @@ export function DocumentsTableContainer({
     onAssign,
     onToggleTag,
     onTagOptionsChange: handleTagOptionsChange,
-    onRenameInline,
+    onRenameRequest: openRenameDialog,
     onDeleteRequest,
     onRestoreRequest,
     onReprocessRequest,
@@ -1574,7 +1602,6 @@ export function DocumentsTableContainer({
     onDownloadOriginal: handleDownloadOriginal,
     onDownloadEventsLog: handleDownloadEventsLog,
     isRowActionPending: isRowMutationPending,
-    inlineRenameRequest,
   });
 
   const { table, debounceMs, throttleMs, shallow } = useDataTable({
@@ -1814,7 +1841,6 @@ export function DocumentsTableContainer({
         lifecycle,
         isBusy: isRowMutationPending(row.id),
         isSelfAssigned: row.assignee?.id === currentUser.id,
-        canRenameInline: true,
         surface: "context",
         onOpen: () => openDocument(row.id, "activity"),
         onOpenPreview: () => openDocument(row.id, "preview"),
@@ -1826,7 +1852,7 @@ export function DocumentsTableContainer({
           },
         onRename:
           () => {
-            requestInlineRename(row.id);
+            openRenameDialog(row);
           },
         onDeleteRequest: lifecycle === "active" ? onDeleteRequest : undefined,
         onRestoreRequest: lifecycle === "archived" ? onRestoreRequest : undefined,
@@ -1840,10 +1866,10 @@ export function DocumentsTableContainer({
       handleDownloadOriginal,
       isRowMutationPending,
       lifecycle,
+      openRenameDialog,
       onAssign,
       onDeleteRequest,
       openDocument,
-      requestInlineRename,
     ],
   );
 
@@ -1925,6 +1951,8 @@ export function DocumentsTableContainer({
 
   const deletePending =
     deleteTarget ? pendingMutations[deleteTarget.id]?.has("delete") ?? false : false;
+  const renamePending =
+    renameTarget ? renameMutation.pendingDocumentId === renameTarget.id : false;
   const restorePending =
     restoreTarget ? pendingMutations[restoreTarget.id]?.has("restore") ?? false : false;
   const restoreRenamePending =
@@ -2228,6 +2256,19 @@ export function DocumentsTableContainer({
         onConfirmDeleteView={() => {
           void handleDeleteViewConfirm();
         }}
+      />
+      <RenameDocumentDialog
+        open={Boolean(renameTarget)}
+        documentName={renameTarget?.name ?? ""}
+        isPending={renamePending}
+        errorMessage={renameError}
+        onOpenChange={(open) => {
+          if (!open) closeRenameDialog();
+        }}
+        onClearError={() => {
+          if (renameError) setRenameError(null);
+        }}
+        onSubmit={confirmRenameDialog}
       />
       <RenameDocumentDialog
         open={Boolean(restoreRenameTarget)}

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/actions/__tests__/documentRowActions.test.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/actions/__tests__/documentRowActions.test.ts
@@ -51,7 +51,6 @@ describe("buildDocumentRowActions", () => {
       lifecycle: "active",
       isBusy: false,
       isSelfAssigned: false,
-      canRenameInline: true,
       surface: "overflow",
       onDownloadLatest: handlers.onDownloadLatest,
       onDownloadOriginal: handlers.onDownloadOriginal,
@@ -66,7 +65,6 @@ describe("buildDocumentRowActions", () => {
       lifecycle: "active",
       isBusy: false,
       isSelfAssigned: false,
-      canRenameInline: true,
       surface: "context",
       onOpen: handlers.onOpen,
       onOpenPreview: handlers.onOpenPreview,
@@ -91,13 +89,11 @@ describe("buildDocumentRowActions", () => {
       lifecycle: "archived",
       isBusy: false,
       isSelfAssigned: false,
-      canRenameInline: false,
       surface: "overflow",
       onDownloadLatest: vi.fn(),
       onDownloadOriginal: vi.fn(),
       onDownloadEventsLog: vi.fn(),
       onAssignToMe: vi.fn(),
-      onRename: vi.fn(),
       onDeleteRequest: vi.fn(),
     });
 
@@ -116,7 +112,6 @@ describe("buildDocumentRowActions", () => {
       lifecycle: "archived",
       isBusy: false,
       isSelfAssigned: false,
-      canRenameInline: true,
       surface: "overflow",
       onDownloadLatest: vi.fn(),
       onDownloadOriginal: vi.fn(),
@@ -138,7 +133,6 @@ describe("buildDocumentRowActions", () => {
       lifecycle: "active",
       isBusy: false,
       isSelfAssigned: true,
-      canRenameInline: true,
       surface: "overflow",
       onAssignToMe: vi.fn(),
     });
@@ -157,7 +151,6 @@ describe("buildDocumentRowActions", () => {
       lifecycle: "active",
       isBusy: false,
       isSelfAssigned: false,
-      canRenameInline: true,
       surface: "overflow",
       onDownloadLatest: vi.fn(),
       onDownloadOriginal: vi.fn(),
@@ -168,5 +161,20 @@ describe("buildDocumentRowActions", () => {
     });
 
     expect(actions.find((item) => item.id === "download-events-log")).toBeUndefined();
+  });
+
+  it("hides rename when no rename handler is provided", () => {
+    const document = makeDocument();
+    const actions = buildDocumentRowActions({
+      document,
+      lifecycle: "active",
+      isBusy: false,
+      isSelfAssigned: false,
+      surface: "overflow",
+      onDownloadLatest: vi.fn(),
+      onDownloadOriginal: vi.fn(),
+    });
+
+    expect(actions.find((item) => item.id === "rename")).toBeUndefined();
   });
 });

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/actions/documentRowActions.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/actions/documentRowActions.ts
@@ -23,7 +23,6 @@ export function buildDocumentRowActions({
   lifecycle,
   isBusy,
   isSelfAssigned,
-  canRenameInline,
   surface,
   onOpen,
   onOpenPreview,
@@ -39,7 +38,6 @@ export function buildDocumentRowActions({
   lifecycle: "active" | "archived";
   isBusy: boolean;
   isSelfAssigned: boolean;
-  canRenameInline: boolean;
   surface: DocumentRowActionSurface;
   onOpen?: () => void;
   onOpenPreview?: () => void;
@@ -119,7 +117,7 @@ export function buildDocumentRowActions({
     });
   }
 
-  if (canRenameInline && onRename) {
+  if (onRename) {
     pushCore({
       id: "rename",
       label: "Rename",

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/cells/DocumentNameCell.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/cells/DocumentNameCell.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { Check, Ellipsis, Pencil, RotateCcw, X } from "lucide-react";
+import { useMemo, type ReactNode } from "react";
+import { Ellipsis, Pencil, RotateCcw } from "lucide-react";
 
 import { ChatIcon, CloseIcon, EyeIcon, RefreshIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
@@ -9,13 +9,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import type { DocumentPresenceEntry } from "@/pages/Workspace/hooks/presence/presenceParticipants";
-import {
-  composeFileName,
-  splitFileName,
-} from "@/pages/Workspace/sections/Documents/shared/rename/fileNameParts";
 
 import type { DocumentRow } from "../../../shared/types";
 import { DocumentPresenceBadges } from "../../../shared/presence/DocumentPresenceBadges";
@@ -33,7 +28,7 @@ export function DocumentNameCell({
   currentUserId,
   onOpenPreview,
   onOpenActivity,
-  onRename,
+  onRenameRequest,
   onAssignToMe,
   onDeleteRequest,
   onRestoreRequest,
@@ -42,7 +37,6 @@ export function DocumentNameCell({
   onDownloadEventsLog,
   onReprocessRequest,
   onCancelRunRequest,
-  externalRenameSignal,
 }: {
   document: DocumentRow;
   lifecycle: "active" | "archived";
@@ -51,7 +45,7 @@ export function DocumentNameCell({
   currentUserId?: string;
   onOpenPreview?: () => void;
   onOpenActivity?: () => void;
-  onRename?: (nextName: string) => Promise<void> | void;
+  onRenameRequest?: () => void;
   onAssignToMe?: () => void;
   onDeleteRequest?: (document: DocumentRow) => void;
   onRestoreRequest?: (document: DocumentRow) => void;
@@ -60,83 +54,20 @@ export function DocumentNameCell({
   onDownloadEventsLog?: (document: DocumentRow) => void;
   onReprocessRequest?: (document: DocumentRow) => void;
   onCancelRunRequest?: (document: DocumentRow) => void;
-  externalRenameSignal?: number;
 }) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [draftBaseName, setDraftBaseName] = useState(() => splitFileName(document.name).baseName);
-  const [lockedExtension, setLockedExtension] = useState(() => splitFileName(document.name).extension);
-  const [renameError, setRenameError] = useState<string | null>(null);
-  const [isSubmittingRename, setIsSubmittingRename] = useState(false);
-  const lastRenameSignalRef = useRef(externalRenameSignal ?? 0);
-
   const isArchivedLifecycle = lifecycle === "archived";
   const runActive = isRunActive(document);
   const runActionLabel = isArchivedLifecycle ? "Restore" : runActive ? "Cancel run" : "Reprocess";
   const commentCount = document.commentCount ?? 0;
   const commentBadgeLabel = commentCount > 99 ? "99+" : String(commentCount);
   const isSelfAssigned = Boolean(currentUserId && document.assignee?.id === currentUserId);
-
-  const canRenameInline = Boolean(onRename);
-  const resetDraftFromName = useCallback((name: string) => {
-    const next = splitFileName(name);
-    setDraftBaseName(next.baseName);
-    setLockedExtension(next.extension);
-  }, []);
-
-  const startRename = useCallback(() => {
-    if (!canRenameInline || isBusy) return;
-    resetDraftFromName(document.name);
-    setIsEditing(true);
-    setRenameError(null);
-  }, [canRenameInline, document.name, isBusy, resetDraftFromName]);
-
-  useEffect(() => {
-    if (isEditing) return;
-    resetDraftFromName(document.name);
-  }, [document.name, isEditing, resetDraftFromName]);
-
-  const submitRename = async () => {
-    if (!onRename) return;
-    const normalizedBase = draftBaseName.trim();
-    if (!normalizedBase) {
-      setRenameError("Document name cannot be blank.");
-      return;
-    }
-    const nextName = composeFileName({
-      baseName: normalizedBase,
-      extension: lockedExtension,
-    });
-    if (nextName === document.name) {
-      setIsEditing(false);
-      setRenameError(null);
-      return;
-    }
-
-    setIsSubmittingRename(true);
-    setRenameError(null);
-    try {
-      await onRename(nextName);
-      setIsEditing(false);
-      setRenameError(null);
-    } catch (error) {
-      setRenameError(error instanceof Error ? error.message : "Unable to rename document.");
-    } finally {
-      setIsSubmittingRename(false);
-    }
-  };
+  const canRename = Boolean(onRenameRequest);
 
   const runActionIcon = useMemo(() => {
     if (isArchivedLifecycle) return <RotateCcw className="h-4 w-4" />;
     if (runActive) return <CloseIcon className="h-4 w-4" />;
     return <RefreshIcon className="h-4 w-4" />;
   }, [isArchivedLifecycle, runActive]);
-
-  useEffect(() => {
-    const nextSignal = externalRenameSignal ?? 0;
-    if (nextSignal === lastRenameSignalRef.current) return;
-    lastRenameSignalRef.current = nextSignal;
-    startRename();
-  }, [externalRenameSignal, startRename]);
 
   const overflowActions = useMemo(
     () =>
@@ -145,18 +76,16 @@ export function DocumentNameCell({
         lifecycle,
         isBusy,
         isSelfAssigned,
-        canRenameInline,
         surface: "overflow",
         onDownloadLatest,
         onDownloadOriginal,
         onDownloadEventsLog,
         onAssignToMe,
-        onRename: startRename,
+        onRename: onRenameRequest,
         onDeleteRequest,
         onRestoreRequest,
       }),
     [
-      canRenameInline,
       document,
       isBusy,
       isSelfAssigned,
@@ -166,100 +95,17 @@ export function DocumentNameCell({
       onDownloadLatest,
       onDownloadOriginal,
       onDownloadEventsLog,
+      onRenameRequest,
       onRestoreRequest,
-      startRename,
     ],
   );
 
   return (
     <div className="group/name-cell flex min-w-0 items-start gap-2">
       <div className="min-w-0 flex-1">
-        {isEditing ? (
-          <div className="space-y-1" data-row-interactive data-ignore-row-click>
-            <div className="flex items-center gap-1">
-              <Input
-                value={draftBaseName}
-                onChange={(event) => setDraftBaseName(event.target.value)}
-                autoFocus
-                disabled={isSubmittingRename || isBusy}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault();
-                    void submitRename();
-                  }
-                  if (event.key === "Escape") {
-                    event.preventDefault();
-                    resetDraftFromName(document.name);
-                    setIsEditing(false);
-                    setRenameError(null);
-                  }
-                }}
-                className={lockedExtension ? "h-8 rounded-r-none border-r-0" : "h-8"}
-              />
-              {lockedExtension ? (
-                <div className="inline-flex h-8 items-center rounded-r-md border border-input bg-muted/40 px-2 text-xs text-muted-foreground">
-                  {lockedExtension}
-                </div>
-              ) : null}
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-8 w-8"
-                onClick={() => {
-                  void submitRename();
-                }}
-                disabled={isSubmittingRename || isBusy}
-                aria-label="Save document name"
-                data-row-interactive
-              >
-                <Check className="h-4 w-4" />
-              </Button>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-8 w-8"
-                onClick={() => {
-                  resetDraftFromName(document.name);
-                  setIsEditing(false);
-                  setRenameError(null);
-                }}
-                disabled={isSubmittingRename || isBusy}
-                aria-label="Cancel rename"
-                data-row-interactive
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-            {renameError ? <p className="text-xs text-destructive">{renameError}</p> : null}
-          </div>
-        ) : (
-          <>
-            {canRenameInline ? (
-              <button
-                type="button"
-                data-allow-row-activate
-                className="w-full truncate text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                title={document.name}
-                onDoubleClick={() => {
-                  startRename();
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== "F2") return;
-                  event.preventDefault();
-                  startRename();
-                }}
-              >
-                {document.name}
-              </button>
-            ) : (
-              <div className="truncate font-medium" title={document.name}>
-                {document.name}
-              </div>
-            )}
-          </>
-        )}
+        <div className="truncate font-medium" title={document.name}>
+          {document.name}
+        </div>
         <DocumentPresenceBadges entries={presenceEntries} />
       </div>
 
@@ -268,11 +114,11 @@ export function DocumentNameCell({
         data-row-interactive
         data-ignore-row-click
       >
-        {canRenameInline ? (
+        {canRename ? (
           <IconButton
             label="Rename document"
-            onClick={startRename}
-            disabled={isSubmittingRename || isBusy}
+            onClick={() => onRenameRequest?.()}
+            disabled={isBusy}
           >
             <Pencil className="h-4 w-4" />
           </IconButton>

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/cells/__tests__/DocumentNameCell.test.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/cells/__tests__/DocumentNameCell.test.tsx
@@ -35,37 +35,31 @@ function makeDocument(): DocumentRow {
 }
 
 describe("DocumentNameCell", () => {
-  it("supports inline rename via F2 + Enter", async () => {
+  it("triggers rename from the row action button", async () => {
     const user = userEvent.setup();
     const document = makeDocument();
-    const onRename = vi.fn().mockResolvedValue(undefined);
+    const onRenameRequest = vi.fn();
 
     render(
       <DocumentNameCell
         document={document}
         lifecycle="active"
         presenceEntries={[]}
-        onRename={onRename}
+        onRenameRequest={onRenameRequest}
       />,
     );
 
-    const name = screen.getByText("source.csv");
-    name.focus();
-    await user.keyboard("{F2}");
+    await user.click(screen.getByLabelText("Rename document"));
 
-    const input = await screen.findByRole("textbox");
-    await user.clear(input);
-    await user.type(input, "renamed");
-    await user.keyboard("{Enter}");
-
-    expect(onRename).toHaveBeenCalledWith("renamed.csv");
+    expect(onRenameRequest).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
   it("renders shared overflow actions and supports assign-to-me", async () => {
     const user = userEvent.setup();
     const document = makeDocument();
     const onAssignToMe = vi.fn();
-    const onRename = vi.fn().mockResolvedValue(undefined);
+    const onRenameRequest = vi.fn();
     const onDownloadLatest = vi.fn();
     const onDownloadOriginal = vi.fn();
     const onDownloadEventsLog = vi.fn();
@@ -77,7 +71,7 @@ describe("DocumentNameCell", () => {
         presenceEntries={[]}
         currentUserId="user_me"
         onAssignToMe={onAssignToMe}
-        onRename={onRename}
+        onRenameRequest={onRenameRequest}
         onDownloadLatest={onDownloadLatest}
         onDownloadOriginal={onDownloadOriginal}
         onDownloadEventsLog={onDownloadEventsLog}
@@ -93,6 +87,27 @@ describe("DocumentNameCell", () => {
     await user.click(screen.getByRole("menuitem", { name: "Assign to me" }));
 
     expect(onAssignToMe).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers the overflow rename handler", async () => {
+    const user = userEvent.setup();
+    const document = makeDocument();
+    const onRenameRequest = vi.fn();
+
+    render(
+      <DocumentNameCell
+        document={document}
+        lifecycle="active"
+        presenceEntries={[]}
+        onRenameRequest={onRenameRequest}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("More actions"));
+    await user.click(screen.getByRole("menuitem", { name: "Rename" }));
+
+    expect(onRenameRequest).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
   it("triggers the overflow events log handler", async () => {
@@ -113,34 +128,5 @@ describe("DocumentNameCell", () => {
     await user.click(screen.getByRole("menuitem", { name: "Download events log" }));
 
     expect(onDownloadEventsLog).toHaveBeenCalledWith(document);
-  });
-
-  it("locks extension while renaming inline", async () => {
-    const user = userEvent.setup();
-    const document = makeDocument();
-    const onRename = vi.fn().mockResolvedValue(undefined);
-
-    render(
-      <DocumentNameCell
-        document={document}
-        lifecycle="active"
-        presenceEntries={[]}
-        onRename={onRename}
-      />,
-    );
-
-    const name = screen.getByText("source.csv");
-    name.focus();
-    await user.keyboard("{F2}");
-
-    expect(screen.getByText(".csv")).toBeInTheDocument();
-
-    const input = await screen.findByRole("textbox");
-    await user.clear(input);
-    await user.type(input, "new-name");
-    await user.keyboard("{Enter}");
-
-    expect(onRename).toHaveBeenCalledWith("new-name.csv");
-    expect(onRename).not.toHaveBeenCalledWith("new-name");
   });
 });

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/documentsColumns.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/documentsColumns.tsx
@@ -26,7 +26,7 @@ export type DocumentsColumnContext = {
   onOpenActivity?: (documentId: string) => void;
   onAssign: (documentId: string, assigneeId: string | null) => void;
   onToggleTag: (documentId: string, tag: string) => void;
-  onRenameInline: (document: DocumentRow, nextName: string) => Promise<void>;
+  onRenameRequest: (document: DocumentRow) => void;
   onDeleteRequest: (document: DocumentRow) => void;
   onRestoreRequest: (document: DocumentRow) => void;
   onDownloadLatest: (document: DocumentRow) => void;
@@ -35,7 +35,6 @@ export type DocumentsColumnContext = {
   onReprocessRequest: (document: DocumentRow) => void;
   onCancelRunRequest: (document: DocumentRow) => void;
   isRowActionPending?: (documentId: string) => boolean;
-  inlineRenameRequest?: { documentId: string; nonce: number } | null;
 };
 
 type DocumentsColumnMeta = {
@@ -60,7 +59,7 @@ export function useDocumentsColumns({
   onOpenActivity,
   onAssign,
   onToggleTag,
-  onRenameInline,
+  onRenameRequest,
   onDeleteRequest,
   onRestoreRequest,
   onDownloadLatest,
@@ -69,7 +68,6 @@ export function useDocumentsColumns({
   onReprocessRequest,
   onCancelRunRequest,
   isRowActionPending,
-  inlineRenameRequest,
 }: DocumentsColumnContext) {
   const runStatusOptions = useMemo(() => {
     const statuses = (["queued", "running", "succeeded", "failed", "cancelled"] as RunStatus[]).map((value) => ({
@@ -148,7 +146,7 @@ export function useDocumentsColumns({
               currentUserId={currentUserId}
               onOpenPreview={onOpenPreview ? () => onOpenPreview(row.original.id) : undefined}
               onOpenActivity={onOpenActivity ? () => onOpenActivity(row.original.id) : undefined}
-              onRename={(nextName) => onRenameInline(row.original, nextName)}
+              onRenameRequest={() => onRenameRequest(row.original)}
               onAssignToMe={() => onAssign(row.original.id, currentUserId)}
               onDeleteRequest={onDeleteRequest}
               onRestoreRequest={onRestoreRequest}
@@ -157,9 +155,6 @@ export function useDocumentsColumns({
               onDownloadEventsLog={onDownloadEventsLog}
               onReprocessRequest={onReprocessRequest}
               onCancelRunRequest={onCancelRunRequest}
-              externalRenameSignal={
-                inlineRenameRequest?.documentId === row.original.id ? inlineRenameRequest.nonce : 0
-              }
             />
           );
         },
@@ -402,8 +397,7 @@ export function useDocumentsColumns({
       onDownloadEventsLog,
       onReprocessRequest,
       onCancelRunRequest,
-      inlineRenameRequest,
-      onRenameInline,
+      onRenameRequest,
       onTagOptionsChange,
       onToggleTag,
       people,


### PR DESCRIPTION
## Summary
- replace fragile inline document renaming in the list with the existing modal rename flow
- make the row context menu available across the row surface instead of only on non-interactive gaps
- raise the document detail preview request window to 10,000 rows and 10,000 columns to match the backend preview endpoint

## Root cause
- rename state lived inside a volatile table cell, so live document updates and page refreshes could remount the editor and kick users out mid-edit
- the right-click Rename action reused that same inline path, so it failed for the same reason
- the context menu intentionally refused to open over most interactive row content
- the document preview endpoint already supported large limits, but the frontend preview hook was explicitly capping requests to a much smaller window

## Impact
- list rename is now one stable dialog flow for the overflow menu, right-click menu, and pencil action
- right-click works across the row surface while still respecting open overlay surfaces
- document preview now requests the full supported preview window

## Validation
- `cd backend && uv run ade web test`
- `cd backend && uv run ade web lint`
- `git diff --check`