### PR TITLE
feat(documents): persist rows per page preference

### DIFF
--- a/frontend/src/components/data-table/data-table-pagination.tsx
+++ b/frontend/src/components/data-table/data-table-pagination.tsx
@@ -18,12 +18,14 @@ import { cn } from "@/lib/utils";
 
 interface DataTablePaginationProps<TData> extends React.ComponentProps<"div"> {
   table: Table<TData>;
-  pageSizeOptions?: number[];
+  pageSizeOptions?: readonly number[];
+  onPageSizeChange?: (pageSize: number) => void;
 }
 
 export function DataTablePagination<TData>({
   table,
   pageSizeOptions = [10, 20, 30, 40, 50],
+  onPageSizeChange,
   className,
   ...props
 }: DataTablePaginationProps<TData>) {
@@ -45,7 +47,9 @@ export function DataTablePagination<TData>({
           <Select
             value={`${table.getState().pagination.pageSize}`}
             onValueChange={(value) => {
-              table.setPageSize(Number(value));
+              const pageSize = Number(value);
+              onPageSizeChange?.(pageSize);
+              table.setPageSize(pageSize);
             }}
           >
             <SelectTrigger className="h-8 w-24 data-size:h-8">

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -25,7 +25,8 @@ import { cn } from "@/lib/utils";
 interface DataTableProps<TData> extends React.ComponentProps<"div"> {
   table: TanstackTable<TData>;
   actionBar?: React.ReactNode;
-  pageSizeOptions?: number[];
+  pageSizeOptions?: readonly number[];
+  onPageSizeChange?: (pageSize: number) => void;
   onRowActivate?: (row: Row<TData>) => void;
   onRowContextMenu?: (row: Row<TData>, position: { x: number; y: number }) => void;
 }
@@ -34,6 +35,7 @@ export function DataTable<TData>({
   table,
   actionBar,
   pageSizeOptions,
+  onPageSizeChange,
   onRowActivate,
   onRowContextMenu,
   children,
@@ -201,7 +203,11 @@ export function DataTable<TData>({
         </Table>
       </div>
       <div className="flex flex-col gap-2.5">
-        <DataTablePagination table={table} pageSizeOptions={pageSizeOptions} />
+        <DataTablePagination
+          table={table}
+          pageSizeOptions={pageSizeOptions}
+          onPageSizeChange={onPageSizeChange}
+        />
         {actionBar &&
           table.getFilteredSelectedRowModel().rows.length > 0 &&
           actionBar}

--- a/frontend/src/lib/uiStorageKeys.ts
+++ b/frontend/src/lib/uiStorageKeys.ts
@@ -7,6 +7,8 @@ export const uiStorageKeys = {
   workspaceLastActive: `${UI_STORAGE_PREFIX}.workspace.lastActive`,
   documentsCursor: (workspaceId: string) => `${UI_STORAGE_PREFIX}.workspace.${workspaceId}.documents.cursor`,
   documentsLastView: (workspaceId: string) => `${UI_STORAGE_PREFIX}.workspace.${workspaceId}.documents.lastView`,
+  documentsRowsPerPage: (workspaceId: string) =>
+    `${UI_STORAGE_PREFIX}.workspace.${workspaceId}.documents.rowsPerPage`,
   documentsTableColumnSizing: (workspaceId: string) =>
     `${UI_STORAGE_PREFIX}.workspace.${workspaceId}.documents.table.columnSizing`,
   documentsPreviewPaneHeight: (workspaceId: string) =>

--- a/frontend/src/pages/Workspace/sections/Documents/list/DocumentsListPage.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/DocumentsListPage.tsx
@@ -172,7 +172,7 @@ export default function DocumentsListPage() {
 
   return (
     <div className="documents flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background text-foreground">
-      <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden py-3 sm:py-4">
+      <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-3 sm:pt-4">
         <DocumentsTableView
           workspaceId={workspace.id}
           currentUser={currentUser}

--- a/frontend/src/pages/Workspace/sections/Documents/list/__tests__/DocumentsListPage.layout.test.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/__tests__/DocumentsListPage.layout.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@/test/test-utils";
+
+import DocumentsListPage from "../DocumentsListPage";
+
+vi.mock("@/providers/auth/SessionContext", () => ({
+  useSession: () => ({
+    user: {
+      id: "user-1",
+      email: "user@example.com",
+      display_name: "User Example",
+    },
+  }),
+}));
+
+vi.mock("@/providers/notifications", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/providers/notifications")>();
+  return {
+    ...actual,
+    useNotifications: () => ({
+      notifyToast: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("@/pages/Workspace/context/WorkspaceContext", () => ({
+  useWorkspaceContext: () => ({
+    workspace: {
+      id: "ws-1",
+      processing_paused: false,
+    },
+  }),
+}));
+
+vi.mock("@/pages/Workspace/hooks/configurations", () => ({
+  useConfigurationsQuery: () => ({
+    data: {
+      items: [{ id: "cfg-1", status: "active" }],
+    },
+    isSuccess: true,
+  }),
+}));
+
+vi.mock("@/pages/Workspace/sections/Documents/list/upload/useUploadManager", () => ({
+  useUploadManager: () => ({
+    items: [],
+    summary: {
+      active: 0,
+      queued: 0,
+      completed: 0,
+      failed: 0,
+      conflicts: 0,
+      total: 0,
+    },
+    enqueue: () => [],
+    pause: vi.fn(),
+    resume: vi.fn(),
+    retry: vi.fn(),
+    resolveConflict: vi.fn(),
+    resolveAllConflicts: vi.fn(),
+    cancel: vi.fn(),
+    remove: vi.fn(),
+    clearCompleted: vi.fn(),
+  }),
+}));
+
+vi.mock("@/pages/Workspace/sections/Documents/list/upload/UploadManager", () => ({
+  UploadManager: () => <div data-testid="upload-manager" />,
+}));
+
+vi.mock("@/pages/Workspace/sections/Documents/list/upload/UploadPreflightDialog", () => ({
+  UploadPreflightDialog: () => null,
+}));
+
+vi.mock("@/pages/Workspace/sections/Documents/list/table/DocumentsTableView", () => ({
+  DocumentsTableView: () => <div data-testid="documents-table-view" />,
+}));
+
+describe("DocumentsListPage layout", () => {
+  it("uses top-only section padding so the table footer can sit at the bottom edge", () => {
+    render(<DocumentsListPage />, { route: "/workspaces/ws-1/documents" });
+
+    const section = screen.getByTestId("documents-table-view").parentElement;
+    expect(section).not.toBeNull();
+    expect(section).toHaveClass("pt-3");
+    expect(section).not.toHaveClass("py-3");
+  });
+});

--- a/frontend/src/pages/Workspace/sections/Documents/list/hooks/__tests__/useDocumentsListParams.test.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/hooks/__tests__/useDocumentsListParams.test.tsx
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { render, screen } from "@/test/test-utils";
+
+import { useDocumentsListParams } from "../useDocumentsListParams";
+
+function ParamsHarness({ defaultPerPage }: { readonly defaultPerPage: number }) {
+  const { perPage } = useDocumentsListParams({
+    currentUserId: "user-1",
+    defaultPerPage,
+  });
+
+  return <div data-testid="per-page">{perPage}</div>;
+}
+
+describe("useDocumentsListParams", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("uses the provided default page size when the URL does not specify perPage", () => {
+    render(<ParamsHarness defaultPerPage={500} />, {
+      route: "/workspaces/ws-1/documents",
+    });
+
+    expect(screen.getByTestId("per-page")).toHaveTextContent("500");
+  });
+
+  it("prefers an explicit perPage query param over the provided default", () => {
+    render(<ParamsHarness defaultPerPage={100} />, {
+      route: "/workspaces/ws-1/documents?perPage=1000",
+    });
+
+    expect(screen.getByTestId("per-page")).toHaveTextContent("1000");
+  });
+});

--- a/frontend/src/pages/Workspace/sections/Documents/list/hooks/__tests__/useDocumentsPageSizePreference.test.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/hooks/__tests__/useDocumentsPageSizePreference.test.tsx
@@ -1,0 +1,63 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { uiStorageKeys } from "@/lib/uiStorageKeys";
+
+import { useDocumentsPageSizePreference } from "../useDocumentsPageSizePreference";
+
+describe("useDocumentsPageSizePreference", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults to 100 rows when no preference is stored", () => {
+    const { result } = renderHook(() => useDocumentsPageSizePreference("ws-1"));
+
+    expect(result.current.defaultPageSize).toBe(100);
+  });
+
+  it("persists supported page sizes to workspace-scoped storage", async () => {
+    const { result, unmount } = renderHook(() => useDocumentsPageSizePreference("ws-1"));
+
+    act(() => {
+      result.current.setPageSizePreference(500);
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(uiStorageKeys.documentsRowsPerPage("ws-1"))).toBe(
+        JSON.stringify(500),
+      );
+    });
+
+    unmount();
+
+    const next = renderHook(() => useDocumentsPageSizePreference("ws-1"));
+    expect(next.result.current.defaultPageSize).toBe(500);
+  });
+
+  it("falls back to 100 when the stored value is invalid", () => {
+    window.localStorage.setItem(
+      uiStorageKeys.documentsRowsPerPage("ws-1"),
+      JSON.stringify(999),
+    );
+
+    const { result } = renderHook(() => useDocumentsPageSizePreference("ws-1"));
+
+    expect(result.current.defaultPageSize).toBe(100);
+  });
+
+  it("isolates page size preferences by workspace id", async () => {
+    const ws1 = renderHook(() => useDocumentsPageSizePreference("ws-1"));
+    const ws2 = renderHook(() => useDocumentsPageSizePreference("ws-2"));
+
+    act(() => {
+      ws1.result.current.setPageSizePreference(1000);
+    });
+
+    await waitFor(() => {
+      expect(ws1.result.current.defaultPageSize).toBe(1000);
+    });
+
+    expect(ws2.result.current.defaultPageSize).toBe(100);
+  });
+});

--- a/frontend/src/pages/Workspace/sections/Documents/list/hooks/useDocumentsListParams.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/list/hooks/useDocumentsListParams.ts
@@ -6,21 +6,28 @@ import type { DocumentLifecycle } from "@/api/documents";
 import type { DocumentsListParams } from "../../shared/types";
 import {
   buildDocumentsQuerySnapshot,
+  createDocumentsPerPageParser,
   documentsFiltersParser,
   documentsJoinOperatorParser,
   documentsLifecycleParser,
   documentsPageParser,
-  documentsPerPageParser,
   documentsSearchParser,
   documentsSortParser,
   resolveListFiltersForApi,
 } from "../state/queryState";
+import { DEFAULT_PAGE_SIZE } from "../../shared/constants";
 
 export function useDocumentsListParams({
   currentUserId = null,
+  defaultPerPage = DEFAULT_PAGE_SIZE,
 }: {
   currentUserId?: string | null;
+  defaultPerPage?: number;
 } = {}): DocumentsListParams {
+  const documentsPerPageParser = useMemo(
+    () => createDocumentsPerPageParser(defaultPerPage),
+    [defaultPerPage],
+  );
   const [page] = useQueryState("page", documentsPageParser);
   const [perPage] = useQueryState("perPage", documentsPerPageParser);
   const [q] = useQueryState("q", documentsSearchParser);

--- a/frontend/src/pages/Workspace/sections/Documents/list/hooks/useDocumentsPageSizePreference.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/list/hooks/useDocumentsPageSizePreference.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { createScopedStorage } from "@/lib/storage";
+import { uiStorageKeys } from "@/lib/uiStorageKeys";
+
+import { normalizeDocumentsPageSize, type DocumentsPageSize } from "../../shared/constants";
+
+function resolveStoredPageSize(value: unknown): DocumentsPageSize {
+  return normalizeDocumentsPageSize(typeof value === "number" ? value : null);
+}
+
+export function readDocumentsPageSizePreference(value: unknown): DocumentsPageSize {
+  return resolveStoredPageSize(value);
+}
+
+export function useDocumentsPageSizePreference(workspaceId: string) {
+  const storage = useMemo(
+    () => createScopedStorage(uiStorageKeys.documentsRowsPerPage(workspaceId)),
+    [workspaceId],
+  );
+
+  const [pageSize, setPageSize] = useState<DocumentsPageSize>(() =>
+    resolveStoredPageSize(storage.get<unknown>()),
+  );
+
+  useEffect(() => {
+    setPageSize(resolveStoredPageSize(storage.get<unknown>()));
+  }, [storage]);
+
+  const setPageSizePreference = useCallback(
+    (value: number) => {
+      const normalized = normalizeDocumentsPageSize(value);
+      setPageSize(normalized);
+      storage.set(normalized);
+    },
+    [storage],
+  );
+
+  return {
+    defaultPageSize: pageSize,
+    setPageSizePreference,
+  };
+}

--- a/frontend/src/pages/Workspace/sections/Documents/list/state/queryState.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/list/state/queryState.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_PAGE_SIZE,
   DOCUMENTS_FILTER_IDS,
   DOCUMENTS_SORT_IDS,
+  normalizeDocumentsPageSize,
 } from "../../shared/constants";
 import type { DocumentListRow } from "../../shared/types";
 
@@ -39,7 +40,6 @@ export type DocumentsQuerySnapshot = {
 const USER_TOKEN_FILTER_IDS = new Set(["assigneeId", "mentionedUserId"]);
 
 export const documentsPageParser = parseAsInteger.withDefault(1);
-export const documentsPerPageParser = parseAsInteger.withDefault(DEFAULT_PAGE_SIZE);
 export const documentsViewIdParser = parseAsString;
 export const documentsSortParser = getSortingStateParser<DocumentListRow>(DOCUMENTS_SORT_IDS);
 export const documentsFiltersParser = getFiltersStateParser<DocumentListRow>(DOCUMENTS_FILTER_IDS);
@@ -58,6 +58,10 @@ export const documentsQueryParsers = {
   joinOperator: documentsJoinOperatorParser,
   lifecycle: documentsLifecycleParser,
 };
+
+export function createDocumentsPerPageParser(defaultPerPage: number = DEFAULT_PAGE_SIZE) {
+  return parseAsInteger.withDefault(normalizeDocumentsPageSize(defaultPerPage));
+}
 
 function normalizeString(value: string | null): string | null {
   const trimmed = value?.trim() ?? "";

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTable.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTable.tsx
@@ -20,9 +20,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { DocumentRow } from "../../shared/types";
+import { DOCUMENTS_PAGE_SIZE_OPTIONS } from "../../shared/constants";
 import { DocumentsActiveFiltersRail } from "./DocumentsActiveFiltersRail";
-
-const DOCUMENTS_PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50, 100, 500, 1000];
 
 interface DocumentsTableProps {
   table: Table<DocumentRow>;
@@ -31,6 +30,7 @@ interface DocumentsTableProps {
   shallow: boolean;
   leadingToolbarActions?: ReactNode;
   toolbarActions?: ReactNode;
+  onPageSizeChange?: (pageSize: number) => void;
   onRowActivate?: (document: DocumentRow) => void;
   onBulkReprocessRequest?: (documents: DocumentRow[]) => void;
   onBulkCancelRequest?: (documents: DocumentRow[]) => void;
@@ -51,6 +51,7 @@ export function DocumentsTable({
   shallow,
   leadingToolbarActions,
   toolbarActions,
+  onPageSizeChange,
   onRowActivate,
   onBulkReprocessRequest,
   onBulkCancelRequest,
@@ -233,6 +234,7 @@ export function DocumentsTable({
           table={table}
           actionBar={actionBar}
           pageSizeOptions={DOCUMENTS_PAGE_SIZE_OPTIONS}
+          onPageSizeChange={onPageSizeChange}
           onRowActivate={
             onRowActivate
               ? (row) => {

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/DocumentsTableContainer.tsx
@@ -47,6 +47,7 @@ import { partitionDocumentChanges } from "../../shared/documentChanges";
 import type { DocumentRow, WorkspacePerson } from "../../shared/types";
 import { useDocumentsListParams } from "../hooks/useDocumentsListParams";
 import { useDocumentsListData } from "../hooks/useDocumentsListData";
+import { useDocumentsPageSizePreference } from "../hooks/useDocumentsPageSizePreference";
 import { useDocumentsDeltaSync } from "../../shared/hooks/useDocumentsDeltaSync";
 import { getRenameDocumentErrorMessage, useRenameDocumentMutation } from "../../shared/hooks/useRenameDocumentMutation";
 import { buildDocumentDetailUrl } from "../../shared/navigation";
@@ -65,7 +66,7 @@ import { buildDocumentRowActions, toContextMenuItems } from "./actions/documentR
 import { useWorkspacePresence } from "@/pages/Workspace/context/WorkspacePresenceContext";
 import { useWorkspaceContext } from "@/pages/Workspace/context/WorkspaceContext";
 import { useDataTable } from "@/hooks/use-data-table";
-import { DEFAULT_PAGE_SIZE, DEFAULT_SORTING } from "../../shared/constants";
+import { DEFAULT_SORTING } from "../../shared/constants";
 import { useDocumentViews } from "../hooks/useDocumentViews";
 import {
   ReprocessPreflightDialog,
@@ -261,8 +262,10 @@ export function DocumentsTableContainer({
   } = useDocumentsRowActions();
 
   const presence = useWorkspacePresence();
+  const { defaultPageSize, setPageSizePreference } = useDocumentsPageSizePreference(workspaceId);
   const { page, perPage, sort, q, lifecycle, filters, joinOperator } = useDocumentsListParams({
     currentUserId: currentUser.id,
+    defaultPerPage: defaultPageSize,
   });
   const filtersKey = useMemo(() => (filters?.length ? JSON.stringify(filters) : ""), [filters]);
   const viewKey = useMemo(
@@ -1616,7 +1619,7 @@ export function DocumentsTableContainer({
     },
     initialState: {
       sorting: DEFAULT_SORTING,
-      pagination: { pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE },
+      pagination: { pageIndex: 0, pageSize: defaultPageSize },
       columnVisibility: {
         select: true,
         id: false,
@@ -1978,7 +1981,7 @@ export function DocumentsTableContainer({
 
   const tableContent = (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col px-3 pb-4 pt-2 sm:px-4 sm:pb-6 lg:px-6">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col px-3 pt-2 sm:px-4 lg:px-6">
         {configBanner}
         {updatesBanner}
         <DocumentsTable
@@ -1988,6 +1991,7 @@ export function DocumentsTableContainer({
           shallow={shallow}
           leadingToolbarActions={viewsToolbarControl}
           toolbarActions={toolbarContent}
+          onPageSizeChange={setPageSizePreference}
           onRowActivate={(document) => openDocument(document.id, "activity")}
           onBulkReprocessRequest={lifecycle === "active" ? onBulkReprocessRequest : undefined}
           onBulkCancelRequest={lifecycle === "active" ? onBulkCancelRequest : undefined}

--- a/frontend/src/pages/Workspace/sections/Documents/list/table/__tests__/DocumentsTable.page-size.test.tsx
+++ b/frontend/src/pages/Workspace/sections/Documents/list/table/__tests__/DocumentsTable.page-size.test.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import userEvent from "@testing-library/user-event";
+import type { ColumnDef } from "@tanstack/react-table";
+import { describe, expect, it } from "vitest";
+
+import { DataTablePagination } from "@/components/data-table/data-table-pagination";
+import { uiStorageKeys } from "@/lib/uiStorageKeys";
+import { render, screen, waitFor } from "@/test/test-utils";
+import { useDataTable } from "@/hooks/use-data-table";
+
+import { useDocumentsListParams } from "../../hooks/useDocumentsListParams";
+import { useDocumentsPageSizePreference } from "../../hooks/useDocumentsPageSizePreference";
+import { DOCUMENTS_PAGE_SIZE_OPTIONS } from "../../../shared/constants";
+
+type RowData = {
+  id: string;
+  name: string;
+};
+
+function PageSizeHarness() {
+  const columns = useMemo<ColumnDef<RowData>[]>(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: "Name",
+      },
+    ],
+    [],
+  );
+  const { defaultPageSize, setPageSizePreference } = useDocumentsPageSizePreference("ws-1");
+  const { perPage } = useDocumentsListParams({ defaultPerPage: defaultPageSize });
+  const { table } = useDataTable({
+    data: [{ id: "doc-1", name: "Doc 1" }],
+    columns,
+    pageCount: 1,
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: defaultPageSize },
+    },
+    getRowId: (row) => row.id,
+  });
+
+  return (
+    <div>
+      <div data-testid="query-per-page">{perPage}</div>
+      <div data-testid="table-page-size">{table.getState().pagination.pageSize}</div>
+      <DataTablePagination
+        table={table}
+        pageSizeOptions={DOCUMENTS_PAGE_SIZE_OPTIONS}
+        onPageSizeChange={setPageSizePreference}
+      />
+    </div>
+  );
+}
+
+describe("documents rows-per-page persistence", () => {
+  it("restores the remembered page size when remounting without a perPage query param", async () => {
+    window.localStorage.clear();
+
+    const user = userEvent.setup();
+    const firstRender = render(<PageSizeHarness />, { route: "/workspaces/ws-1/documents" });
+
+    expect(screen.getByTestId("query-per-page")).toHaveTextContent("100");
+    expect(screen.getByTestId("table-page-size")).toHaveTextContent("100");
+
+    const trigger = document.querySelector("[data-slot='select-trigger']");
+    expect(trigger).not.toBeNull();
+
+    await user.click(trigger as HTMLElement);
+    await user.click(await screen.findByRole("option", { name: "500" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("query-per-page")).toHaveTextContent("500");
+    });
+    expect(screen.getByTestId("table-page-size")).toHaveTextContent("500");
+    expect(window.localStorage.getItem(uiStorageKeys.documentsRowsPerPage("ws-1"))).toBe(
+      JSON.stringify(500),
+    );
+
+    firstRender.unmount();
+
+    render(<PageSizeHarness />, { route: "/workspaces/ws-1/documents" });
+
+    expect(screen.getByTestId("query-per-page")).toHaveTextContent("500");
+    expect(screen.getByTestId("table-page-size")).toHaveTextContent("500");
+  });
+});

--- a/frontend/src/pages/Workspace/sections/Documents/shared/constants.ts
+++ b/frontend/src/pages/Workspace/sections/Documents/shared/constants.ts
@@ -2,7 +2,20 @@ import type { ExtendedColumnSort } from "@/types/data-table";
 
 import type { DocumentListRow } from "./types";
 
-export const DEFAULT_PAGE_SIZE = 20;
+export const DOCUMENTS_PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50, 100, 500, 1000] as const;
+
+export type DocumentsPageSize = (typeof DOCUMENTS_PAGE_SIZE_OPTIONS)[number];
+
+export const DEFAULT_PAGE_SIZE: DocumentsPageSize = 100;
+
+const DOCUMENTS_PAGE_SIZE_OPTION_SET = new Set<number>(DOCUMENTS_PAGE_SIZE_OPTIONS);
+
+export function normalizeDocumentsPageSize(value: number | null | undefined): DocumentsPageSize {
+  if (typeof value === "number" && DOCUMENTS_PAGE_SIZE_OPTION_SET.has(value)) {
+    return value as DocumentsPageSize;
+  }
+  return DEFAULT_PAGE_SIZE;
+}
 
 export const DEFAULT_SORTING: ExtendedColumnSort<DocumentListRow>[] = [
   { id: "createdAt", desc: true },

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -6,6 +6,18 @@ if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = vi.fn();
 }
 
+if (typeof HTMLElement !== "undefined") {
+  if (typeof HTMLElement.prototype.hasPointerCapture !== "function") {
+    HTMLElement.prototype.hasPointerCapture = vi.fn(() => false);
+  }
+  if (typeof HTMLElement.prototype.setPointerCapture !== "function") {
+    HTMLElement.prototype.setPointerCapture = vi.fn();
+  }
+  if (typeof HTMLElement.prototype.releasePointerCapture !== "function") {
+    HTMLElement.prototype.releasePointerCapture = vi.fn();
+  }
+}
+
 if (typeof window !== "undefined") {
   if (typeof globalThis.fetch === "function") {
     Object.defineProperty(window, "fetch", {


### PR DESCRIPTION
## Summary
- persist documents rows-per-page per workspace when `perPage` is absent from the URL
- raise the documents default rows-per-page to 100 while keeping 1000 selectable
- remove extra bottom padding so the documents table footer sits on the bottom edge of the page area

## Testing
- cd backend && uv run ade web lint
- cd backend && uv run ade web test
- cd backend && uv run ade web build
- cd frontend && npm run typecheck
- cd frontend && npx -y react-doctor@latest . --verbose --diff